### PR TITLE
New rule `order-in-components`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-confusing-v-for-v-if](./docs/rules/no-confusing-v-for-v-if.md) | disallow confusing `v-for` and `v-if` on the same element. |
 |  | [no-duplicate-attributes](./docs/rules/no-duplicate-attributes.md) | disallow duplicate arguments. |
 | :white_check_mark: | [no-textarea-mustache](./docs/rules/no-textarea-mustache.md) | disallow mustaches in `<textarea>`. |
+| :white_check_mark: | [order-in-components](./docs/rules/order-in-components.md) | Keep order of properties in components |
 | :white_check_mark: | [require-component-is](./docs/rules/require-component-is.md) | require `v-bind:is` of `<component>` elements. |
 | :white_check_mark: | [require-v-for-key](./docs/rules/require-v-for-key.md) | require `v-bind:key` with `v-for` directives. |
 
@@ -108,13 +109,6 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-invalid-v-show](./docs/rules/no-invalid-v-show.md) | disallow invalid v-show directives. |
 | :white_check_mark: | [no-invalid-v-text](./docs/rules/no-invalid-v-text.md) | disallow invalid v-text directives. |
 | :white_check_mark: | [no-parsing-error](./docs/rules/no-parsing-error.md) | disallow parsing errors in `<template>`. |
-
-
-### Best practices
-
-|    | Rule ID | Description |
-|:---|:--------|:------------|
-| :white_check_mark: | [order-in-components](./docs/rules/order-in-components.md) | Keep order of properties in components |
 
 <!--RULES_TABLE_END-->
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-invalid-v-text](./docs/rules/no-invalid-v-text.md) | disallow invalid v-text directives. |
 | :white_check_mark: | [no-parsing-error](./docs/rules/no-parsing-error.md) | disallow parsing errors in `<template>`. |
 
+
+### Fill me in
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+|  | [order-in-components](./docs/rules/order-in-components.md) | Keep order of properties in components |
+
 <!--RULES_TABLE_END-->
 
 ## :anchor: Semantic Versioning Policy

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-parsing-error](./docs/rules/no-parsing-error.md) | disallow parsing errors in `<template>`. |
 
 
-### Fill me in
+### Best practices
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-|  | [order-in-components](./docs/rules/order-in-components.md) | Keep order of properties in components |
+| :white_check_mark: | [order-in-components](./docs/rules/order-in-components.md) | Keep order of properties in components |
 
 <!--RULES_TABLE_END-->
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-confusing-v-for-v-if](./docs/rules/no-confusing-v-for-v-if.md) | disallow confusing `v-for` and `v-if` on the same element. |
 |  | [no-duplicate-attributes](./docs/rules/no-duplicate-attributes.md) | disallow duplicate arguments. |
 | :white_check_mark: | [no-textarea-mustache](./docs/rules/no-textarea-mustache.md) | disallow mustaches in `<textarea>`. |
