### PR TITLE
Fix Should typo

### DIFF
--- a/lib/rules/html-no-self-closing.js
+++ b/lib/rules/html-no-self-closing.js
@@ -29,7 +29,7 @@ function create (context) {
         context.report({
           node,
           loc: node.loc,
-          message: 'Self-closing shuld not be used.',
+          message: 'Self-closing should not be used.',
           fix: (fixer) => fixer.removeRange([pos, pos + 1])
         })
       }

--- a/tests/lib/rules/html-no-self-closing.js
+++ b/tests/lib/rules/html-no-self-closing.js
@@ -45,19 +45,19 @@ tester.run('html-no-self-closing', rule, {
       filename: 'test.vue',
       code: '<template><div><br/></div></template>',
       output: '<template><div><br></div></template>',
-      errors: ['Self-closing shuld not be used.']
+      errors: ['Self-closing should not be used.']
     },
     {
       filename: 'test.vue',
       code: '<template><div><input/></div></template>',
       output: '<template><div><input></div></template>',
-      errors: ['Self-closing shuld not be used.']
+      errors: ['Self-closing should not be used.']
     },
     {
       filename: 'test.vue',
       code: '<template><div><div/></div></template>',
       output: '<template><div><div></div></template>',
-      errors: ['Self-closing shuld not be used.']
+      errors: ['Self-closing should not be used.']
     }
   ]
 })


### PR DESCRIPTION
There's a small typo on `html-no-self-closing` rule, `shuld` => `should`