### PR TITLE
Fix: crash `no-v-invalid-v-for` on `:key` (fixes #37)

### DIFF
--- a/lib/rules/no-invalid-v-for.js
+++ b/lib/rules/no-invalid-v-for.js
@@ -21,6 +21,9 @@ const utils = require('../utils')
  * @returns {boolean} `true` if the node is using the variables which are defined by `v-for` directives.
  */
 function isUsingIterationVar (node) {
+  if (node.value == null) {
+    return false
+  }
   const references = node.value.references
   const variables = node.parent.parent.variables
 

--- a/tests/lib/rules/no-invalid-v-for.js
+++ b/tests/lib/rules/no-invalid-v-for.js
@@ -144,6 +144,11 @@ tester.run('no-invalid-v-for', rule, {
       filename: 'test.vue',
       code: '<template><div><custom-component v-for="x in list" :key="foo"></custom-component></div></template>',
       errors: ["Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><div v-for="(item, index) in suggestions" :key></div></div></template>',
+      errors: ["Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."]
     }
   ]
 })


### PR DESCRIPTION
Fixes #37.