### PR TITLE
Fix: upgrade vue-eslint-parser (fixes #51, fixes #52, fixes #55)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,9 +1974,9 @@
       "dev": true
     },
     "vue-eslint-parser": {
-      "version": "1.1.0-6",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-1.1.0-6.tgz",
-      "integrity": "sha512-HKaWwqfPOUSR3lMX1/2fQkgNoVnmhQtHyeGzE3kyf1j6BgAw4fzaHeoNLPLCLvq7c/SoxY2VXRxFCxq+1mB3JQ=="
+      "version": "1.1.0-7",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-1.1.0-7.tgz",
+      "integrity": "sha512-dY0AR5BxSjN8TT4bStUuGb55yjSyAvN1ifUrzfuD7kMdmd5g7e/LYIXCqcvB3GuI5wWOs3fa3o31fqQHfQOHew=="
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "requireindex": "^1.1.0",
-    "vue-eslint-parser": "^1.1.0-6"
+    "vue-eslint-parser": "^1.1.0-7"
   },
   "devDependencies": {
     "@types/node": "^4.2.6",

--- a/tests/lib/rules/no-parsing-error.js
+++ b/tests/lib/rules/no-parsing-error.js
@@ -34,6 +34,18 @@ tester.run('no-parsing-error', rule, {
     {
       filename: 'test.vue',
       code: '<template>{{a + b + c}}</template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><svg class="icon"><use xlink:href="#chevron"></use></svg></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><svg viewBox="0 0 40 40"></svg></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<table><tr><td></td></tr></table>'
     }
   ],
   invalid: [


### PR DESCRIPTION
Fixes #51, fixes #52, fixes #55.

This PR upgrades `vue-eslint-parser` to fix several issues.

- https://github.com/mysticatea/vue-eslint-parser/commit/65a673a23fdaa36b7fd76163ba8ca187f5e60379 fixed crash if foreign attributes exist. Thank you, @benjarwar!
- https://github.com/mysticatea/vue-eslint-parser/commit/8168db16df3eaa327bacded0f244f0565b563a0f fixed crash if `<tbody>`/`<thead>` elements are omitted.