### PR TITLE
Specify ecmaVersion to 2017

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -4,7 +4,7 @@ module.exports = {
   parser: require.resolve('vue-eslint-parser'),
 
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true,


### PR DESCRIPTION
For now using async/await syntax in `.vue` files will get `Parsing error: The keyword 'await' is reserved (Fatal)`.

Specify `ecmaVersion` to 2017 should solve this problem.