### PR TITLE
Add `return-in-computed-property` rule.

### DIFF
--- a/docs/rules/return-in-computed-property.md
+++ b/docs/rules/return-in-computed-property.md
@@ -1,0 +1,44 @@
+# Enforces that a return statement is present in computed property (return-in-computed-property)
+
+## :book: Rule Details
+
+This rule enforces that a `return` statement is present in `computed` properties.
+
+:-1: Examples of **incorrect** code for this rule:
+
+```js
+export default {
+  computed: {
+    foo () {
+    },
+    bar: function () {
+    }
+  }
+}
+```
+
+:+1: Examples of **correct** code for this rule:
+
+```js
+export default {
+  computed: {
+    foo () {
+      return true
+    },
+    bar: function () {
+      return false
+    }
+  }
+}
+```
+
+## :wrench: Options
+
+This rule has an object option:
+- `"treatUndefinedAsUnspecified"`: `true` (default) disallows implicitly returning undefined with a `return;` statement.
+
+```
+vue/return-in-computed-property: [2, {
+  treatUndefinedAsUnspecified: true
+}]
+```

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -1,0 +1,111 @@
+/**
+ * @fileoverview Enforces that a return statement is present in computed property (return-in-computed-property)
+ * @author Armano
+ */
+'use strict'
+
+const utils = require('../utils')
+
+function create (context) {
+  const options = context.options[0] || {}
+  const treatUndefinedAsUnspecified = !(options.treatUndefinedAsUnspecified === false)
+
+  let funcInfo = {
+    funcInfo: null,
+    codePath: null,
+    hasReturn: false,
+    hasReturnValue: false,
+    node: null
+  }
+  const forbiddenNodes = []
+
+  // ----------------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------------
+  function isValidReturn () {
+    return (!treatUndefinedAsUnspecified && funcInfo.hasReturn) || (treatUndefinedAsUnspecified && funcInfo.hasReturnValue)
+  }
+
+  // ----------------------------------------------------------------------
+  // Public
+  // ----------------------------------------------------------------------
+
+  return Object.assign({},
+    {
+      onCodePathStart (codePath, node) {
+        funcInfo = {
+          codePath,
+          funcInfo: funcInfo,
+          hasReturn: false,
+          hasReturnValue: false,
+          node
+        }
+      },
+      onCodePathEnd () {
+        funcInfo = funcInfo.funcInfo
+      },
+      ReturnStatement (node) {
+        funcInfo.hasReturn = true
+        funcInfo.hasReturnValue = Boolean(node.argument)
+      },
+      'FunctionExpression:exit' (node) {
+        if (!isValidReturn() && funcInfo.codePath.currentSegments.some((segment) => segment.reachable)) {
+          forbiddenNodes.push({
+            hasReturn: funcInfo.hasReturn,
+            node: funcInfo.node,
+            type: 'return'
+          })
+        }
+      }
+    },
+    utils.executeOnVueComponent(context, properties => {
+      const computedProperties = utils.getComputedProperties(properties)
+
+      computedProperties.forEach(cp => {
+        forbiddenNodes.forEach(el => {
+          if (
+            cp.value &&
+            el.node.loc.start.line >= cp.value.loc.start.line &&
+            el.node.loc.end.line <= cp.value.loc.end.line
+          ) {
+            context.report({
+              node: el.node,
+              message: 'Expected to return a value in "{{name}}" computed property.',
+              data: {
+                name: cp.key
+              }
+            })
+          }
+        })
+      })
+    })
+  )
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Enforces that a return statement is present in computed property.',
+      category: 'Possible Errors',
+      recommended: false
+    },
+    fixable: null,  // or "code" or "whitespace"
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          treatUndefinedAsUnspecified: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  },
+
+  create
+}

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -23,7 +23,10 @@ function create (context) {
   // Helpers
   // ----------------------------------------------------------------------
   function isValidReturn () {
-    return (!treatUndefinedAsUnspecified && funcInfo.hasReturn) || (treatUndefinedAsUnspecified && funcInfo.hasReturnValue)
+    if (!funcInfo.hasReturn) {
+      return false
+    }
+    return !treatUndefinedAsUnspecified || funcInfo.hasReturnValue
   }
 
   // ----------------------------------------------------------------------
@@ -49,7 +52,7 @@ function create (context) {
         funcInfo.hasReturnValue = Boolean(node.argument)
       },
       'FunctionExpression:exit' (node) {
-        if (!isValidReturn() && funcInfo.codePath.currentSegments.some((segment) => segment.reachable)) {
+        if (!isValidReturn()) {
           forbiddenNodes.push({
             hasReturn: funcInfo.hasReturn,
             node: funcInfo.node,

--- a/tests/lib/rules/return-in-computed-property.js
+++ b/tests/lib/rules/return-in-computed-property.js
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview Enforces that a return statement is present in computed property (return-in-computed-property)
+ * @author Armano
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/return-in-computed-property')
+
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester()
+ruleTester.run('return-in-computed-property', rule, {
+
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo () {
+              return true
+            },
+            bar: function () {
+              return false
+            },
+            bar3: {
+              set () {
+                return true
+              },
+              get () {
+                return true
+              }
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 8, sourceType: 'module' }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo: {
+              get () {
+                return
+              }
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 8, sourceType: 'module' },
+      options: [{ treatUndefinedAsUnspecified: false }]
+    }
+  ],
+
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo () {
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 8, sourceType: 'module' },
+      errors: [{
+        message: 'Expected to return a value in "foo" computed property.',
+        line: 4
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo: function () {
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Expected to return a value in "foo" computed property.',
+        line: 4
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo: function () {
+              if (a) {
+                return
+              }
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Expected to return a value in "foo" computed property.',
+        line: 4
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo: {
+              set () {
+              },
+              get () {
+              }
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 8, sourceType: 'module' },
+      errors: [{
+        message: 'Expected to return a value in "foo" computed property.',
+        line: 7
+      }]
+    }
+  ]
+})

--- a/tests/lib/rules/return-in-computed-property.js
+++ b/tests/lib/rules/return-in-computed-property.js
@@ -133,6 +133,26 @@ ruleTester.run('return-in-computed-property', rule, {
         message: 'Expected to return a value in "foo" computed property.',
         line: 7
       }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo: function () {
+              function bar () {
+                return this.baz * 2
+              }
+              bar()
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 8, sourceType: 'module' },
+      errors: [{
+        message: 'Expected to return a value in "foo" computed property.',
+        line: 4
+      }]
     }
   ]
 })

--- a/tests/lib/rules/return-in-computed-property.js
+++ b/tests/lib/rules/return-in-computed-property.js
@@ -153,6 +153,44 @@ ruleTester.run('return-in-computed-property', rule, {
         message: 'Expected to return a value in "foo" computed property.',
         line: 4
       }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo () {
+            },
+            bar () {
+              return
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 8, sourceType: 'module' },
+      options: [{ treatUndefinedAsUnspecified: false }],
+      errors: [{
+        message: 'Expected to return a value in "foo" computed property.',
+        line: 4
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo () {
+              return
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 8, sourceType: 'module' },
+      options: [{ treatUndefinedAsUnspecified: true }],
+      errors: [{
+        message: 'Expected to return a value in "foo" computed property.',
+        line: 4
+      }]
     }
   ]
 })


### PR DESCRIPTION
This PR implements rules proposed in #75

**DONE:**
- [x] Basic check for `return`
- [x] Check if all paths `return` value
- [x] Option: `treatUndefinedAsUnspecified` - disallows implicitly returning undefined with a `return;` statement.