### PR TITLE
Add missing schema to rule order-in-components

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -143,6 +143,16 @@ module.exports = {
       recommended: false
     },
     fixable: null,
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          order: {
+            type: 'array'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
 }


### PR DESCRIPTION
Rule `vue/order-in-components` throws eslint rule schema validation error on custom order
bacause is missing schema definition

issue: #73