### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/vuejs/eslint-plugin-vue#readme",
   "peerDependencies": {
-    "eslint": "^2.0.0 || ^3.0.0"
+    "eslint": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "dependencies": {
-    "eslint-plugin-html": "^2.0.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-html": "^3.0.0",
+    "eslint-plugin-react": "^7.0"
   }
 }


### PR DESCRIPTION
This PR fixes #21 regarding `eslint-plugin-html` and `eslint@4.x` compatibility.

We decided to do a minor release for 2.x version while working on 3.x anyway.