### PR TITLE
Update: improve warnings about key on template elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 | :white_check_mark: | [no-invalid-v-show](./docs/rules/no-invalid-v-show.md) | disallow invalid v-show directives. |
 | :white_check_mark: | [no-invalid-v-text](./docs/rules/no-invalid-v-text.md) | disallow invalid v-text directives. |
 | :white_check_mark: | [no-parsing-error](./docs/rules/no-parsing-error.md) | disallow parsing errors in `<template>`. |
+|  | [no-template-key](./docs/rules/no-template-key.md) | disallow 'key' attribute on '<template>'. |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rules/html-end-tags.md
+++ b/docs/rules/html-end-tags.md
@@ -1,20 +1,20 @@
 # Enforce end tag style (html-end-tags)
 
-- 🔧 This rule is fixable with `eslint --fix` command.
+- :wrench: This rule is fixable with `eslint --fix` command.
 
 This rule enforce the way of end tags.
 
 - [Void elements] disallow end tags.
 - Other elements require end tags.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports the following elements:
 
 - [Void elements] which have end tags.
 - Other elements which do not have end tags and are not self-closing.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -28,7 +28,7 @@ This rule reports the following elements:
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -42,7 +42,7 @@ This rule reports the following elements:
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 

--- a/docs/rules/html-no-self-closing.md
+++ b/docs/rules/html-no-self-closing.md
@@ -1,15 +1,15 @@
 # Disallow self-closing elements (html-no-self-closing)
 
-- 🔧 This rule is fixable with `eslint --fix` command.
+- :wrench: This rule is fixable with `eslint --fix` command.
 
 Self-closing (e.g. `<br/>`) is syntax of XML/XHTML.
 HTML ignores it.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports every self-closing element except XML context.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -19,7 +19,7 @@ This rule reports every self-closing element except XML context.
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -33,6 +33,6 @@ This rule reports every self-closing element except XML context.
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/html-quotes.md
+++ b/docs/rules/html-quotes.md
@@ -8,11 +8,11 @@ You can shoose quotes of HTML attributes from:
 
 This rule enforces the quotes style of HTML attributes.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports the quotes of attributes if it is different to configured quotes.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -23,7 +23,7 @@ This rule reports the quotes of attributes if it is different to configured quot
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -33,7 +33,7 @@ This rule reports the quotes of attributes if it is different to configured quot
 </template>
 ```
 
-👎 Examples of **incorrect** code for this rule with `"single"` option:
+:-1: Examples of **incorrect** code for this rule with `"single"` option:
 
 ```html
 <template>
@@ -44,7 +44,7 @@ This rule reports the quotes of attributes if it is different to configured quot
 </template>
 ```
 
-👍 Examples of **correct** code for this rule with `"single"` option:
+:+1: Examples of **correct** code for this rule with `"single"` option:
 
 ```html
 <template>
@@ -54,7 +54,7 @@ This rule reports the quotes of attributes if it is different to configured quot
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 - `"double"` (default) ... requires double quotes.
 - `"single"` ... requires single quotes.

--- a/docs/rules/no-confusing-v-for-v-if.md
+++ b/docs/rules/no-confusing-v-for-v-if.md
@@ -6,7 +6,7 @@
 
 So when they exist on the same node, `v-if` directive should use the reference which is to the variables which are defined by the `v-for` directives.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports the elements which have both `v-for` and `v-if` directives in the following cases:
 
@@ -14,7 +14,7 @@ This rule reports the elements which have both `v-for` and `v-if` directives in 
 
 In that case, the `v-if` should be written on the wrapper element.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -26,7 +26,7 @@ In that case, the `v-if` should be written on the wrapper element.
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -48,6 +48,6 @@ In that case, the `v-if` should be written on the wrapper element.
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/no-duplicate-attributes.md
+++ b/docs/rules/no-duplicate-attributes.md
@@ -3,12 +3,12 @@
 When duplicate arguments exist, only the last one is valid.
 It's possibly mistakes.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports duplicate attributes.
 `v-bind:foo` directives are handled as the attributes `foo`.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -16,7 +16,7 @@ This rule reports duplicate attributes.
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -25,7 +25,7 @@ This rule reports duplicate attributes.
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 

