### PR TITLE
Fix: more robust parser setting (fixes #30)

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
 
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
 
   parserOptions: {
     ecmaVersion: 6,


### PR DESCRIPTION
Fixes #30.

This PR ensures that this plugin uses correct `vue-eslint-parser` even if modules are not flatten.