### PR TITLE
Add namespace check of svg & mathML instead of tag names

### DIFF
--- a/lib/rules/html-no-self-closing.js
+++ b/lib/rules/html-no-self-closing.js
@@ -24,7 +24,7 @@ const utils = require('../utils')
 function create (context) {
   utils.registerTemplateBodyVisitor(context, {
     'VElement' (node) {
-      if (utils.isSvgElementName(node.name)) {
+      if (utils.isSvgElementNode(node)) {
         return
       }
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -183,7 +183,7 @@ module.exports = {
     assert(node && node.type === 'VElement')
 
     return (
-      !(this.isHtmlElementNode(node) || this.isSvgElementNode(node) || this.isMathMLElementNode(node)) ||
+      !(this.isKnownHtmlElementNode(node) || this.isSvgElementNode(node) || this.isMathMLElementNode(node)) ||
       this.hasAttribute(node, 'is') ||
       this.hasDirective(node, 'bind', 'is')
     )
@@ -194,10 +194,10 @@ module.exports = {
    * @param {ASTNode} node The node to check.
    * @returns {boolean} `true` if the node is a HTML element.
    */
-  isHtmlElementNode (node) {
+  isKnownHtmlElementNode (node) {
     assert(node && node.type === 'VElement')
 
-    return HTML_ELEMENT_NAMES.has(node.name.toLowerCase())
+    return node.namespace === vueEslintParser.AST.NS.HTML && HTML_ELEMENT_NAMES.has(node.name.toLowerCase())
   },
 
   /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -10,9 +10,9 @@
 // ------------------------------------------------------------------------------
 
 const HTML_ELEMENT_NAMES = new Set(require('./html-elements.json'))
-const SVG_ELEMENT_NAMES = new Set(require('./svg-elements.json'))
 const VOID_ELEMENT_NAMES = new Set(require('./void-elements.json'))
 const assert = require('assert')
+const vueEslintParser = require('vue-eslint-parser')
 
 // ------------------------------------------------------------------------------
 // Exports
@@ -36,24 +36,6 @@ module.exports = {
       return
     }
     context.parserServices.registerTemplateBodyVisitor(context, visitor)
-  },
-
-  /**
-   * Get the token store of template body from parser services.
-   * If the parser service of `vue-eslint-parser` was not found,
-   * this generates a warning.
-   *
-   * @returns {void}
-   */
-  getTemplateBodyTokenStore () {
-    if (context.parserServices.getTemplateBodyTokenStore == null) {
-      context.report({
-        loc: { line: 1, column: 0 },
-        message: 'Use the latest vue-eslint-parser. See also https://github.com/vuejs/eslint-plugin-vue#what-is-the-use-the-latest-vue-eslint-parser-error'
-      })
-      return context.getSourceCode()
-    }
-    return context.parserServices.getTemplateBodyTokenStore()
   },
 
   /**
@@ -200,34 +182,44 @@ module.exports = {
   isCustomComponent (node) {
     assert(node && node.type === 'VElement')
 
-    const name = node.name
     return (
-            !(this.isHtmlElementName(name) || this.isSvgElementName(name)) ||
-            this.hasAttribute(node, 'is') ||
-            this.hasDirective(node, 'bind', 'is')
+      !(this.isHtmlElementNode(node) || this.isSvgElementNode(node) || this.isMathMLElementNode(node)) ||
+      this.hasAttribute(node, 'is') ||
+      this.hasDirective(node, 'bind', 'is')
     )
   },
 
   /**
-   * Check whether the given name is a HTML element name or not.
-   * @param {string} name The name to check.
-   * @returns {boolean} `true` if the name is a HTML element name.
+   * Check whether the given node is a HTML element or not.
+   * @param {ASTNode} node The node to check.
+   * @returns {boolean} `true` if the node is a HTML element.
    */
-  isHtmlElementName (name) {
-    assert(typeof name === 'string')
+  isHtmlElementNode (node) {
+    assert(node && node.type === 'VElement')
 
-    return HTML_ELEMENT_NAMES.has(name.toLowerCase())
+    return HTML_ELEMENT_NAMES.has(node.name.toLowerCase())
   },
 
   /**
-   * Check whether the given name is a SVG element name or not.
-   * @param {string} name The name to check.
-   * @returns {boolean} `true` if the name is a SVG element name.
+   * Check whether the given node is a SVG element or not.
+   * @param {ASTNode} node The node to check.
+   * @returns {boolean} `true` if the name is a SVG element.
    */
-  isSvgElementName (name) {
-    assert(typeof name === 'string')
+  isSvgElementNode (node) {
+    assert(node && node.type === 'VElement')
 
-    return SVG_ELEMENT_NAMES.has(name.toLowerCase())
+    return node.namespace === vueEslintParser.AST.NS.SVG
+  },
+
+  /**
+   * Check whether the given name is a MathML element or not.
+   * @param {ASTNode} name The node to check.
+   * @returns {boolean} `true` if the node is a MathML element.
+   */
+  isMathMLElementNode (node) {
+    assert(node && node.type === 'VElement')
+
+    return node.namespace === vueEslintParser.AST.NS.MathML
   },
 
   /**

--- a/lib/utils/svg-elements.json
+++ b/lib/utils/svg-elements.json
@@ -1,1 +1,0 @@
-["svg","animate","circle","clippath","cursor","defs","desc","ellipse","filter","font-face","foreignObject","g","glyph","image","line","marker","mask","missing-glyph","path","pattern","polygon","polyline","rect","switch","symbol","text","textpath","tspan","use","view"]


### PR DESCRIPTION
**Old:**
- `isHtmlElementName(string)`
- `isSvgElementName(string)`

**New:**
- `isKnownHtmlElementNode(ASTNode)`
- `isSvgElementNode(ASTNode)`
- `isMathMLElementNode(ASTNode)`

and broken / deprecated / unused `getTemplateBodyTokenStore` is removed in this commit