--- a/docs/rules/no-invalid-template-root.md
+++ b/docs/rules/no-invalid-template-root.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every template root is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports the template root in the following cases:
 
@@ -12,7 +12,7 @@ This rule reports the template root in the following cases:
 - The root element has `v-for` directives. E.g. `<template><div v-for="x in list">{{x}}</div></template>`.
 - The root element is `<template>` or `<slot>` elements. E.g. `<template><template>hello</template></template>`.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -38,7 +38,7 @@ This rule reports the template root in the following cases:
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -59,6 +59,6 @@ This rule reports the template root in the following cases:
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/no-invalid-v-bind.md
+++ b/docs/rules/no-invalid-v-bind.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-bind` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-bind` directives in the following cases:
 
@@ -13,7 +13,7 @@ This rule does not report `v-bind` directives which do not have their argument (
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -25,7 +25,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -38,11 +38,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-parsing-error]
 

--- a/docs/rules/no-invalid-v-cloak.md
+++ b/docs/rules/no-invalid-v-cloak.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-cloak` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-cloak` directives in the following cases:
 
@@ -10,7 +10,7 @@ This rule reports `v-cloak` directives in the following cases:
 - The directive has that modifier. E.g. `<div v-cloak.bbb></div>`
 - The directive has that attribute value. E.g. `<div v-cloak="ccc"></div>`
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -22,7 +22,7 @@ This rule reports `v-cloak` directives in the following cases:
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -32,6 +32,6 @@ This rule reports `v-cloak` directives in the following cases:
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/no-invalid-v-else-if.md
+++ b/docs/rules/no-invalid-v-else-if.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-else-if` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-else-if` directives in the following cases:
 
@@ -14,7 +14,7 @@ This rule reports `v-else-if` directives in the following cases:
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -26,7 +26,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -37,11 +37,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-invalid-v-if]
 - [no-invalid-v-else]

--- a/docs/rules/no-invalid-v-else.md
+++ b/docs/rules/no-invalid-v-else.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-else` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-else` directives in the following cases:
 
@@ -12,7 +12,7 @@ This rule reports `v-else` directives in the following cases:
 - The directive is on the elements that the previous element don't have `v-if`/`v-if-else` directives. E.g. `<div v-else></div>`
 - The directive is on the elements which have `v-if`/`v-if-else` directives. E.g. `<div v-if="foo" v-else></div>`
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -24,7 +24,7 @@ This rule reports `v-else` directives in the following cases:
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -35,11 +35,11 @@ This rule reports `v-else` directives in the following cases:
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-invalid-v-if]
 - [no-invalid-v-else]

--- a/docs/rules/no-invalid-v-for.md
+++ b/docs/rules/no-invalid-v-for.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-for` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-for` directives in the following cases:
 
@@ -20,7 +20,7 @@ The following cases are syntax errors:
 - The directive's value is not the form `alias in expr`. E.g. `<div v-for="foo"></div>`
 - The alias is not LHS. E.g. `<div v-for="foo() in list"></div>`
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -35,7 +35,7 @@ The following cases are syntax errors:
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -47,11 +47,11 @@ The following cases are syntax errors:
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [require-v-for-key]
 - [no-parsing-error]

--- a/docs/rules/no-invalid-v-html.md
+++ b/docs/rules/no-invalid-v-html.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-html` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-html` directives in the following cases:
 
@@ -12,7 +12,7 @@ This rule reports `v-html` directives in the following cases:
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -24,7 +24,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -34,11 +34,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-parsing-error]
 

--- a/docs/rules/no-invalid-v-if.md
+++ b/docs/rules/no-invalid-v-if.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-if` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-if` directives in the following cases:
 
@@ -13,7 +13,7 @@ This rule reports `v-if` directives in the following cases:
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -27,7 +27,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -39,11 +39,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-invalid-v-else]
 - [no-invalid-v-else-if]

