### PR TITLE
Update dependancy versioning to fix compatability with eslint v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/vuejs/eslint-plugin-vue#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
-    "eslint-plugin-html": "^2.0.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-html": "^2.0.0 || ^3.0.0",
+    "eslint-plugin-react": "^6.9.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
This fixes an error where eslint-plugin-html versions in the v2 range have issues with eslint v4's api changes.

This simply adds the new versions optional as valid dependancy ranges.