### PR TITLE
Update config

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -7,7 +7,8 @@ module.exports = {
     ecmaVersion: 6,
     sourceType: 'module',
     ecmaFeatures: {
-      jsx: true
+      jsx: true,
+      experimentalObjectRestSpread: true
     }
   },
 


### PR DESCRIPTION
This PR adds `experimentalObjectRestSpread` in base configuration.

Using object spread notation is so common, that I think it should be in base configuration, so it works for more people out of the box without the need to configure it additionally.

It came up here: #59 