-| :white_check_mark: | [order-in-components](./docs/rules/order-in-components.md) | Keep order of properties in components |
+|  | [order-in-components](./docs/rules/order-in-components.md) | Keep order of properties in components |
 | :white_check_mark: | [require-component-is](./docs/rules/require-component-is.md) | require `v-bind:is` of `<component>` elements. |
 | :white_check_mark: | [require-v-for-key](./docs/rules/require-v-for-key.md) | require `v-bind:key` with `v-for` directives. |
 

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -1,0 +1,81 @@
+# Keep proper order of properties in your components (order-in-components)
+
+This rule makes sure you keep declared order of properties in components.
+
+## :book: Rule Details
+
+Recommended order of properties is as follows:
+
+1. Options / Misc (`name`, `delimiters`, `functional`, `model`)
+2. `el`
+3. Options / Assets (`components`, `directives`, `filters`)
+4. Options / Composition (`parent`, `mixins`, `extends`, `provide`, `inject`)
+5. Options / Data
+  1. `props`
+  2. `propsData`
+  3. `data`
+  4. `computed`
+  5. `methods`
+  6. `watch`
+6. lifecycle hooks
+7. `template`
+8. `render`
+9. `renderError`
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+export default {
+  name: 'app',
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+  props: {
+    propA: Number,
+  },
+}
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+export default {
+  name: 'app',
+  props: {
+    propA: Number,
+  },
+  data () {
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    }
+  },
+}
+
+```
+
+### Options
+
+If you want you can change the order providing the optional configuration in your `.eslintrc` file. Setting responsible for the above order looks like this:
+
+```
+vue/order-in-components: [2, {
+  order: [
+    'name',
+    ['mixins', 'components', 'directives', 'filters'],
+    'props',
+    'template',
+    'data',
+    'computed',
+    'methods',
+    'lifecycle_hooks',
+    'render',
+  ]
+}]
+```
+
+If you want some of properties to be treated equally in order you can group them into arrays, like we did with `mixins`, `components`, `directives` and `filters`.

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -16,10 +16,12 @@ Recommended order of properties is as follows:
 8. `data`
 9. `computed`
 10. `watch`
-11. lifecycle hooks
+11. `lifecycleHooks`
 12. `methods`
 13. `render`
 14. `renderError`
+
+Note that `lifecycleHooks` is not a regular property - it indicates the group of all lifecycle hooks just to simplify the configuration.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -7,20 +7,19 @@ This rule makes sure you keep declared order of properties in components.
 Recommended order of properties is as follows:
 
 1. Options / Misc (`name`, `delimiters`, `functional`, `model`)
-2. `el`
-3. Options / Assets (`components`, `directives`, `filters`)
-4. Options / Composition (`parent`, `mixins`, `extends`, `provide`, `inject`)
-5. Options / Data
-  1. `props`
-  2. `propsData`
-  3. `data`
-  4. `computed`
-  5. `methods`
-  6. `watch`
-6. lifecycle hooks
-7. `template`
-8. `render`
-9. `renderError`
+2. Options / Assets (`components`, `directives`, `filters`)
+3. Options / Composition (`parent`, `mixins`, `extends`, `provide`, `inject`)
+4. `el`
+5. `template`
+6. `props`
+7. `propsData`
+8. `data`
+9. `computed`
+10. `watch`
+11. lifecycle hooks
+12. `methods`
+13. `render`
+14. `renderError`
 
 Examples of **incorrect** code for this rule:
 
@@ -65,17 +64,22 @@ If you want you can change the order providing the optional configuration in you
 ```
 vue/order-in-components: [2, {
   order: [
-    'name',
-    ['mixins', 'components', 'directives', 'filters'],
-    'props',
+    ['name', 'delimiters', 'functional', 'model'],
+    ['components', 'directives', 'filters'],
+    ['parent', 'mixins', 'extends', 'provide', 'inject'],
+    'el',
     'template',
+    'props',
+    'propsData',
     'data',
     'computed',
-    'methods',
+    'watch',
     'lifecycle_hooks',
+    'methods',
     'render',
+    'renderError'
   ]
 }]
 ```
 
-If you want some of properties to be treated equally in order you can group them into arrays, like we did with `mixins`, `components`, `directives` and `filters`.
+If you want some of properties to be treated equally in order you can group them into arrays, like we did with `name`, `delimiters`, `funcitonal` and `model`.

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -26,6 +26,7 @@ module.exports = {
   "vue/no-invalid-v-text": "error",
   "vue/no-parsing-error": "error",
   "vue/no-textarea-mustache": "error",
+  "vue/order-in-components": "off",
   "vue/require-component-is": "error",
   "vue/require-v-for-key": "error",
   "vue/v-bind-style": "off",

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -26,7 +26,7 @@ module.exports = {
   "vue/no-invalid-v-text": "error",
   "vue/no-parsing-error": "error",
   "vue/no-textarea-mustache": "error",
-  "vue/order-in-components": "error",
+  "vue/order-in-components": "off",
   "vue/require-component-is": "error",
   "vue/require-v-for-key": "error",
   "vue/v-bind-style": "off",

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -26,7 +26,7 @@ module.exports = {
   "vue/no-invalid-v-text": "error",
   "vue/no-parsing-error": "error",
   "vue/no-textarea-mustache": "error",
-  "vue/order-in-components": "off",
+  "vue/order-in-components": "error",
   "vue/require-component-is": "error",
   "vue/require-v-for-key": "error",
   "vue/v-bind-style": "off",

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -36,8 +36,9 @@ const groups = {
   ]
 }
 
-function isComponentFile (path) {
-  return path.endsWith('.vue') || path.endsWith('.jsx')
+function isComponentFile (node, path) {
+  const isVueFile = path.endsWith('.vue') || path.endsWith('.jsx')
+  return isVueFile && node.declaration.type === 'ObjectExpression'
 }
 
 function isVueComponent (node) {
@@ -113,7 +114,7 @@ function create (context) {
   return {
     ExportDefaultDeclaration (node) {
       // export default {} in .vue || .jsx
-      if (!isComponentFile(filePath)) return
+      if (!isComponentFile(node, filePath)) return
       checkOrder(node.declaration.properties, orderMap, context)
     },
     CallExpression (node) {

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -41,11 +41,26 @@ function isComponentFile (path) {
 }
 
 function isVueComponent (node) {
-  return true
+  const callee = node.callee
+
+  const isFullVueComponent = node.type === 'CallExpression' &&
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'Vue' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'component'
+
+  const isDestructedVueComponent = callee.type === 'Identifier' &&
+    callee.name === 'component'
+
+  return isFullVueComponent || isDestructedVueComponent
 }
 
 function isVueInstance (node) {
-  return true
+  const callee = node.callee
+  return node.type === 'NewExpression' &&
+    callee.type === 'Identifier' &&
+    callee.name === 'Vue'
 }
 
 function getOrderMap (order) {
@@ -65,18 +80,19 @@ function getOrderMap (order) {
 function checkOrder (propertiesNodes, orderMap, context) {
   const properties = propertiesNodes.map(property => property.key)
 
-  // To be changed - iterate over all properties above the current one
-  // which order is higher than the order of current one
-  // and get the one with the lowest order
-  properties.sort((prevNode, nextNode) => {
-    const { name: prevPropName } = prevNode
-    const { name: nextPropName } = nextNode
-    const nextPropOrder = orderMap.get(nextPropName)
-    const prevPropOrder = orderMap.get(prevPropName)
-    const prevNodeLine = prevNode.loc.start.line
+  properties.forEach((property, i) => {
+    const propertiesAbove = properties.slice(0, i)
+    const unorderedProperties = propertiesAbove
+      .filter(p => orderMap.get(p.name) > orderMap.get(property.name))
+      .sort((p1, p2) => orderMap.get(p1.name) < orderMap.get(p2.name))
+    const firstUnorderedProperty = unorderedProperties[0]
 
-    if (nextPropOrder < prevPropOrder) {
-      context.report(nextNode, `The "${nextPropName}" property should be above the "${prevPropName}" property on line ${prevNodeLine}.`)
+    if (firstUnorderedProperty) {
+      const line = firstUnorderedProperty.loc.start.line
+      context.report(
+        property,
+        `The "${property.name}" property should be above the "${firstUnorderedProperty.name}" property on line ${line}.`
+      )
     }
   })
 }
@@ -96,9 +112,9 @@ function create (context) {
       checkOrder(node.declaration.properties, orderMap, context)
     },
     CallExpression (node) {
-      // Vue.component('xxx', {})
+      // Vue.component('xxx', {}) || component('xxx', {})
       if (!isVueComponent(node)) return
-      checkOrder(node.arguments[1].properties, orderMap, context)
+      checkOrder(node.arguments.slice(-1)[0].properties, orderMap, context)
     },
     NewExpression (node) {
       // new Vue({})

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -117,7 +117,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'Keep order of properties in components',
-      category: 'Best practices',
+      category: 'Best Practices',
       recommended: true
     },
     fixable: null,

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Keep order of properties in components
+ * @author Michał Sajnóg
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Keep order of properties in components',
+      category: 'Fill me in',
+      recommended: false
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [
+      // fill in your schema
+    ]
+  },
+
+  create (context) {
+    return {
+
+      // give me methods
+
+    }
+  }
+}

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -84,15 +84,16 @@ function checkOrder (propertiesNodes, orderMap, context) {
     const propertiesAbove = properties.slice(0, i)
     const unorderedProperties = propertiesAbove
       .filter(p => orderMap.get(p.name) > orderMap.get(property.name))
-      .sort((p1, p2) => orderMap.get(p1.name) < orderMap.get(p2.name))
+      .sort((p1, p2) => orderMap.get(p1.name) > orderMap.get(p2.name))
+
     const firstUnorderedProperty = unorderedProperties[0]
 
     if (firstUnorderedProperty) {
       const line = firstUnorderedProperty.loc.start.line
-      context.report(
-        property,
-        `The "${property.name}" property should be above the "${firstUnorderedProperty.name}" property on line ${line}.`
-      )
+      context.report({
+        node: property,
+        message: `The "${property.name}" property should be above the "${firstUnorderedProperty.name}" property on line ${line}.`
+      })
     }
   })
 }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const ORDER = [
+const defaultOrder = [
   ['name', 'delimiters', 'functional', 'model'],
   ['components', 'directives', 'filters'],
   ['parent', 'mixins', 'extends', 'provide', 'inject'],
@@ -15,62 +15,95 @@ const ORDER = [
   'data',
   'computed',
   'watch',
-  'lifecycle_hooks',
+  'LIFECYCLE_HOOKS',
   'methods',
   'render',
   'renderError'
 ]
 
-function isVueFile (path) {
-  return path.endsWith('.vue')
+const groups = {
+  LIFECYCLE_HOOKS: [
+    'beforeCreate',
+    'created',
+    'beforeMount',
+    'mounted',
+    'beforeUpdate',
+    'updated',
+    'activated',
+    'deactivated',
+    'beforeDestroy',
+    'destroyed'
+  ]
 }
 
-function normalizeOrder (orderConfig) {
-  return orderConfig.reduce((acc, el, i) => {
-    if (Array.isArray(el)) {
-      const subOrder = el.reduce((acc2, subEl) => {
-        acc[subEl] = i
-      }, {})
-      acc = Object.assign({}, acc, subOrder)
-    } else if (el === 'lifecycle_hooks') {
-      acc = Object.assign({}, acc, {
-        // to be added
-      })
+function isComponentFile (path) {
+  return path.endsWith('.vue') || path.endsWith('.jsx')
+}
+
+function isVueComponent (node) {
+  return true
+}
+
+function isVueInstance (node) {
+  return true
+}
+
+function getOrderMap (order) {
+  const orderMap = new Map()
+
+  order.forEach((property, i) => {
+    if (Array.isArray(property)) {
+      property.forEach(p => orderMap.set(p, i))
     } else {
-      acc[el] = i
+      orderMap.set(property, i)
     }
-    return acc
-  }, {})
+  })
+
+  return orderMap
 }
 
-function formatProperties (properties, order) {
-  return properties
-    .map(p => {
-      const name = p.key.name
-      return [name, order[name], p.key]
-    })
+function checkOrder (propertiesNodes, orderMap, context) {
+  const properties = propertiesNodes.map(property => property.key)
+
+  // To be changed - iterate over all properties above the current one
+  // which order is higher than the order of current one
+  // and get the one with the lowest order
+  properties.sort((prevNode, nextNode) => {
+    const { name: prevPropName } = prevNode
+    const { name: nextPropName } = nextNode
+    const nextPropOrder = orderMap.get(nextPropName)
+    const prevPropOrder = orderMap.get(prevPropName)
+    const prevNodeLine = prevNode.loc.start.line
+
+    if (nextPropOrder < prevPropOrder) {
+      context.report(nextNode, `The "${nextPropName}" property should be above the "${prevPropName}" property on line ${prevNodeLine}.`)
+    }
+  })
 }
 
 function create (context) {
   const options = context.options[0] || {}
-  const order = options.order || ORDER
+  const order = options.order || defaultOrder
   const filePath = context.getFilename()
-  const normalizedOrder = normalizeOrder(order)
+
+  const extendedOrder = order.map(property => groups[property] || property)
+  const orderMap = getOrderMap(extendedOrder)
 
   return {
     ExportDefaultDeclaration (node) {
-      if (!isVueFile(filePath)) return
-      const properties = formatProperties(node.declaration.properties, normalizedOrder)
-
-      properties.sort((prev, next) => {
-        const [prevPropName, prevPropOrder, prevNode] = prev
-        const [nextPropName, nextPropOrder, nextNode] = next
-        const prevNodeLine = prevNode.loc.start.line
-
-        if (nextPropOrder < prevPropOrder) {
-          context.report(nextNode, `The "${nextPropName}" property should be above the "${prevPropName}" property on line ${prevNodeLine}.`)
-        }
-      })
+      // export default {} in .vue || .jsx
+      if (!isComponentFile(filePath)) return
+      checkOrder(node.declaration.properties, orderMap, context)
+    },
+    CallExpression (node) {
+      // Vue.component('xxx', {})
+      if (!isVueComponent(node)) return
+      checkOrder(node.arguments[1].properties, orderMap, context)
+    },
+    NewExpression (node) {
+      // new Vue({})
+      if (!isVueInstance(node)) return
+      checkOrder(node.arguments[0].properties, orderMap, context)
     }
   }
 }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -48,7 +48,9 @@ function isVueComponent (node) {
     callee.object.type === 'Identifier' &&
     callee.object.name === 'Vue' &&
     callee.property.type === 'Identifier' &&
-    callee.property.name === 'component'
+    callee.property.name === 'component' &&
+    node.arguments.length &&
+    node.arguments.slice(-1)[0].type === 'ObjectExpression'
 
   const isDestructedVueComponent = callee.type === 'Identifier' &&
     callee.name === 'component'
@@ -60,7 +62,9 @@ function isVueInstance (node) {
   const callee = node.callee
   return node.type === 'NewExpression' &&
     callee.type === 'Identifier' &&
-    callee.name === 'Vue'
+    callee.name === 'Vue' &&
+    node.arguments.length &&
+    node.arguments[0].type === 'ObjectExpression'
 }
 
 function getOrderMap (order) {

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -140,7 +140,7 @@ module.exports = {
     docs: {
       description: 'Keep order of properties in components',
       category: 'Best Practices',
-      recommended: true
+      recommended: false
     },
     fixable: null,
     schema: []

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -4,28 +4,90 @@
  */
 'use strict'
 
+const ORDER = [
+  ['name', 'delimiters', 'functional', 'model'],
+  ['components', 'directives', 'filters'],
+  ['parent', 'mixins', 'extends', 'provide', 'inject'],
+  'el',
+  'template',
+  'props',
+  'propsData',
+  'data',
+  'computed',
+  'watch',
+  'lifecycle_hooks',
+  'methods',
+  'render',
+  'renderError'
+]
+
+function isVueFile (path) {
+  return path.endsWith('.vue')
+}
+
+function normalizeOrder (orderConfig) {
+  return orderConfig.reduce((acc, el, i) => {
+    if (Array.isArray(el)) {
+      const subOrder = el.reduce((acc2, subEl) => {
+        acc[subEl] = i
+      }, {})
+      acc = Object.assign({}, acc, subOrder)
+    } else if (el === 'lifecycle_hooks') {
+      acc = Object.assign({}, acc, {
+        // to be added
+      })
+    } else {
+      acc[el] = i
+    }
+    return acc
+  }, {})
+}
+
+function formatProperties (properties, order) {
+  return properties
+    .map(p => {
+      const name = p.key.name
+      return [name, order[name], p.key]
+    })
+}
+
+function create (context) {
+  const options = context.options[0] || {}
+  const order = options.order || ORDER
+  const filePath = context.getFilename()
+  const normalizedOrder = normalizeOrder(order)
+
+  return {
+    ExportDefaultDeclaration (node) {
+      if (!isVueFile(filePath)) return
+      const properties = formatProperties(node.declaration.properties, normalizedOrder)
+
+      properties.sort((prev, next) => {
+        const [prevPropName, prevPropOrder, prevNode] = prev
+        const [nextPropName, nextPropOrder, nextNode] = next
+        const prevNodeLine = prevNode.loc.start.line
+
+        if (nextPropOrder < prevPropOrder) {
+          context.report(nextNode, `The "${nextPropName}" property should be above the "${prevPropName}" property on line ${prevNodeLine}.`)
+        }
+      })
+    }
+  }
+}
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
 module.exports = {
+  create,
   meta: {
     docs: {
       description: 'Keep order of properties in components',
-      category: 'Fill me in',
-      recommended: false
+      category: 'Best practices',
+      recommended: true
     },
-    fixable: null, // or "code" or "whitespace"
-    schema: [
-      // fill in your schema
-    ]
-  },
-
-  create (context) {
-    return {
-
-      // give me methods
-
-    }
+    fixable: null,
+    schema: []
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vue",
-  "version": "3.0.1",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "lib/index.js",
   "scripts": {
     "start": "npm run test:simple -- --watch --growl",
-    "test:base": "mocha \"tests/lib/**/*.js\" \"tests/integrations/*.js\" --timeout 60000",
+    "test:base": "mocha \"tests/lib/**/*.js\"",
     "test:simple": "npm run test:base -- --reporter nyan",
-    "test": "nyc npm run test:base",
+    "test": "nyc npm run test:base -- \"tests/integrations/*.js\" --timeout 60000",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "preversion": "npm run update && npm test",

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Keep order of properties in components
+ * @author Michał Sajnóg
+ */
+'use strict'
+
+const rule = require('../../../lib/rules/order-in-components')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('order-in-components', rule, {
+
+  valid: [
+    {
+      code: `
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      code: ``,
+      errors: [{
+        message: 'Fill me in.'
+      }]
+    }
+  ]
+})

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -28,6 +28,51 @@ ruleTester.run('order-in-components', rule, {
         }
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      filename: 'test.jsx',
+      code: `
+        export default {
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      filename: 'test.js',
+      code: `
+        Vue.component('smart-list', {
+          name: 'app',
+          components: {},
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      filename: 'test.js',
+      code: `
+        new Vue({
+          name: 'app',
+          components: {},
+          el: '#app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 }
     }
   ],
 
@@ -51,6 +96,85 @@ ruleTester.run('order-in-components', rule, {
       errors: [{
         message: 'The "props" property should be above the "data" property on line 4.',
         line: 9
+      }]
+    },
+    {
+      filename: 'test.jsx',
+      code: `
+        export default {
+          render (h) {
+            return (
+              <span>{ this.msg }</span>
+            )
+          },
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          props: {
+            propA: Number,
+          },
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module', ecmaFeatures: { jsx: true }},
+      errors: [{
+        message: 'The "name" property should be above the "render" property on line 3.',
+        line: 8
+      }, {
+        message: 'The "props" property should be above the "data" property on line 9.',
+        line: 14
+      }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        Vue.component('smart-list', {
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          components: {},
+          template: '<div></div>'
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'The "components" property should be above the "data" property on line 4.',
+        line: 9
+      }, {
+        message: 'The "template" property should be above the "data" property on line 4.',
+        line: 10
+      }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        new Vue({
+          el: '#app',
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          components: {},
+          template: '<div></div>'
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'The "name" property should be above the "el" property on line 3.',
+        line: 4
+      }, {
+        message: 'The "components" property should be above the "data" property on line 5.',
+        line: 10
+      }, {
+        message: 'The "template" property should be above the "data" property on line 5.',
+        line: 11
       }]
     }
   ]

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -61,6 +61,22 @@ ruleTester.run('order-in-components', rule, {
     {
       filename: 'test.js',
       code: `
+        const { component } = Vue;
+        component('smart-list', {
+          name: 'app',
+          components: {},
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      filename: 'test.js',
+      code: `
         new Vue({
           name: 'app',
           components: {},
@@ -123,7 +139,10 @@ ruleTester.run('order-in-components', rule, {
         message: 'The "name" property should be above the "render" property on line 3.',
         line: 8
       }, {
-        message: 'The "props" property should be above the "data" property on line 9.',
+        message: 'The "data" property should be above the "render" property on line 3.',
+        line: 9
+      }, {
+        message: 'The "props" property should be above the "render" property on line 3.',
         line: 14
       }]
     },
@@ -148,6 +167,30 @@ ruleTester.run('order-in-components', rule, {
       }, {
         message: 'The "template" property should be above the "data" property on line 4.',
         line: 10
+      }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { component } = Vue;
+        component('smart-list', {
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          components: {},
+          template: '<div></div>'
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: 'The "components" property should be above the "data" property on line 5.',
+        line: 10
+      }, {
+        message: 'The "template" property should be above the "data" property on line 5.',
+        line: 11
       }]
     },
     {

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -30,6 +30,13 @@ ruleTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
+      filename: 'test.vue',
+      code: `
+        export default {}
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
       filename: 'test.jsx',
       code: `
         export default {
@@ -55,6 +62,13 @@ ruleTester.run('order-in-components', rule, {
             }
           }
         })
+      `,
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      filename: 'test.js',
+      code: `
+        Vue.component('example')
       `,
       parserOptions: { ecmaVersion: 6 }
     },
@@ -87,6 +101,13 @@ ruleTester.run('order-in-components', rule, {
             }
           }
         })
+      `,
+      parserOptions: { ecmaVersion: 6 }
+    },
+    {
+      filename: 'test.js',
+      code: `
+        new Vue()
       `,
       parserOptions: { ecmaVersion: 6 }
     }

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -142,7 +142,7 @@ ruleTester.run('order-in-components', rule, {
         message: 'The "data" property should be above the "render" property on line 3.',
         line: 9
       }, {
-        message: 'The "props" property should be above the "render" property on line 3.',
+        message: 'The "props" property should be above the "data" property on line 9.',
         line: 14
       }]
     },
@@ -213,11 +213,37 @@ ruleTester.run('order-in-components', rule, {
         message: 'The "name" property should be above the "el" property on line 3.',
         line: 4
       }, {
-        message: 'The "components" property should be above the "data" property on line 5.',
+        message: 'The "components" property should be above the "el" property on line 3.',
         line: 10
       }, {
         message: 'The "template" property should be above the "data" property on line 5.',
         line: 11
+      }]
+    },
+    {
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+            return {
+              isActive: false,
+            };
+          },
+          methods: {
+            toggleMenu() {
+              this.isActive = !this.isActive;
+            },
+            closeMenu() {
+              this.isActive = false;
+            }
+          },
+          name: 'burger',
+        };
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 16
       }]
     }
   ]

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -13,16 +13,44 @@ ruleTester.run('order-in-components', rule, {
 
   valid: [
     {
+      filename: 'test.vue',
       code: `
-      `
+        export default {
+          name: 'app',
+          props: {
+            propA: Number,
+          },
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     }
   ],
 
   invalid: [
     {
-      code: ``,
+      filename: 'test.vue',
+      code: `
+        export default {
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          props: {
+            propA: Number,
+          },
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [{
-        message: 'Fill me in.'
+        message: 'The "props" property should be above the "data" property on line 4.',
+        line: 9
       }]
     }
   ]

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -37,6 +37,13 @@ ruleTester.run('order-in-components', rule, {
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
+      filename: 'test.vue',
+      code: `
+        export default 'example-text'
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
       filename: 'test.jsx',
       code: `
         export default {


### PR DESCRIPTION
This PR adds new rule regarding this proposition: #13 

This rule will be applied on:
- `export default {}` inside `.vue` and `.jsx` files
- `new Vue({})` in any file
- `Vue.component('xxx', {})` or `component('xxx', {})` in any file

Thing to be noted - we won't support dynamically loaded components, as it's not so obvious to tell if it actually is or is not a vue component.