### PR TITLE
Note that eslint-config-vue is optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,28 @@ ESLint plugin for Vue.js projects
 
 ## Usage
 
-1. `npm install --save-dev eslint-config-vue eslint-plugin-vue`
+1. `npm install --save-dev eslint-plugin-vue`
 2. create a file named `.eslintrc` in your project:
 
 ```js
 {
-  "extends": "vue"
-  // Your overrides...
+  extends: [ /* your usual extends */ ],
+  plugins: ["vue"],
+  rules: {
+    'vue/jsx-uses-vars': 2,
+  },
+}
+```
+3. OPTIONAL: install [eslint-config-vue](https://github.com/vuejs/eslint-config-vue): `npm install --save-dev eslint-config-vue`
+4. OPTIONAL: then use the recommended configurations in your `.eslintrc`:
+
+```js
+{
+  extends: ["vue", /* your other extends */],
+  plugins: ["vue"],
+  rules: {
+    /* your overrides -- vue/jsx-uses-vars is included in eslint-config-vue */
+  },
 }
 ```
 


### PR DESCRIPTION
If you're using other configs, inserting eslint-config-vue might add too much noise.
There is only one rule added by this plugin, we could show how to use it and _optionally_ extend the recommended vue rules.