--- a/docs/rules/no-invalid-v-model.md
+++ b/docs/rules/no-invalid-v-model.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-model` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-model` directives in the following cases:
 
@@ -17,7 +17,7 @@ This rule reports `v-model` directives in the following cases:
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -34,7 +34,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -50,11 +50,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-parsing-error]
 

--- a/docs/rules/no-invalid-v-on.md
+++ b/docs/rules/no-invalid-v-on.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-on` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-on` directives in the following cases:
 
@@ -12,7 +12,7 @@ This rule reports `v-on` directives in the following cases:
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -24,7 +24,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -38,11 +38,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-parsing-error]
 

--- a/docs/rules/no-invalid-v-once.md
+++ b/docs/rules/no-invalid-v-once.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-once` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-once` directives in the following cases:
 
@@ -10,7 +10,7 @@ This rule reports `v-once` directives in the following cases:
 - The directive has that modifier. E.g. `<div v-once.bbb></div>`
 - The directive has that attribute value. E.g. `<div v-once="ccc"></div>`
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -22,7 +22,7 @@ This rule reports `v-once` directives in the following cases:
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -32,6 +32,6 @@ This rule reports `v-once` directives in the following cases:
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/no-invalid-v-pre.md
+++ b/docs/rules/no-invalid-v-pre.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-pre` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-pre` directives in the following cases:
 
@@ -10,7 +10,7 @@ This rule reports `v-pre` directives in the following cases:
 - The directive has that modifier. E.g. `<div v-pre.bbb></div>`
 - The directive has that attribute value. E.g. `<div v-pre="ccc"></div>`
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -22,7 +22,7 @@ This rule reports `v-pre` directives in the following cases:
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -32,6 +32,6 @@ This rule reports `v-pre` directives in the following cases:
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/no-invalid-v-show.md
+++ b/docs/rules/no-invalid-v-show.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-show` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-show` directives in the following cases:
 
@@ -12,7 +12,7 @@ This rule reports `v-show` directives in the following cases:
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -24,7 +24,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -34,11 +34,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-parsing-error]
 

--- a/docs/rules/no-invalid-v-text.md
+++ b/docs/rules/no-invalid-v-text.md
@@ -2,7 +2,7 @@
 
 This rule checks whether every `v-text` directive is valid.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports `v-text` directives in the following cases:
 
@@ -12,7 +12,7 @@ This rule reports `v-text` directives in the following cases:
 
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -24,7 +24,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -34,11 +34,11 @@ This rule does not check syntax errors in directives because it's checked by [no
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-parsing-error]
 

--- a/docs/rules/no-parsing-error.md
+++ b/docs/rules/no-parsing-error.md
@@ -2,12 +2,12 @@
 
 This rule reports syntax errors in directives/mustaches of `<template>`.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule tries to parse directives/mustaches in `<template>` by the parser which parses `<script>`.
 Then reports syntax errors if exist.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -15,7 +15,7 @@ Then reports syntax errors if exist.
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -23,6 +23,6 @@ Then reports syntax errors if exist.
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/no-template-key.md
+++ b/docs/rules/no-template-key.md
@@ -2,11 +2,11 @@
 
 Vue.js disallows `key` attribute on `<template>` elements.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports the `<template>` elements which have `key` attribute.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -18,7 +18,7 @@ This rule reports the `<template>` elements which have `key` attribute.
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -29,6 +29,6 @@ This rule reports the `<template>` elements which have `key` attribute.
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/no-template-key.md
+++ b/docs/rules/no-template-key.md
@@ -1,0 +1,34 @@
+# Disallow 'key' attribute on '<template>' (no-template-key)
+
+Vue.js disallows `key` attribute on `<template>` elements.
+
+## 📖 Rule Details
+
+This rule reports the `<template>` elements which have `key` attribute.
+
+👎 Examples of **incorrect** code for this rule:
+
+```html
+<template>
+    <div>
+        <template key="x"></template>
+        <template v-bind:key="y"></template>
+        <template :key="z"></template>
+    </div>
+</template>
+```
+
+👍 Examples of **correct** code for this rule:
+
+```html
+<template>
+    <div>
+        <div key="x"></div>
+        <template></template>
+    </div>
+</template>
+```
+
+## 🔧 Options
+
+Nothing.

