### PR TITLE
Update: upgrade vue-eslint-parser (fixes #36, fixes #56, fixes #96)

### DIFF
--- a/docs/rules/no-parsing-error.md
+++ b/docs/rules/no-parsing-error.md
@@ -1,6 +1,14 @@
 # Disallow parsing errors in `<template>` (no-parsing-error)
 
-This rule reports syntax errors in directives/mustaches of `<template>`.
+This rule reports syntax errors in `<template>`. For example:
+
+- Syntax errors of scripts in directives.
+- Syntax errors of scripts in mustaches.
+- Syntax errors of HTML.
+    - Invalid end tags.
+    - Attributes in end tags.
+    - ...
+    - See also: https://html.spec.whatwg.org/multipage/parsing.html#parse-errors
 
 ## :book: Rule Details
 
@@ -25,4 +33,56 @@ Then reports syntax errors if exist.
 
 ## :wrench: Options
 
-Nothing.
+```json
+{
+    "vue/no-parsing-error": ["error", {
+        "abrupt-closing-of-empty-comment": false,
+        "absence-of-digits-in-numeric-character-reference": false,
+        "cdata-in-html-content": false,
+        "character-reference-outside-unicode-range": false,
+        "control-character-in-input-stream": false,
+        "control-character-reference": false,
+        "eof-before-tag-name": false,
+        "eof-in-cdata": false,
+        "eof-in-comment": false,
+        "eof-in-tag": false,
+        "incorrectly-closed-comment": false,
+        "incorrectly-opened-comment": false,
+        "invalid-first-character-of-tag-name": false,
+        "missing-attribute-value": false,
+        "missing-end-tag-name": false,
+        "missing-semicolon-after-character-reference": false,
+        "missing-whitespace-between-attributes": false,
+        "nested-comment": false,
+        "noncharacter-character-reference": false,
+        "noncharacter-in-input-stream": false,
+        "null-character-reference": false,
+        "surrogate-character-reference": false,
+        "surrogate-in-input-stream": false,
+        "unexpected-character-in-attribute-name": false,
+        "unexpected-character-in-unquoted-attribute-value": false,
+        "unexpected-equals-sign-before-attribute-name": false,
+        "unexpected-null-character": false,
+        "unexpected-question-mark-instead-of-tag-name": false,
+        "unexpected-solidus-in-tag": false,
+        "unknown-named-character-reference": false,
+        "end-tag-with-attributes": false,
+        "duplicate-attribute": false,
+        "end-tag-with-trailing-solidus": false,
+        "non-void-html-element-start-tag-with-trailing-solidus": false,
+        "x-invalid-end-tag": false,
+        "x-invalid-namespace": false
+    }]
+}
+```
+
+You can enable HTML syntax errors by opt-in.
+
+For example, if `"x-invalid-end-tag": true` is given then this rule will catch the end tags of elements which have not opened.
+The error codes are defined in [WHATWG spec](https://html.spec.whatwg.org/multipage/parsing.html#parse-errors), but this rule does not support all of those (E.g., it does not catch errors about DOCTYPE).
+Also, The codes which have `x-` prefix are original in this rule because errors in tree construction phase have not codified yet.
+
+- `x-invalid-end-tag` enables the errors about the end tags of elements which have not opened.
+- `x-invalid-namespace` enables the errors about invalid `xmlns` attributes. See also [step 10. of "create an element for a token"](https://html.spec.whatwg.org/multipage/parsing.html#create-an-element-for-the-token).
+
+> TODO(mysticatea): I will revisit errors in tree construction phase after those are codified.

--- a/lib/rules/html-end-tags.js
+++ b/lib/rules/html-end-tags.js
@@ -24,7 +24,7 @@ const utils = require('../utils')
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     VElement (node) {
-      const name = node.startTag.id.name
+      const name = node.name
       const isVoid = utils.isVoidElementName(name)
       const hasEndTag = node.endTag != null
 

--- a/lib/rules/html-no-self-closing.js
+++ b/lib/rules/html-no-self-closing.js
@@ -23,16 +23,23 @@ const utils = require('../utils')
  */
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
-    'VStartTag[selfClosing=true]' (node) {
-      if (!utils.isSvgElementName(node.id.name)) {
-        const pos = node.range[1] - 2
-        context.report({
-          node,
-          loc: node.loc,
-          message: 'Self-closing should not be used.',
-          fix: (fixer) => fixer.removeRange([pos, pos + 1])
-        })
+    'VElement' (node) {
+      if (utils.isSvgElementName(node.name)) {
+        return
       }
+
+      const sourceCode = context.parserServices.getTemplateBodyTokenStore(context)
+      const lastToken = sourceCode.getLastToken(node.startTag)
+      if (lastToken.type !== 'HTMLSelfClosingTagClose') {
+        return
+      }
+
+      context.report({
+        node: lastToken,
+        loc: lastToken.loc,
+        message: 'Self-closing should not be used.',
+        fix: (fixer) => fixer.removeRange([lastToken.range[0], lastToken.range[0] + 1])
+      })
     }
   })
 
@@ -49,8 +56,10 @@ module.exports = {
     docs: {
       description: 'disallow self-closing elements.',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      replacedBy: []
     },
+    deprecated: true,
     fixable: 'code',
     schema: []
   }

--- a/lib/rules/no-confusing-v-for-v-if.js
+++ b/lib/rules/no-confusing-v-for-v-if.js
@@ -39,7 +39,9 @@ function isUsingIterationVar (vIf) {
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='if']" (node) {
-      if (utils.hasDirective(node.parent, 'for') && !isUsingIterationVar(node)) {
+      const element = node.parent.parent
+
+      if (utils.hasDirective(element, 'for') && !isUsingIterationVar(node)) {
         context.report({
           node,
           loc: node.loc,

--- a/lib/rules/no-invalid-template-root.js
+++ b/lib/rules/no-invalid-template-root.js
@@ -26,24 +26,24 @@ function create (context) {
 
   return {
     Program (program) {
-      const node = program.templateBody
-      if (node == null) {
+      const element = program.templateBody
+      if (element == null) {
         return
       }
 
-      const hasSrc = utils.hasAttribute(node.startTag, 'src')
+      const hasSrc = utils.hasAttribute(element, 'src')
       const rootElements = []
       let extraText = null
       let extraElement = null
       let vIf = false
-      for (const child of node.children) {
+      for (const child of element.children) {
         if (child.type === 'VElement') {
           if (rootElements.length === 0 && !hasSrc) {
             rootElements.push(child)
-            vIf = utils.hasDirective(child.startTag, 'if')
-          } else if (vIf && utils.hasDirective(child.startTag, 'else-if')) {
+            vIf = utils.hasDirective(child, 'if')
+          } else if (vIf && utils.hasDirective(child, 'else-if')) {
             rootElements.push(child)
-          } else if (vIf && utils.hasDirective(child.startTag, 'else')) {
+          } else if (vIf && utils.hasDirective(child, 'else')) {
             rootElements.push(child)
             vIf = false
           } else {
@@ -74,14 +74,14 @@ function create (context) {
         })
       } else if (rootElements.length === 0 && !hasSrc) {
         context.report({
-          node,
-          loc: node.loc,
+          node: element,
+          loc: element.loc,
           message: 'The template root requires exactly one element.'
         })
       } else {
         for (const element of rootElements) {
           const tag = element.startTag
-          const name = tag.id.name
+          const name = element.name
 
           if (name === 'template' || name === 'slot') {
             context.report({
@@ -91,7 +91,7 @@ function create (context) {
               data: { name }
             })
           }
-          if (utils.hasDirective(tag, 'for')) {
+          if (utils.hasDirective(element, 'for')) {
             context.report({
               node: tag,
               loc: tag.loc,

--- a/lib/rules/no-invalid-v-else-if.js
+++ b/lib/rules/no-invalid-v-else-if.js
@@ -24,21 +24,23 @@ const utils = require('../utils')
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='else-if']" (node) {
-      if (!utils.prevElementHasIf(node.parent.parent)) {
+      const element = node.parent.parent
+
+      if (!utils.prevElementHasIf(element)) {
         context.report({
           node,
           loc: node.loc,
           message: "'v-else-if' directives require being preceded by the element which has a 'v-if' or 'v-else-if' directive."
         })
       }
-      if (utils.hasDirective(node.parent, 'if')) {
+      if (utils.hasDirective(element, 'if')) {
         context.report({
           node,
           loc: node.loc,
           message: "'v-else-if' and 'v-if' directives can't exist on the same element."
         })
       }
-      if (utils.hasDirective(node.parent, 'else')) {
+      if (utils.hasDirective(element, 'else')) {
         context.report({
           node,
           loc: node.loc,

--- a/lib/rules/no-invalid-v-else.js
+++ b/lib/rules/no-invalid-v-else.js
@@ -24,21 +24,23 @@ const utils = require('../utils')
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='else']" (node) {
-      if (!utils.prevElementHasIf(node.parent.parent)) {
+      const element = node.parent.parent
+
+      if (!utils.prevElementHasIf(element)) {
         context.report({
           node,
           loc: node.loc,
           message: "'v-else' directives require being preceded by the element which has a 'v-if' or 'v-else' directive."
         })
       }
-      if (utils.hasDirective(node.parent, 'if')) {
+      if (utils.hasDirective(element, 'if')) {
         context.report({
           node,
           loc: node.loc,
           message: "'v-else' and 'v-if' directives can't exist on the same element. You may want 'v-else-if' directives."
         })
       }
-      if (utils.hasDirective(node.parent, 'else-if')) {
+      if (utils.hasDirective(element, 'else-if')) {
         context.report({
           node,
           loc: node.loc,

--- a/lib/rules/no-invalid-v-for.js
+++ b/lib/rules/no-invalid-v-for.js
@@ -43,13 +43,21 @@ function isUsingIterationVar (vFor, vBindKey) {
  * @param {ASTNode} element The element node to check.
  */
 function checkKey (context, vFor, element) {
-  const startTag = element.startTag
-  const vBindKey = utils.getDirective(startTag, 'bind', 'key')
+  if (element.name === 'template') {
+    for (const child of element.children) {
+      if (child.type === 'VElement') {
+        checkKey(context, vFor, child)
+      }
+    }
+    return
+  }
 
-  if (utils.isCustomComponent(startTag) && vBindKey == null) {
+  const vBindKey = utils.getDirective(element, 'bind', 'key')
+
+  if (utils.isCustomComponent(element) && vBindKey == null) {
     context.report({
-      node: startTag,
-      loc: startTag.loc,
+      node: element.startTag,
+      loc: element.startTag.loc,
       message: "Custom elements in iteration require 'v-bind:key' directives."
     })
   }
@@ -76,13 +84,6 @@ function create (context) {
       const element = node.parent.parent
 
       checkKey(context, node, element)
-      if (element.startTag.id.name === 'template') {
-        for (const child of element.children) {
-          if (child.type === 'VElement') {
-            checkKey(context, node, child)
-          }
-        }
-      }
 
       if (node.key.argument) {
         context.report({

--- a/lib/rules/no-invalid-v-if.js
+++ b/lib/rules/no-invalid-v-if.js
@@ -24,14 +24,16 @@ const utils = require('../utils')
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='if']" (node) {
-      if (utils.hasDirective(node.parent, 'else')) {
+      const element = node.parent.parent
+
+      if (utils.hasDirective(element, 'else')) {
         context.report({
           node,
           loc: node.loc,
           message: "'v-if' and 'v-else' directives can't exist on the same element. You may want 'v-else-if' directives."
         })
       }
-      if (utils.hasDirective(node.parent, 'else-if')) {
+      if (utils.hasDirective(element, 'else-if')) {
         context.report({
           node,
           loc: node.loc,

--- a/lib/rules/no-invalid-v-model.js
+++ b/lib/rules/no-invalid-v-model.js
@@ -19,11 +19,11 @@ const VALID_MODIFIERS = new Set(['lazy', 'number', 'trim'])
 
 /**
  * Check whether the given node is valid or not.
- * @param {ASTNode} node The start tag node to check.
+ * @param {ASTNode} node The element node to check.
  * @returns {boolean} `true` if the node is valid.
  */
 function isValidElement (node) {
-  const name = node.id.name
+  const name = node.name
   return (
         name === 'input' ||
         name === 'select' ||
@@ -82,32 +82,36 @@ function getVariable (name, leafNode) {
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='model']" (node) {
-      if (!isValidElement(node.parent)) {
+      const element = node.parent.parent
+      const name = element.name
+
+      if (!isValidElement(element)) {
         context.report({
           node,
           loc: node.loc,
           message: "'v-model' directives aren't supported on <{{name}}> elements.",
-          data: node.parent.id
+          data: { name }
         })
       }
-      if (node.parent.id.name === 'input') {
-        if (utils.hasDirective(node.parent, 'bind', 'type')) {
+      if (name === 'input') {
+        if (utils.hasDirective(element, 'bind', 'type')) {
           context.report({
             node,
             loc: node.loc,
             message: "'v-model' directives don't support dynamic input types.",
-            data: node.parent.id
+            data: { name }
           })
         }
-        if (utils.hasAttribute(node.parent, 'type', 'file')) {
+        if (utils.hasAttribute(element, 'type', 'file')) {
           context.report({
             node,
             loc: node.loc,
             message: "'v-model' directives don't support 'file' input type.",
-            data: node.parent.id
+            data: { name }
           })
         }
       }
+
       if (node.key.argument) {
         context.report({
           node,
@@ -115,6 +119,7 @@ function create (context) {
           message: "'v-model' directives require no argument."
         })
       }
+
       for (const modifier of node.key.modifiers) {
         if (!VALID_MODIFIERS.has(modifier)) {
           context.report({
@@ -147,8 +152,7 @@ function create (context) {
             continue
           }
 
-          const elementNode = node.parent.parent
-          const variable = getVariable(id.name, elementNode)
+          const variable = getVariable(id.name, element)
           if (variable != null) {
             context.report({
               node,

--- a/lib/rules/no-parsing-error.js
+++ b/lib/rules/no-parsing-error.js
@@ -6,14 +6,49 @@
 'use strict'
 
 // ------------------------------------------------------------------------------
-// Requirements
-// ------------------------------------------------------------------------------
-
-const utils = require('../utils')
-
-// ------------------------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------------------------
+
+// https://html.spec.whatwg.org/multipage/parsing.html#parse-errors
+// TODO: Enable all by default.
+const DEFAULT_OPTIONS = Object.freeze(Object.assign(Object.create(null), {
+  'abrupt-closing-of-empty-comment': false,
+  'absence-of-digits-in-numeric-character-reference': false,
+  'cdata-in-html-content': false,
+  'character-reference-outside-unicode-range': false,
+  'control-character-in-input-stream': false,
+  'control-character-reference': false,
+  'eof-before-tag-name': false,
+  'eof-in-cdata': false,
+  'eof-in-comment': false,
+  'eof-in-tag': false,
+  'incorrectly-closed-comment': false,
+  'incorrectly-opened-comment': false,
+  'invalid-first-character-of-tag-name': false,
+  'missing-attribute-value': false,
+  'missing-end-tag-name': false,
+  'missing-semicolon-after-character-reference': false,
+  'missing-whitespace-between-attributes': false,
+  'nested-comment': false,
+  'noncharacter-character-reference': false,
+  'noncharacter-in-input-stream': false,
+  'null-character-reference': false,
+  'surrogate-character-reference': false,
+  'surrogate-in-input-stream': false,
+  'unexpected-character-in-attribute-name': false,
+  'unexpected-character-in-unquoted-attribute-value': false,
+  'unexpected-equals-sign-before-attribute-name': false,
+  'unexpected-null-character': false,
+  'unexpected-question-mark-instead-of-tag-name': false,
+  'unexpected-solidus-in-tag': false,
+  'unknown-named-character-reference': false,
+  'end-tag-with-attributes': false,
+  'duplicate-attribute': false,
+  'end-tag-with-trailing-solidus': false,
+  'non-void-html-element-start-tag-with-trailing-solidus': false,
+  'x-invalid-end-tag': false,
+  'x-invalid-namespace': false
+}))
 
 /**
  * Creates AST event handlers for no-parsing-error.
@@ -22,24 +57,33 @@ const utils = require('../utils')
  * @returns {object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
-    'VExpressionContainer[syntaxError!=null]' (node) {
-      const message = node.syntaxError.message
+  const options = Object.assign({}, DEFAULT_OPTIONS, context.options[0] || {})
 
-      context.report({
-        node,
-        loc: node.loc,
-        message: 'Parsing error: {{message}}.',
-        data: {
-          message: message.endsWith('.')
-                        ? message.slice(0, -1)
-                        : message
+  return {
+    Program (program) {
+      const node = program.templateBody
+      if (node == null || node.errors == null) {
+        return
+      }
+
+      for (const error of node.errors) {
+        if (error.code && !options[error.code]) {
+          continue
         }
-      })
-    }
-  })
 
-  return {}
+        context.report({
+          node,
+          loc: { line: error.lineNumber, column: error.column },
+          message: 'Parsing error: {{message}}.',
+          data: {
+            message: error.message.endsWith('.')
+              ? error.message.slice(0, -1)
+              : error.message
+          }
+        })
+      }
+    }
+  }
 }
 
 // ------------------------------------------------------------------------------
@@ -55,6 +99,15 @@ module.exports = {
       recommended: true
     },
     fixable: false,
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: Object.keys(DEFAULT_OPTIONS).reduce((ret, code) => {
+          ret[code] = { type: 'boolean' }
+          return ret
+        }, {}),
+        additionalProperties: false
+      }
+    ]
   }
 }

--- a/lib/rules/no-template-key.js
+++ b/lib/rules/no-template-key.js
@@ -23,7 +23,7 @@ const utils = require('../utils')
  */
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
-    "VStartTag[id.name='template']" (node) {
+    "VElement[name='template']" (node) {
       if (utils.hasAttribute(node, 'key') || utils.hasDirective(node, 'bind', 'key')) {
         context.report({
           node: node,

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -23,7 +23,7 @@ const utils = require('../utils')
  */
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
-    "VElement[startTag.id.name='textarea'] VExpressionContainer" (node) {
+    "VElement[name='textarea'] VExpressionContainer" (node) {
       if (node.parent.type !== 'VElement') {
         return
       }

--- a/lib/rules/require-component-is.js
+++ b/lib/rules/require-component-is.js
@@ -23,7 +23,7 @@ const utils = require('../utils')
  */
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
-    "VStartTag[id.name='component']" (node) {
+    "VElement[name='component']" (node) {
       if (!utils.hasDirective(node, 'bind', 'is')) {
         context.report({
           node,

--- a/lib/rules/require-v-for-key.js
+++ b/lib/rules/require-v-for-key.js
@@ -21,12 +21,16 @@ const utils = require('../utils')
  * @param {ASTNode} element The element node to check.
  */
 function checkKey (context, element) {
-  const startTag = element.startTag
-
-  if (startTag.id.name !== 'template' && !utils.isCustomComponent(startTag) && !utils.hasDirective(startTag, 'bind', 'key')) {
+  if (element.name === 'template') {
+    for (const child of element.children) {
+      if (child.type === 'VElement') {
+        checkKey(context, child)
+      }
+    }
+  } else if (!utils.isCustomComponent(element) && !utils.hasDirective(element, 'bind', 'key')) {
     context.report({
-      node: startTag,
-      loc: startTag.loc,
+      node: element.startTag,
+      loc: element.startTag.loc,
       message: "Elements in iteration expect to have 'v-bind:key' directives."
     })
   }
@@ -41,16 +45,7 @@ function checkKey (context, element) {
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='for']" (node) {
-      const element = node.parent.parent
-
-      checkKey(context, element)
-      if (element.startTag.id.name === 'template') {
-        for (const child of element.children) {
-          if (child.type === 'VElement') {
-            checkKey(context, child)
-          }
-        }
-      }
+      checkKey(context, node.parent.parent)
     }
   })
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -19,15 +19,15 @@ const assert = require('assert')
 // ------------------------------------------------------------------------------
 
 module.exports = {
-    /**
-     * Register the given visitor to parser services.
-     * If the parser service of `vue-eslint-parser` was not found,
-     * this generates a warning.
-     *
-     * @param {RuleContext} context The rule context to use parser services.
-     * @param {object} visitor The visitor.
-     * @returns {void}
-     */
+  /**
+   * Register the given visitor to parser services.
+   * If the parser service of `vue-eslint-parser` was not found,
+   * this generates a warning.
+   *
+   * @param {RuleContext} context The rule context to use parser services.
+   * @param {object} visitor The visitor.
+   * @returns {void}
+   */
   registerTemplateBodyVisitor (context, visitor) {
     if (context.parserServices.registerTemplateBodyVisitor == null) {
       context.report({
@@ -39,44 +39,43 @@ module.exports = {
     context.parserServices.registerTemplateBodyVisitor(context, visitor)
   },
 
-    /**
-     * Get the token store of template bodies.
-     * If the parser service of `vue-eslint-parser` was not found,
-     * this generates a warning.
-     *
-     * @param {RuleContext} context The rule context to use parser services.
-     * @returns {TokenStore} The gotten token store.
-     */
-  getTemplateBodyTokenStore (context) {
+  /**
+   * Get the token store of template body from parser services.
+   * If the parser service of `vue-eslint-parser` was not found,
+   * this generates a warning.
+   *
+   * @returns {void}
+   */
+  getTemplateBodyTokenStore () {
     if (context.parserServices.getTemplateBodyTokenStore == null) {
       context.report({
         loc: { line: 1, column: 0 },
-        message: 'Use the latest vue-eslint-parser.'
+        message: 'Use the latest vue-eslint-parser. See also https://github.com/vuejs/eslint-plugin-vue#what-is-the-use-the-latest-vue-eslint-parser-error'
       })
-      return null
+      return context.getSourceCode()
     }
-    return context.parserServices.getTemplateBodyTokenStore(context)
+    return context.parserServices.getTemplateBodyTokenStore()
   },
 
-    /**
-     * Check whether the given node is the root element or not.
-     * @param {ASTNode} node The element node to check.
-     * @returns {boolean} `true` if the node is the root element.
-     */
+  /**
+   * Check whether the given node is the root element or not.
+   * @param {ASTNode} node The element node to check.
+   * @returns {boolean} `true` if the node is the root element.
+   */
   isRootElement (node) {
     assert(node && node.type === 'VElement')
 
     return (
-            node.parent.type === 'Program' ||
-            node.parent.parent.type === 'Program'
+      node.parent.type === 'VDocumentFragment' ||
+      node.parent.parent.type === 'VDocumentFragment'
     )
   },
 
-    /**
-     * Get the previous sibling element of the given element.
-     * @param {ASTNode} node The element node to get the previous sibling element.
-     * @returns {ASTNode|null} The previous sibling element.
-     */
+  /**
+   * Get the previous sibling element of the given element.
+   * @param {ASTNode} node The element node to get the previous sibling element.
+   * @returns {ASTNode|null} The previous sibling element.
+   */
   prevSibling (node) {
     assert(node && node.type === 'VElement')
     let prevElement = null
@@ -93,16 +92,16 @@ module.exports = {
     return null
   },
 
-    /**
-     * Check whether the given start tag has specific directive.
-     * @param {ASTNode} node The start tag node to check.
-     * @param {string} name The attribute name to check.
-     * @param {string} [value] The attribute value to check.
-     * @returns {boolean} `true` if the start tag has the directive.
-     */
+  /**
+   * Check whether the given start tag has specific directive.
+   * @param {ASTNode} node The start tag node to check.
+   * @param {string} name The attribute name to check.
+   * @param {string} [value] The attribute value to check.
+   * @returns {boolean} `true` if the start tag has the directive.
+   */
   hasAttribute (node, name, value) {
-    assert(node && node.type === 'VStartTag')
-    return node.attributes.some(a =>
+    assert(node && node.type === 'VElement')
+    return node.startTag.attributes.some(a =>
             !a.directive &&
             a.key.name === name &&
             (
@@ -112,27 +111,27 @@ module.exports = {
         )
   },
 
-    /**
-     * Check whether the given start tag has specific directive.
-     * @param {ASTNode} node The start tag node to check.
-     * @param {string} name The directive name to check.
-     * @param {string} [argument] The directive argument to check.
-     * @returns {boolean} `true` if the start tag has the directive.
-     */
+  /**
+   * Check whether the given start tag has specific directive.
+   * @param {ASTNode} node The start tag node to check.
+   * @param {string} name The directive name to check.
+   * @param {string} [argument] The directive argument to check.
+   * @returns {boolean} `true` if the start tag has the directive.
+   */
   hasDirective (node, name, argument) {
-    assert(node && node.type === 'VStartTag')
-    return node.attributes.some(a =>
+    assert(node && node.type === 'VElement')
+    return node.startTag.attributes.some(a =>
             a.directive &&
             a.key.name === name &&
             (argument === undefined || a.key.argument === argument)
         )
   },
 
-    /**
-     * Check whether the given attribute has their attribute value.
-     * @param {ASTNode} node The attribute node to check.
-     * @returns {boolean} `true` if the attribute has their value.
-     */
+  /**
+   * Check whether the given attribute has their attribute value.
+   * @param {ASTNode} node The attribute node to check.
+   * @returns {boolean} `true` if the attribute has their value.
+   */
   hasAttributeValue (node) {
     assert(node && node.type === 'VAttribute')
     return (
@@ -141,16 +140,16 @@ module.exports = {
     )
   },
 
-    /**
-     * Get the attribute which has the given name.
-     * @param {ASTNode} node The start tag node to check.
-     * @param {string} name The attribute name to check.
-     * @param {string} [value] The attribute value to check.
-     * @returns {ASTNode} The found attribute.
-     */
+  /**
+   * Get the attribute which has the given name.
+   * @param {ASTNode} node The start tag node to check.
+   * @param {string} name The attribute name to check.
+   * @param {string} [value] The attribute value to check.
+   * @returns {ASTNode} The found attribute.
+   */
   getAttribute (node, name, value) {
-    assert(node && node.type === 'VStartTag')
-    return node.attributes.find(a =>
+    assert(node && node.type === 'VElement')
+    return node.startTag.attributes.find(a =>
             !a.directive &&
             a.key.name === name &&
             (
@@ -160,16 +159,16 @@ module.exports = {
         )
   },
 
-    /**
-     * Get the directive which has the given name.
-     * @param {ASTNode} node The start tag node to check.
-     * @param {string} name The directive name to check.
-     * @param {string} [argument] The directive argument to check.
-     * @returns {ASTNode} The found directive.
-     */
+  /**
+   * Get the directive which has the given name.
+   * @param {ASTNode} node The start tag node to check.
+   * @param {string} name The directive name to check.
+   * @param {string} [argument] The directive argument to check.
+   * @returns {ASTNode} The found directive.
+   */
   getDirective (node, name, argument) {
-    assert(node && node.type === 'VStartTag')
-    return node.attributes.find(a =>
+    assert(node && node.type === 'VElement')
+    return node.startTag.attributes.find(a =>
             a.directive &&
             a.key.name === name &&
             (argument === undefined || a.key.argument === argument)
@@ -200,9 +199,9 @@ module.exports = {
      * @returns {boolean} `true` if the node is a custom component.
      */
   isCustomComponent (node) {
-    assert(node && node.type === 'VStartTag')
+    assert(node && node.type === 'VElement')
 
-    const name = node.id.name
+    const name = node.name
     return (
             !(this.isHtmlElementName(name) || this.isSvgElementName(name)) ||
             this.hasAttribute(node, 'is') ||
@@ -210,33 +209,33 @@ module.exports = {
     )
   },
 
-    /**
-     * Check whether the given name is a HTML element name or not.
-     * @param {string} name The name to check.
-     * @returns {boolean} `true` if the name is a HTML element name.
-     */
+  /**
+   * Check whether the given name is a HTML element name or not.
+   * @param {string} name The name to check.
+   * @returns {boolean} `true` if the name is a HTML element name.
+   */
   isHtmlElementName (name) {
     assert(typeof name === 'string')
 
     return HTML_ELEMENT_NAMES.has(name.toLowerCase())
   },
 
-    /**
-     * Check whether the given name is a SVG element name or not.
-     * @param {string} name The name to check.
-     * @returns {boolean} `true` if the name is a SVG element name.
-     */
+  /**
+   * Check whether the given name is a SVG element name or not.
+   * @param {string} name The name to check.
+   * @returns {boolean} `true` if the name is a SVG element name.
+   */
   isSvgElementName (name) {
     assert(typeof name === 'string')
 
     return SVG_ELEMENT_NAMES.has(name.toLowerCase())
   },
 
-    /**
-     * Check whether the given name is a void element name or not.
-     * @param {string} name The name to check.
-     * @returns {boolean} `true` if the name is a void element name.
-     */
+  /**
+   * Check whether the given name is a void element name or not.
+   * @param {string} name The name to check.
+   * @returns {boolean} `true` if the name is a void element name.
+   */
   isVoidElementName (name) {
     assert(typeof name === 'string')
 
@@ -309,14 +308,14 @@ module.exports = {
       })
   },
 
-    /**
-     * Check whether the given node is a Vue component based
-     * on the filename and default export type
-     * export default {} in .vue || .jsx
-     * @param {ASTNode} node Node to check
-     * @param {string} path File name with extension
-     * @returns {boolean}
-     */
+  /**
+   * Check whether the given node is a Vue component based
+   * on the filename and default export type
+   * export default {} in .vue || .jsx
+   * @param {ASTNode} node Node to check
+   * @param {string} path File name with extension
+   * @returns {boolean}
+   */
   isVueComponentFile (node, path) {
     const isVueFile = path.endsWith('.vue') || path.endsWith('.jsx')
     return isVueFile &&
@@ -324,12 +323,12 @@ module.exports = {
       node.declaration.type === 'ObjectExpression'
   },
 
-    /**
-     * Check whether given node is Vue component
-     * Vue.component('xxx', {}) || component('xxx', {})
-     * @param {ASTNode} node Node to check
-     * @returns {boolean}
-     */
+  /**
+   * Check whether given node is Vue component
+   * Vue.component('xxx', {}) || component('xxx', {})
+   * @param {ASTNode} node Node to check
+   * @returns {boolean}
+   */
   isVueComponent (node) {
     const callee = node.callee
 
@@ -348,12 +347,12 @@ module.exports = {
     return isFullVueComponent || isDestructedVueComponent
   },
 
-    /**
-     * Check whether given node is new Vue instance
-     * new Vue({})
-     * @param {ASTNode} node Node to check
-     * @returns {boolean}
-     */
+  /**
+   * Check whether given node is new Vue instance
+   * new Vue({})
+   * @param {ASTNode} node Node to check
+   * @returns {boolean}
+   */
   isVueInstance (node) {
     const callee = node.callee
     return node.type === 'NewExpression' &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,27 @@
 {
   "name": "eslint-plugin-vue",
-  "version": "3.5.0",
+  "version": "3.8.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.11.tgz",
-      "integrity": "sha512-7fdgKgV+AbMyQZOajKUMYTb6iKrxRvWshqcxbAGZwO9k8CrO7fecLRGf2wx2yd/6+astrQuhu3JauXoMYq9AzA==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.16.tgz",
+      "integrity": "sha512-goVnbj0oGmXXGYjXviARHjgxj/rEyizBy3q0kYI/kb1yKDVaNrj0/vaFcYzfBQvFEbd3K+1SNru432et3/ys6w==",
       "dev": true
     },
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -30,7 +34,11 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -60,13 +68,19 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -80,10 +94,87 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-eslint": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.25.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.25.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
       "dev": true
     },
     "balanced-match": {
@@ -96,7 +187,11 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -108,7 +203,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -116,23 +214,53 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "chai": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.0.tgz",
+      "integrity": "sha1-MxoDkbVcOvh0CunDt0WLwcOAXm0=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "2.0.2",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.3"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -156,7 +284,10 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -168,6 +299,17 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
+    },
+    "core-js": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
       "dev": true
     },
     "core-util-is": {
@@ -180,12 +322,35 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.24"
+      }
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+      "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+      "dev": true,
+      "requires": {
+        "type-detect": "3.0.0"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
+          "dev": true
+        }
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -197,7 +362,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "diff": {
       "version": "3.2.0",
@@ -209,13 +383,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -235,13 +417,20 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
     },
     "domutils": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
       "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
     },
     "entities": {
       "version": "1.1.1",
@@ -250,40 +439,74 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "version": "0.10.24",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
+      "integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -295,64 +518,121 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.9.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      }
     },
     "eslint-plugin-eslint-plugin": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-0.7.2.tgz",
-      "integrity": "sha1-cT/8Y8aSfoiBZV6BXf6i+74xtJo=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-0.8.0.tgz",
+      "integrity": "sha512-SRDlLt3GSb+pIOqhakorah9u/33fGOE4oHxxIHu7jqP6OdUMeNl6MeafzfUeHYOkQi6ytAglqsHkhKcJd3QzmQ==",
       "dev": true
     },
     "eslint-plugin-html": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-2.0.3.tgz",
       "integrity": "sha1-fImIOrDIX6XSi2ZqFKTpBqqQuJc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "htmlparser2": "3.9.2"
+      }
     },
     "eslint-plugin-vue-libs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue-libs/-/eslint-plugin-vue-libs-1.2.0.tgz",
       "integrity": "sha512-E68eNTMw0BBvsFaVwldd51AgX9UKEGf9BdMPCJAVhNGwnVFZPkWjKnFAwKpzeTyAcm0MUxUQG5TrcS4+23TFEA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint-plugin-html": "2.0.3"
+      }
     },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug="
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "espree": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q="
+      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
       "dev": true
     },
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI="
-        }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
       }
     },
     "estraverse": {
@@ -370,7 +650,11 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -388,19 +672,33 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -418,13 +716,30 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -436,7 +751,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -460,7 +783,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -472,7 +798,15 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.1",
+        "domutils": "1.6.2",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
     },
     "ignore": {
       "version": "3.3.3",
@@ -490,7 +824,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -502,7 +840,22 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "interpret": {
       "version": "1.0.3",
@@ -510,17 +863,35 @@
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
       "dev": true
     },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -532,13 +903,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-property": {
       "version": "1.0.2",
@@ -550,7 +927,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -559,22 +939,29 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
+      "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json3": {
       "version": "3.3.2",
@@ -598,19 +985,26 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -640,7 +1034,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -658,23 +1057,30 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
-    "lodash.sortedindex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortedindex/-/lodash.sortedindex-4.1.0.tgz",
-      "integrity": "sha1-P2QX7iDosiQWqwBb+hY0SgRGtEg="
-    },
-    "lodash.sortedindexby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortedindexby/-/lodash.sortedindexby-4.6.0.tgz",
-      "integrity": "sha1-RvGY+9+80Jxv1MF303zaPMZS2fk="
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -686,25 +1092,52 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -716,7 +1149,10 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -744,15 +1180,49 @@
       "dev": true
     },
     "nyc": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-10.3.2.tgz",
-      "integrity": "sha1-8n9NkfKp2zbCT1dP9cbv/wIz3kY=",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.1.0.tgz",
+      "integrity": "sha1-1rPF4WiSolr2MTi6SEZ2qooi7ac=",
       "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.0",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.0.7",
+        "istanbul-lib-instrument": "1.7.4",
+        "istanbul-lib-report": "1.1.1",
+        "istanbul-lib-source-maps": "1.2.1",
+        "istanbul-reports": "1.1.1",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.4",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.1",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.3.8",
+        "test-exclude": "4.1.1",
+        "yargs": "8.0.2",
+        "yargs-parser": "5.0.0"
+      },
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
         },
         "amdefine": {
           "version": "1.0.1",
@@ -772,7 +1242,10 @@
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
         },
         "archy": {
           "version": "1.0.0",
@@ -782,10 +1255,13 @@
         "arr-diff": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
         },
         "arr-flatten": {
-          "version": "1.0.3",
+          "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
@@ -807,57 +1283,112 @@
         "babel-code-frame": {
           "version": "6.22.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
         },
         "babel-generator": {
-          "version": "6.24.1",
+          "version": "6.25.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.25.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
+          }
         },
         "babel-messages": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
         },
         "babel-runtime": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
+          }
         },
         "babel-template": {
-          "version": "6.24.1",
+          "version": "6.25.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.25.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
+            "lodash": "4.17.4"
+          }
         },
         "babel-traverse": {
-          "version": "6.24.1",
+          "version": "6.25.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.22.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
+            "debug": "2.6.8",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
         },
         "babel-types": {
-          "version": "6.24.1",
+          "version": "6.25.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
         },
         "babylon": {
-          "version": "6.17.0",
+          "version": "6.17.4",
           "bundled": true,
           "dev": true
         },
         "balanced-match": {
-          "version": "0.4.2",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.7",
+          "version": "1.1.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
         },
         "braces": {
           "version": "1.8.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -867,7 +1398,12 @@
         "caching-transform": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
         },
         "camelcase": {
           "version": "1.2.1",
@@ -879,18 +1415,34 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
         },
         "chalk": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
@@ -928,12 +1480,19 @@
         "cross-spawn": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.2.14"
+          }
         },
         "debug": {
-          "version": "2.6.6",
+          "version": "2.6.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "debug-log": {
           "version": "1.0.1",
@@ -948,17 +1507,26 @@
         "default-require-extensions": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
         },
         "detect-indent": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
         },
         "error-ex": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -970,20 +1538,43 @@
           "bundled": true,
           "dev": true
         },
+        "execa": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "get-stream": "2.3.1",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
         "expand-brackets": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
         },
         "expand-range": {
           "version": "1.8.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
         },
         "extglob": {
           "version": "0.3.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
         },
         "filename-regex": {
           "version": "2.0.1",
@@ -993,17 +1584,32 @@
         "fill-range": {
           "version": "2.2.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
         },
         "find-cache-dir": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
         },
         "find-up": {
-          "version": "1.1.2",
+          "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
         },
         "for-in": {
           "version": "1.0.2",
@@ -1013,12 +1619,19 @@
         "for-own": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
         },
         "foreground-child": {
           "version": "1.5.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1030,23 +1643,47 @@
           "bundled": true,
           "dev": true
         },
-        "glob": {
-          "version": "7.1.1",
+        "get-stream": {
+          "version": "2.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "glob-base": {
           "version": "0.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
         },
         "glob-parent": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
         },
         "globals": {
-          "version": "9.17.0",
+          "version": "9.18.0",
           "bundled": true,
           "dev": true
         },
@@ -1056,21 +1693,33 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.8",
+          "version": "4.0.10",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
@@ -1078,7 +1727,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.4.2",
+          "version": "2.5.0",
           "bundled": true,
           "dev": true
         },
@@ -1090,7 +1739,11 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1100,7 +1753,10 @@
         "invariant": {
           "version": "2.2.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
         },
         "invert-kv": {
           "version": "1.0.0",
@@ -1120,17 +1776,23 @@
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
         },
         "is-dotfile": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
         },
         "is-extendable": {
           "version": "0.1.1",
@@ -1145,22 +1807,34 @@
         "is-finite": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-glob": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
         },
         "is-number": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -1169,6 +1843,11 @@
         },
         "is-primitive": {
           "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
@@ -1190,47 +1869,81 @@
         "isobject": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
         },
         "istanbul-lib-coverage": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.7.1",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-report": {
-          "version": "1.1.0",
+          "version": "1.0.7",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.25.0",
+            "babel-template": "6.25.0",
+            "babel-traverse": "6.25.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.3.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
             }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "1.2.0",
+          "version": "1.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debug": "2.6.8",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "source-map": "0.5.6"
+          }
         },
         "istanbul-reports": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.10"
+          }
         },
         "js-tokens": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true
         },
@@ -1240,9 +1953,12 @@
           "dev": true
         },
         "kind-of": {
-          "version": "3.2.0",
+          "version": "3.2.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         },
         "lazy-cache": {
           "version": "1.0.4",
@@ -1253,12 +1969,38 @@
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
         },
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
         },
         "lodash": {
           "version": "4.17.4",
@@ -1273,37 +2015,81 @@
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
         },
         "lru-cache": {
-          "version": "4.0.2",
+          "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         },
         "md5-hex": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
         },
         "md5-o-matic": {
           "version": "0.1.1",
           "bundled": true,
           "dev": true
         },
-        "merge-source-map": {
-          "version": "1.0.3",
+        "mem": {
+          "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
         },
         "micromatch": {
           "version": "2.3.11",
           "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -1313,22 +2099,42 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
-          "version": "0.7.3",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
-          "version": "2.3.8",
+          "version": "2.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          }
         },
         "normalize-path": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.0.2"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -1343,17 +2149,28 @@
         "object.omit": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -1361,27 +2178,67 @@
           "dev": true
         },
         "os-locale": {
-          "version": "1.4.0",
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "0.5.1",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
         },
         "parse-glob": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
         },
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -1393,7 +2250,12 @@
         "path-type": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "pify": {
           "version": "2.3.0",
@@ -1408,12 +2270,29 @@
         "pinkie-promise": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
         },
         "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
         },
         "preserve": {
           "version": "0.2.0",
@@ -1426,19 +2305,71 @@
           "dev": true
         },
         "randomatic": {
-          "version": "1.1.6",
+          "version": "1.1.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
+            }
+          }
         },
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
         },
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
         },
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -1448,10 +2379,14 @@
         "regex-cache": {
           "version": "0.4.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
+          }
         },
         "remove-trailing-separator": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
@@ -1468,7 +2403,10 @@
         "repeating": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
         },
         "require-directory": {
           "version": "2.1.1",
@@ -1489,12 +2427,18 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "semver": {
           "version": "5.3.0",
@@ -1522,21 +2466,25 @@
           "dev": true
         },
         "spawn-wrap": {
-          "version": "1.2.4",
+          "version": "1.3.8",
           "bundled": true,
           "dev": true,
-          "dependencies": {
-            "signal-exit": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            }
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.1",
+            "signal-exit": "3.0.2",
+            "which": "1.2.14"
           }
         },
         "spdx-correct": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
@@ -1549,17 +2497,52 @@
           "dev": true
         },
         "string-width": {
-          "version": "1.0.2",
+          "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-bom": {
           "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -1569,9 +2552,16 @@
           "dev": true
         },
         "test-exclude": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -1584,16 +2574,27 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.22",
+          "version": "2.8.29",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
@@ -1606,15 +2607,22 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
         },
         "which": {
           "version": "1.2.14",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
         },
         "which-module": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -1632,7 +2640,23 @@
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -1642,7 +2666,12 @@
         "write-file-atomic": {
           "version": "1.3.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
         },
         "y18n": {
           "version": "3.2.1",
@@ -1655,19 +2684,102 @@
           "dev": true
         },
         "yargs": {
-          "version": "7.1.0",
+          "version": "8.0.2",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.0.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.0",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          },
           "dependencies": {
             "camelcase": {
-              "version": "3.0.0",
+              "version": "4.1.0",
               "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
               "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+              }
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pify": "2.3.0"
+              }
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true
+            },
+            "yargs-parser": {
+              "version": "7.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
             }
           }
         },
@@ -1675,6 +2787,9 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -1694,7 +2809,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -1706,25 +2824,21 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "parse5": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
-      "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
-      "dependencies": {
-        "@types/node": {
-          "version": "6.0.78",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.78.tgz",
-          "integrity": "sha512-+vD6E8ixntRzzZukoF3uP1iV+ZjVN3koTcaeK+BEoc/kSfGbLDIGC7RmCaUgVpUfN6cWvfczFRERCyKM9mkvXg=="
-        }
-      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1744,6 +2858,12 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1760,7 +2880,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -1787,28 +2910,55 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-      "dev": true
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "requireindex": {
       "version": "1.1.0",
@@ -1816,10 +2966,13 @@
       "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI="
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -1831,19 +2984,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -1852,16 +3015,21 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -1876,22 +3044,33 @@
       "dev": true
     },
     "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -1916,7 +3095,21 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1924,10 +3117,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -1943,6 +3149,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -1953,6 +3165,15 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
     "typedarray": {
@@ -1965,7 +3186,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1974,9 +3198,15 @@
       "dev": true
     },
     "vue-eslint-parser": {
-      "version": "1.1.0-7",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-1.1.0-7.tgz",
-      "integrity": "sha512-dY0AR5BxSjN8TT4bStUuGb55yjSyAvN1ifUrzfuD7kMdmd5g7e/LYIXCqcvB3GuI5wWOs3fa3o31fqQHfQOHew=="
+      "version": "1.1.0-8",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-1.1.0-8.tgz",
+      "integrity": "sha512-K6dNK/vfzVAFjPV/2RCjIcGBPNkw3ffxf7Aa3a6rz6xNwD2pih8OkIuH9l2RN6CsyIQJtMRarTfBkvHOlEGxdA==",
+      "requires": {
+        "debug": "2.6.8",
+        "eslint-scope": "3.7.1",
+        "espree": "3.4.3",
+        "lodash": "4.17.4"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -1994,7 +3224,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3198,9 +3198,9 @@
       "dev": true
     },
     "vue-eslint-parser": {
-      "version": "1.1.0-8",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-1.1.0-8.tgz",
-      "integrity": "sha512-K6dNK/vfzVAFjPV/2RCjIcGBPNkw3ffxf7Aa3a6rz6xNwD2pih8OkIuH9l2RN6CsyIQJtMRarTfBkvHOlEGxdA==",
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.0-beta.0.tgz",
+      "integrity": "sha512-GfJgr4S0kEBsT2k24yqBaYIq1cKHXwiajrEzF+6gpr56pRFY/5FibDwCTEo4QmNqugtG5XSKwlwwygDMMH8g5g==",
       "requires": {
         "debug": "2.6.8",
         "eslint-scope": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "npm run test:simple -- --watch --growl",
     "test:base": "mocha \"tests/lib/**/*.js\"",
-    "test:simple": "npm run test:base -- --reporter nyan",
+    "test:simple": "npm run test:base -- --reporter dot",
     "test": "nyc npm run test:base -- \"tests/integrations/*.js\" --timeout 60000",
     "lint": "eslint .",
     "pretest": "npm run lint",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "requireindex": "^1.1.0",
-    "vue-eslint-parser": "^1.1.0-8"
+    "vue-eslint-parser": "2.0.0-beta.0"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "requireindex": "^1.1.0",
-    "vue-eslint-parser": "2.0.0-beta.0"
+    "vue-eslint-parser": "^2.0.0-beta.2"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",

--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
   },
   "dependencies": {
     "requireindex": "^1.1.0",
-    "vue-eslint-parser": "^1.1.0-7"
+    "vue-eslint-parser": "^1.1.0-8"
   },
   "devDependencies": {
-    "@types/node": "^4.2.6",
+    "@types/node": "^4.2.16",
     "babel-eslint": "^7.2.3",
     "chai": "^4.1.0",
-    "eslint": "^3.18.0",
-    "eslint-plugin-eslint-plugin": "^0.7.1",
+    "eslint": "^3.19.0",
+    "eslint-plugin-eslint-plugin": "^0.8.0",
     "eslint-plugin-vue-libs": "^1.2.0",
     "mocha": "^3.2.0",
-    "nyc": "^10.2.0"
+    "nyc": "^11.1.0"
   }
 }

--- a/tests/lib/rules/no-invalid-template-root.js
+++ b/tests/lib/rules/no-invalid-template-root.js
@@ -62,6 +62,14 @@ tester.run('no-invalid-template-root', rule, {
     {
       filename: 'test.vue',
       code: '<template src="foo.html"></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><textarea/>test</div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><table><custom-thead></custom-thead></table></template>'
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-parsing-error.js
+++ b/tests/lib/rules/no-parsing-error.js
@@ -50,6 +50,195 @@ tester.run('no-parsing-error', rule, {
     {
       filename: 'test.vue',
       code: '<a @click="foo(); bar()">link</a>'
+    },
+    {
+      filename: 'test.vue',
+      code: `<template v-for="x of list"><slot name="item" /></template>`
+    },
+    {
+      code: `<template><!--></template>`,
+      options: [{ 'abrupt-closing-of-empty-comment': false }],
+      errors: ['Parsing error: abrupt-closing-of-empty-comment.']
+    },
+    {
+      code: `<template><!---></template>`,
+      options: [{ 'abrupt-closing-of-empty-comment': false }],
+      errors: ['Parsing error: abrupt-closing-of-empty-comment.']
+    },
+    {
+      code: `<template>&#qux;</template>`,
+      options: [{ 'absence-of-digits-in-numeric-character-reference': false }],
+      errors: ['Parsing error: absence-of-digits-in-numeric-character-reference.']
+    },
+    {
+      code: '<template><![CDATA[cdata]]></template>',
+      options: [{ 'cdata-in-html-content': false }],
+      errors: ['Parsing error: cdata-in-html-content.']
+    },
+    {
+      code: '<template>&#1234567;</template>',
+      options: [{ 'character-reference-outside-unicode-range': false }],
+      errors: ['Parsing error: character-reference-outside-unicode-range.']
+    },
+    {
+      code: '<template>\u0003</template>',
+      options: [{ 'control-character-in-input-stream': false }],
+      errors: ['Parsing error: control-character-in-input-stream.']
+    },
+    {
+      code: '<template>&#0003;</template>',
+      options: [{ 'control-character-reference': false }],
+      errors: ['Parsing error: control-character-reference.']
+    },
+    {
+      code: '<template><',
+      options: [{ 'eof-before-tag-name': false }],
+      errors: ['Parsing error: eof-before-tag-name.']
+    },
+    {
+      code: '<template><svg><![CDATA[cdata',
+      options: [{ 'eof-in-cdata': false }],
+      errors: ['Parsing error: eof-in-cdata.']
+    },
+    {
+      code: '<template><!--comment',
+      options: [{ 'eof-in-comment': false }],
+      errors: ['Parsing error: eof-in-comment.']
+    },
+    {
+      code: '<template><div class=""',
+      options: [{ 'eof-in-tag': false }],
+      errors: ['Parsing error: eof-in-tag.']
+    },
+    {
+      code: '<template><!--comment--!></template>',
+      options: [{ 'incorrectly-closed-comment': false }],
+      errors: ['Parsing error: incorrectly-closed-comment.']
+    },
+    {
+      code: '<template><!ELEMENT br EMPTY></template>',
+      options: [{ 'incorrectly-opened-comment': false }],
+      errors: ['Parsing error: incorrectly-opened-comment.']
+    },
+    {
+      code: '<template><👍>/template>',
+      options: [{ 'invalid-first-character-of-tag-name': false }],
+      errors: ['Parsing error: invalid-first-character-of-tag-name.']
+    },
+    {
+      code: '<template><div id=></template>',
+      options: [{ 'missing-attribute-value': false }],
+      errors: ['Parsing error: missing-attribute-value.']
+    },
+    {
+      code: '<template></></template>',
+      options: [{ 'missing-end-tag-name': false }],
+      errors: ['Parsing error: missing-end-tag-name.']
+    },
+    {
+      code: '<template>&amp</template>',
+      options: [{ 'missing-semicolon-after-character-reference': false }],
+      errors: ['Parsing error: missing-semicolon-after-character-reference.']
+    },
+    {
+      code: '<template><div id="foo"class="bar"></template>',
+      options: [{ 'missing-whitespace-between-attributes': false }],
+      errors: ['Parsing error: missing-whitespace-between-attributes.']
+    },
+    {
+      code: '<template><!--a<!--b--></template>',
+      options: [{ 'nested-comment': false }],
+      errors: ['Parsing error: nested-comment.']
+    },
+    {
+      code: '<template>&#xFFFE;</template>',
+      options: [{ 'noncharacter-character-reference': false }],
+      errors: ['Parsing error: noncharacter-character-reference.']
+    },
+    {
+      code: '<template>\uFFFE</template>',
+      options: [{ 'noncharacter-in-input-stream': false }],
+      errors: ['Parsing error: noncharacter-in-input-stream.']
+    },
+    {
+      code: '<template>&#0000;</template>',
+      options: [{ 'null-character-reference': false }],
+      errors: ['Parsing error: null-character-reference.']
+    },
+    {
+      code: '<template>&#xD800;</template>',
+      options: [{ 'surrogate-character-reference': false }],
+      errors: ['Parsing error: surrogate-character-reference.']
+    },
+    {
+      code: '<template>\uD800</template>',
+      options: [{ 'surrogate-in-input-stream': false }],
+      errors: ['Parsing error: surrogate-in-input-stream.']
+    },
+    {
+      code: '<template><div a"bc=""></template>',
+      options: [{ 'unexpected-character-in-attribute-name': false }],
+      errors: ['Parsing error: unexpected-character-in-attribute-name.']
+    },
+    {
+      code: '<template><div foo=bar"></template>',
+      options: [{ 'unexpected-character-in-unquoted-attribute-value': false }],
+      errors: ['Parsing error: unexpected-character-in-unquoted-attribute-value.']
+    },
+    {
+      code: '<template><div =foo></template>',
+      options: [{ 'unexpected-equals-sign-before-attribute-name': false }],
+      errors: ['Parsing error: unexpected-equals-sign-before-attribute-name.']
+    },
+    {
+      code: '<template>\u0000</template>',
+      options: [{ 'unexpected-null-character': false }],
+      errors: ['Parsing error: unexpected-null-character.']
+    },
+    {
+      code: '<template><?xml?></template>',
+      options: [{ 'unexpected-question-mark-instead-of-tag-name': false }],
+      errors: ['Parsing error: unexpected-question-mark-instead-of-tag-name.']
+    },
+    {
+      code: '<template><div id="" / class=""></template>',
+      options: [{ 'unexpected-solidus-in-tag': false }],
+      errors: ['Parsing error: unexpected-solidus-in-tag.']
+    },
+    {
+      code: '<template>&unknown;</template>',
+      options: [{ 'unknown-named-character-reference': false }],
+      errors: ['Parsing error: unknown-named-character-reference.']
+    },
+    {
+      code: '<template><div></div id=""></template>',
+      options: [{ 'end-tag-with-attributes': false }],
+      errors: ['Parsing error: end-tag-with-attributes.']
+    },
+    {
+      code: '<template><div id="" id=""></div></template>',
+      options: [{ 'duplicate-attribute': false }],
+      errors: ['Parsing error: duplicate-attribute.']
+    },
+    {
+      code: '<template><div></div/></template>',
+      options: [{ 'end-tag-with-trailing-solidus': false }],
+      errors: ['Parsing error: end-tag-with-trailing-solidus.']
+    },
+    {
+      code: '<template><div/></template>',
+      options: [{ 'non-void-html-element-start-tag-with-trailing-solidus': false }],
+      errors: ['Parsing error: non-void-html-element-start-tag-with-trailing-solidus.']
+    },
+    {
+      code: '<template></div></template>',
+      options: [{ 'x-invalid-end-tag': false }],
+      errors: ['Parsing error: x-invalid-end-tag.']
+    },
+    {
+      code: '<template><div xmlns=""></template>',
+      options: [{ 'x-invalid-namespace': false }],
+      errors: ['Parsing error: x-invalid-namespace.']
     }
   ],
   invalid: [
@@ -100,6 +289,191 @@ tester.run('no-parsing-error', rule, {
       errors: [
         { message: 'Parsing error: Unexpected token (.', column: 26 }
       ]
+    },
+    {
+      code: `<template><!--></template>`,
+      options: [{ 'abrupt-closing-of-empty-comment': true }],
+      errors: ['Parsing error: abrupt-closing-of-empty-comment.']
+    },
+    {
+      code: `<template><!---></template>`,
+      options: [{ 'abrupt-closing-of-empty-comment': true }],
+      errors: ['Parsing error: abrupt-closing-of-empty-comment.']
+    },
+    {
+      code: `<template>&#qux;</template>`,
+      options: [{ 'absence-of-digits-in-numeric-character-reference': true }],
+      errors: ['Parsing error: absence-of-digits-in-numeric-character-reference.']
+    },
+    {
+      code: '<template><![CDATA[cdata]]></template>',
+      options: [{ 'cdata-in-html-content': true }],
+      errors: ['Parsing error: cdata-in-html-content.']
+    },
+    {
+      code: '<template>&#1234567;</template>',
+      options: [{ 'character-reference-outside-unicode-range': true }],
+      errors: ['Parsing error: character-reference-outside-unicode-range.']
+    },
+    {
+      code: '<template>\u0003</template>',
+      options: [{ 'control-character-in-input-stream': true }],
+      errors: ['Parsing error: control-character-in-input-stream.']
+    },
+    {
+      code: '<template>&#0003;</template>',
+      options: [{ 'control-character-reference': true }],
+      errors: ['Parsing error: control-character-reference.']
+    },
+    {
+      code: '<template><',
+      options: [{ 'eof-before-tag-name': true }],
+      errors: ['Parsing error: eof-before-tag-name.']
+    },
+    {
+      code: '<template><svg><![CDATA[cdata',
+      options: [{ 'eof-in-cdata': true }],
+      errors: ['Parsing error: eof-in-cdata.']
+    },
+    {
+      code: '<template><!--comment',
+      options: [{ 'eof-in-comment': true }],
+      errors: ['Parsing error: eof-in-comment.']
+    },
+    {
+      code: '<template><div class=""',
+      options: [{ 'eof-in-tag': true }],
+      errors: ['Parsing error: eof-in-tag.']
+    },
+    {
+      code: '<template><!--comment--!></template>',
+      options: [{ 'incorrectly-closed-comment': true }],
+      errors: ['Parsing error: incorrectly-closed-comment.']
+    },
+    {
+      code: '<template><!ELEMENT br EMPTY></template>',
+      options: [{ 'incorrectly-opened-comment': true }],
+      errors: ['Parsing error: incorrectly-opened-comment.']
+    },
+    {
+      code: '<template><👍>/template>',
+      options: [{ 'invalid-first-character-of-tag-name': true }],
+      errors: ['Parsing error: invalid-first-character-of-tag-name.']
+    },
+    {
+      code: '<template><div id=></template>',
+      options: [{ 'missing-attribute-value': true }],
+      errors: ['Parsing error: missing-attribute-value.']
+    },
+    {
+      code: '<template></></template>',
+      options: [{ 'missing-end-tag-name': true }],
+      errors: ['Parsing error: missing-end-tag-name.']
+    },
+    {
+      code: '<template>&amp</template>',
+      options: [{ 'missing-semicolon-after-character-reference': true }],
+      errors: ['Parsing error: missing-semicolon-after-character-reference.']
+    },
+    {
+      code: '<template><div id="foo"class="bar"></template>',
+      options: [{ 'missing-whitespace-between-attributes': true }],
+      errors: ['Parsing error: missing-whitespace-between-attributes.']
+    },
+    {
+      code: '<template><!--a<!--b--></template>',
+      options: [{ 'nested-comment': true }],
+      errors: ['Parsing error: nested-comment.']
+    },
+    {
+      code: '<template>&#xFFFE;</template>',
+      options: [{ 'noncharacter-character-reference': true }],
+      errors: ['Parsing error: noncharacter-character-reference.']
+    },
+    {
+      code: '<template>\uFFFE</template>',
+      options: [{ 'noncharacter-in-input-stream': true }],
+      errors: ['Parsing error: noncharacter-in-input-stream.']
+    },
+    {
+      code: '<template>&#0000;</template>',
+      options: [{ 'null-character-reference': true }],
+      errors: ['Parsing error: null-character-reference.']
+    },
+    {
+      code: '<template>&#xD800;</template>',
+      options: [{ 'surrogate-character-reference': true }],
+      errors: ['Parsing error: surrogate-character-reference.']
+    },
+    {
+      code: '<template>\uD800</template>',
+      options: [{ 'surrogate-in-input-stream': true }],
+      errors: ['Parsing error: surrogate-in-input-stream.']
+    },
+    {
+      code: '<template><div a"bc=""></template>',
+      options: [{ 'unexpected-character-in-attribute-name': true }],
+      errors: ['Parsing error: unexpected-character-in-attribute-name.']
+    },
+    {
+      code: '<template><div foo=bar"></template>',
+      options: [{ 'unexpected-character-in-unquoted-attribute-value': true }],
+      errors: ['Parsing error: unexpected-character-in-unquoted-attribute-value.']
+    },
+    {
+      code: '<template><div =foo></template>',
+      options: [{ 'unexpected-equals-sign-before-attribute-name': true }],
+      errors: ['Parsing error: unexpected-equals-sign-before-attribute-name.']
+    },
+    {
+      code: '<template>\u0000</template>',
+      options: [{ 'unexpected-null-character': true }],
+      errors: ['Parsing error: unexpected-null-character.']
+    },
+    {
+      code: '<template><?xml?></template>',
+      options: [{ 'unexpected-question-mark-instead-of-tag-name': true }],
+      errors: ['Parsing error: unexpected-question-mark-instead-of-tag-name.']
+    },
+    {
+      code: '<template><div id="" / class=""></template>',
+      options: [{ 'unexpected-solidus-in-tag': true }],
+      errors: ['Parsing error: unexpected-solidus-in-tag.']
+    },
+    {
+      code: '<template>&unknown;</template>',
+      options: [{ 'unknown-named-character-reference': true }],
+      errors: ['Parsing error: unknown-named-character-reference.']
+    },
+    {
+      code: '<template><div></div id=""></template>',
+      options: [{ 'end-tag-with-attributes': true }],
+      errors: ['Parsing error: end-tag-with-attributes.']
+    },
+    {
+      code: '<template><div id="" id=""></div></template>',
+      options: [{ 'duplicate-attribute': true }],
+      errors: ['Parsing error: duplicate-attribute.']
+    },
+    {
+      code: '<template><div></div/></template>',
+      options: [{ 'end-tag-with-trailing-solidus': true }],
+      errors: ['Parsing error: end-tag-with-trailing-solidus.']
+    },
+    {
+      code: '<template><div/></template>',
+      options: [{ 'non-void-html-element-start-tag-with-trailing-solidus': true }],
+      errors: ['Parsing error: non-void-html-element-start-tag-with-trailing-solidus.']
+    },
+    {
+      code: '<template></div></template>',
+      options: [{ 'x-invalid-end-tag': true }],
+      errors: ['Parsing error: x-invalid-end-tag.']
+    },
+    {
+      code: '<template><div xmlns=""></template>',
+      options: [{ 'x-invalid-namespace': true }],
+      errors: ['Parsing error: x-invalid-namespace.']
     }
   ]
 })

--- a/tests/lib/rules/no-parsing-error.js
+++ b/tests/lib/rules/no-parsing-error.js
@@ -46,6 +46,10 @@ tester.run('no-parsing-error', rule, {
     {
       filename: 'test.vue',
       code: '<table><tr><td></td></tr></table>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<a @click="foo(); bar()">link</a>'
     }
   ],
   invalid: [
@@ -72,27 +76,30 @@ tester.run('no-parsing-error', rule, {
     {
       filename: 'test.vue',
       code: '<template><div>{{ }}</div></template>',
-      errors: ['Parsing error: Expected an expression but got no code.']
+      errors: [
+        { message: 'Parsing error: Expected to be an expression, but got empty.', column: 18 }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div v-show="">hello</div></template>',
-      errors: ['Parsing error: Expected an expression but got no code.']
-    },
-    {
-      filename: 'test.vue',
-      code: '<template><div v-show=>hello</div></template>',
-      errors: ['Parsing error: Expected an expression but got no code.']
+      errors: [
+        { message: 'Parsing error: Expected to be an expression, but got empty.', column: 24 }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div v-for="foo">hello</div></template>',
-      errors: ['Parsing error: Unexpected token ).']
+      errors: [
+        { message: 'Parsing error: Unexpected end of expression.', column: 26 }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div v-for="foo() in list">hello</div></template>',
-      errors: ['Parsing error: Assigning to rvalue.']
+      errors: [
+        { message: 'Parsing error: Unexpected token (.', column: 26 }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Thank you for waiting!
I have almost done to rewrite `vue-eslint-parser`. :sparkles: 

- This PR should fix three bugs: fixes #36, fixes #56, fixes #96.
- This PR enhances `no-parsing-errors` rule. It allows us to catch syntax errors of HTML. Those are opt-in for now since enhancement which increases errors is a breaking change.
- There are some changes to internal API.
    - I changed AST of `<template>` a bit. Notable changes are below:
        - We can get element names with `element.name` property now. It was `element.startTag.id.name` before. 
        - We can get the namespace of elements with `element.namespace`. The value of namespaces are defined in [there](https://infra.spec.whatwg.org/#namespaces).
        - `VOnExpression` node is added in order to handle #96 correctly.
    - The spec of AST is [vue-eslint-parser/docs/ast.md](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md).
    - The type definition of AST is [vue-eslint-parser/src/ast/nodes.ts](https://github.com/mysticatea/vue-eslint-parser/blob/master/src/ast/nodes.ts).

This PR has breaking changes in internal APIs, but the rule behaviors are keeping as is, so I think fine as semver-minor.

> Though I have many tests ([12499 passing](https://travis-ci.org/mysticatea/vue-eslint-parser/jobs/259038583#L1387) :smile:) to parse HTML, I guess some bugs remain.