--- a/docs/rules/no-textarea-mustache.md
+++ b/docs/rules/no-textarea-mustache.md
@@ -4,11 +4,11 @@
 >
 > https://vuejs.org/v2/guide/forms.html#Multiline-text
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports mustaches in `<textarea>`.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -16,7 +16,7 @@ This rule reports mustaches in `<textarea>`.
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -24,6 +24,6 @@ This rule reports mustaches in `<textarea>`.
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/require-component-is.md
+++ b/docs/rules/require-component-is.md
@@ -4,11 +4,11 @@
 >
 > https://vuejs.org/v2/guide/components.html#Dynamic-Components
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports the `<component>` elements which do not have `v-bind:is` attributes.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -16,7 +16,7 @@ This rule reports the `<component>` elements which do not have `v-bind:is` attri
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -24,6 +24,6 @@ This rule reports the `<component>` elements which do not have `v-bind:is` attri
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.

--- a/docs/rules/require-v-for-key.md
+++ b/docs/rules/require-v-for-key.md
@@ -3,14 +3,14 @@
 When `v-for` is written on custom components, it requires `v-bind:key` at the same time.
 On other elements, it's better that `v-bind:key` is written as well.
 
-## 📖 Rule Details
+## :book: Rule Details
 
 This rule reports the elements which have `v-for` and do not have `v-bind:key`.
 
 This rule does not report custom components.
 It will be reported by [no-invalid-v-for] rule.
 
-👎 Examples of **incorrect** code for this rule:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -20,7 +20,7 @@ It will be reported by [no-invalid-v-for] rule.
 </template>
 ```
 
-👍 Examples of **correct** code for this rule:
+:+1: Examples of **correct** code for this rule:
 
 ```html
 <template>
@@ -30,11 +30,11 @@ It will be reported by [no-invalid-v-for] rule.
 </template>
 ```
 
-## 🔧 Options
+## :wrench: Options
 
 Nothing.
 
-## 👫 Related rules
+## :couple: Related rules
 
 - [no-invalid-v-for]
 

--- a/docs/rules/v-bind-style.md
+++ b/docs/rules/v-bind-style.md
@@ -1,42 +1,12 @@
 # Enforce v-bind directive style (v-bind-style)
 
-- 🔧 This rule is fixable with `eslint --fix` command.
+- :wrench: This rule is fixable with `eslint --fix` command.
 
 This rule enforces `v-bind` directive style which you should use shorthand or long form.
 
-## 📖 Rule Details
+## :book: Rule Details
 
-👎 Examples of **incorrect** code for this rule:
-
-```html
-<template>
-    <div>
-        <div v-bind:foo="foo"></div>
-    </div>
-</template>
-```
-
-👍 Examples of **correct** code for this rule:
-
-```html
-<template>
-    <div>
-        <div :foo="foo"></div>
-    </div>
-</template>
-```
-
-👎 Examples of **incorrect** code for this rule with `"longform"` option:
-
-```html
-<template>
-    <div>
-        <div :foo="foo"></div>
-    </div>
-</template>
-```
-
-👍 Examples of **correct** code for this rule with `"longform"` option:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -46,7 +16,37 @@ This rule enforces `v-bind` directive style which you should use shorthand or lo
 </template>
 ```
 
-## 🔧 Options
+:+1: Examples of **correct** code for this rule:
+
+```html
+<template>
+    <div>
+        <div :foo="foo"></div>
+    </div>
+</template>
+```
+
+:-1: Examples of **incorrect** code for this rule with `"longform"` option:
+
+```html
+<template>
+    <div>
+        <div :foo="foo"></div>
+    </div>
+</template>
+```
+
+:+1: Examples of **correct** code for this rule with `"longform"` option:
+
+```html
+<template>
+    <div>
+        <div v-bind:foo="foo"></div>
+    </div>
+</template>
+```
+
+## :wrench: Options
 
 - `"shorthand"` (default) ... requires using shorthand.
 - `"longform"` ... requires using long form.

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -1,42 +1,12 @@
 # Enforce v-on directive style (v-on-style)
 
-- 🔧 This rule is fixable with `eslint --fix` command.
+- :wrench: This rule is fixable with `eslint --fix` command.
 
 This rule enforces `v-on` directive style which you should use shorthand or long form.
 
-## 📖 Rule Details
+## :book: Rule Details
 
-👎 Examples of **incorrect** code for this rule:
-
-```html
-<template>
-    <div>
-        <div v-on:click="foo"></div>
-    </div>
-</template>
-```
-
-👍 Examples of **correct** code for this rule:
-
-```html
-<template>
-    <div>
-        <div @click="foo"></div>
-    </div>
-</template>
-```
-
-👎 Examples of **incorrect** code for this rule with `"longform"` option:
-
-```html
-<template>
-    <div>
-        <div @click="foo"></div>
-    </div>
-</template>
-```
-
-👍 Examples of **correct** code for this rule with `"longform"` option:
+:-1: Examples of **incorrect** code for this rule:
 
 ```html
 <template>
@@ -46,7 +16,37 @@ This rule enforces `v-on` directive style which you should use shorthand or long
 </template>
 ```
 
-## 🔧 Options
+:+1: Examples of **correct** code for this rule:
+
+```html
+<template>
+    <div>
+        <div @click="foo"></div>
+    </div>
+</template>
+```
+
+:-1: Examples of **incorrect** code for this rule with `"longform"` option:
+
+```html
+<template>
+    <div>
+        <div @click="foo"></div>
+    </div>
+</template>
+```
+
+:+1: Examples of **correct** code for this rule with `"longform"` option:
+
+```html
+<template>
+    <div>
+        <div v-on:click="foo"></div>
+    </div>
+</template>
+```
+
+## :wrench: Options
 
 - `"shorthand"` (default) ... requires using shorthand.
 - `"longform"` ... requires using long form.

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -25,6 +25,7 @@ module.exports = {
   "vue/no-invalid-v-show": "error",
   "vue/no-invalid-v-text": "error",
   "vue/no-parsing-error": "error",
+  "vue/no-template-key": "off",
   "vue/no-textarea-mustache": "error",
   "vue/order-in-components": "off",
   "vue/require-component-is": "error",

--- a/lib/rules/no-invalid-v-for.js
+++ b/lib/rules/no-invalid-v-for.js
@@ -17,15 +17,16 @@ const utils = require('../utils')
 
 /**
  * Check whether the given attribute is using the variables which are defined by `v-for` directives.
- * @param {ASTNode} node The attribute node to check.
+ * @param {ASTNode} vFor The attribute node of `v-for` to check.
+ * @param {ASTNode} vBindKey The attribute node of `v-bind:key` to check.
  * @returns {boolean} `true` if the node is using the variables which are defined by `v-for` directives.
  */
-function isUsingIterationVar (node) {
-  if (node.value == null) {
+function isUsingIterationVar (vFor, vBindKey) {
+  if (vBindKey.value == null) {
     return false
   }
-  const references = node.value.references
-  const variables = node.parent.parent.variables
+  const references = vBindKey.value.references
+  const variables = vFor.parent.parent.variables
 
   return references.some(reference =>
         variables.some(variable =>
@@ -33,6 +34,32 @@ function isUsingIterationVar (node) {
             variable.kind === 'v-for'
         )
     )
+}
+
+/**
+ * Check the given element about `v-bind:key` attributes.
+ * @param {RuleContext} context The rule context to report.
+ * @param {ASTNode} vFor The attribute node of `v-for` to check.
+ * @param {ASTNode} element The element node to check.
+ */
+function checkKey (context, vFor, element) {
+  const startTag = element.startTag
+  const vBindKey = utils.getDirective(startTag, 'bind', 'key')
+
+  if (utils.isCustomComponent(startTag) && vBindKey == null) {
+    context.report({
+      node: startTag,
+      loc: startTag.loc,
+      message: "Custom elements in iteration require 'v-bind:key' directives."
+    })
+  }
+  if (vBindKey != null && !isUsingIterationVar(vFor, vBindKey)) {
+    context.report({
+      node: vBindKey,
+      loc: vBindKey.loc,
+      message: "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
+    })
+  }
 }
 
 /**
@@ -46,20 +73,15 @@ function create (context) {
 
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='for']" (node) {
-      const vBindKey = utils.getDirective(node.parent, 'bind', 'key')
-      if (utils.isCustomComponent(node.parent) && vBindKey == null) {
-        context.report({
-          node,
-          loc: node.loc,
-          message: "'v-for' directives on custom elements require 'v-bind:key' directives."
-        })
-      }
-      if (vBindKey != null && !isUsingIterationVar(vBindKey)) {
-        context.report({
-          node: vBindKey,
-          loc: vBindKey.loc,
-          message: "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
-        })
+      const element = node.parent.parent
+
+      checkKey(context, node, element)
+      if (element.startTag.id.name === 'template') {
+        for (const child of element.children) {
+          if (child.type === 'VElement') {
+            checkKey(context, node, child)
+          }
+        }
       }
 
       if (node.key.argument) {

--- a/lib/rules/no-template-key.js
+++ b/lib/rules/no-template-key.js
@@ -1,0 +1,55 @@
+/**
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+/**
+ * Creates AST event handlers for no-template-key.
+ *
+ * @param {RuleContext} context - The rule context.
+ * @returns {object} AST event handlers.
+ */
+function create (context) {
+  utils.registerTemplateBodyVisitor(context, {
+    "VStartTag[id.name='template']" (node) {
+      if (utils.hasAttribute(node, 'key') || utils.hasDirective(node, 'bind', 'key')) {
+        context.report({
+          node: node,
+          loc: node.loc,
+          message: "'<template>' cannot be keyed. Place the key on real elements instead."
+        })
+      }
+    }
+  })
+
+  return {}
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  create,
+  meta: {
+    docs: {
+      description: "disallow 'key' attribute on '<template>'.",
+      category: 'Possible Errors',
+      recommended: false
+    },
+    fixable: false,
+    schema: []
+  }
+}

--- a/lib/rules/require-v-for-key.js
+++ b/lib/rules/require-v-for-key.js
@@ -16,6 +16,23 @@ const utils = require('../utils')
 // ------------------------------------------------------------------------------
 
 /**
+ * Check the given element about `v-bind:key` attributes.
+ * @param {RuleContext} context The rule context to report.
+ * @param {ASTNode} element The element node to check.
+ */
+function checkKey (context, element) {
+  const startTag = element.startTag
+
+  if (startTag.id.name !== 'template' && !utils.isCustomComponent(startTag) && !utils.hasDirective(startTag, 'bind', 'key')) {
+    context.report({
+      node: startTag,
+      loc: startTag.loc,
+      message: "Elements in iteration expect to have 'v-bind:key' directives."
+    })
+  }
+}
+
+/**
  * Creates AST event handlers for require-v-for-key.
  *
  * @param {RuleContext} context - The rule context.
@@ -24,12 +41,15 @@ const utils = require('../utils')
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='for']" (node) {
-      if (!utils.hasDirective(node.parent, 'bind', 'key') && !utils.isCustomComponent(node.parent)) {
-        context.report({
-          node: node.parent,
-          loc: node.parent.loc,
-          message: "'v-for' directives require 'v-bind:key' directives."
-        })
+      const element = node.parent.parent
+
+      checkKey(context, element)
+      if (element.startTag.id.name === 'template') {
+        for (const child of element.children) {
+          if (child.type === 'VElement') {
+            checkKey(context, child)
+          }
+        }
       }
     }
   })

--- a/tests/lib/rules/no-invalid-v-for.js
+++ b/tests/lib/rules/no-invalid-v-for.js
@@ -62,6 +62,18 @@ tester.run('no-invalid-v-for', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><div :is="your-component" v-for="x in list" :key="x.id"></div></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-for="x in list"><custom-component :key="x"></custom-component></template></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-for="x in list"><div :key="x"></div></template></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-for="x in list"><div></div></template></div></template>'
     }
   ],
   invalid: [
@@ -108,22 +120,22 @@ tester.run('no-invalid-v-for', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><your-component v-for="x in list"></your-component></div></template>',
-      errors: ["'v-for' directives on custom elements require 'v-bind:key' directives."]
+      errors: ["Custom elements in iteration require 'v-bind:key' directives."]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div is="your-component" v-for="x in list"></div></div></template>',
-      errors: ["'v-for' directives on custom elements require 'v-bind:key' directives."]
+      errors: ["Custom elements in iteration require 'v-bind:key' directives."]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div :is="your-component" v-for="x in list"></div></div></template>',
-      errors: ["'v-for' directives on custom elements require 'v-bind:key' directives."]
+      errors: ["Custom elements in iteration require 'v-bind:key' directives."]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div v-bind:is="your-component" v-for="x in list"></div></div></template>',
-      errors: ["'v-for' directives on custom elements require 'v-bind:key' directives."]
+      errors: ["Custom elements in iteration require 'v-bind:key' directives."]
     },
     {
       filename: 'test.vue',
@@ -149,6 +161,11 @@ tester.run('no-invalid-v-for', rule, {
       filename: 'test.vue',
       code: '<template><div><div v-for="(item, index) in suggestions" :key></div></div></template>',
       errors: ["Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-for="x in list" :key="x"><custom-component></custom-component></template></div></template>',
+      errors: ["Custom elements in iteration require 'v-bind:key' directives."]
     }
   ]
 })

--- a/tests/lib/rules/no-template-key.js
+++ b/tests/lib/rules/no-template-key.js
@@ -1,0 +1,64 @@
+/**
+ * @author Toru Nagashima
+ * @copyright 2017 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-template-key')
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('no-template-key', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: ''
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><template></template></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div key="foo"></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div v-bind:key="foo"></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div :key="foo"></div></template>'
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: '<template><div><template key="foo"></template></div></template>',
+      errors: ["'<template>' cannot be keyed. Place the key on real elements instead."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-bind:key="foo"></template></div></template>',
+      errors: ["'<template>' cannot be keyed. Place the key on real elements instead."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template :key="foo"></template></div></template>',
+      errors: ["'<template>' cannot be keyed. Place the key on real elements instead."]
+    }
+  ]
+})

--- a/tests/lib/rules/require-v-for-key.js
+++ b/tests/lib/rules/require-v-for-key.js
@@ -38,18 +38,27 @@ tester.run('require-v-for-key', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><custom-component v-for="x in list"></custom-component></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-for="x in list"><div :key="x"></div></template></div></template>'
     }
   ],
   invalid: [
     {
       filename: 'test.vue',
       code: '<template><div><div v-for="x in list"></div></div></template>',
-      errors: ["'v-for' directives require 'v-bind:key' directives."]
+      errors: ["Elements in iteration expect to have 'v-bind:key' directives."]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div v-for="x in list" key="100"></div></div></template>',
-      errors: ["'v-for' directives require 'v-bind:key' directives."]
+      errors: ["Elements in iteration expect to have 'v-bind:key' directives."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-for="x in list"><div></div></template></div></template>',
+      errors: ["Elements in iteration expect to have 'v-bind:key' directives."]
     }
   ]
 })


### PR DESCRIPTION
Fixes #43.

This PR does 2 things.

1. Fixes `no-invalid-v-for` and `require-v-for-key` rules to check whether child elements of `<template>` elements have `v-bind:key` attribute. [semver-minor]
2. Add new `no-template-key` rule to disallow `key` attribute on `<template>` elements. I think that `no-template-key` rule should be recommended, however I set `recommended: false` for now because [semver policy of ESLint](https://github.com/eslint/eslint#semantic-versioning-policy) needs a major version to update the recommended config. [semver-minor]