### PR TITLE
Treat Vue.mixin as components

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -381,7 +381,7 @@ module.exports = {
       callee.object.type === 'Identifier' &&
       callee.object.name === 'Vue' &&
       callee.property.type === 'Identifier' &&
-      callee.property.name === 'component' &&
+      (callee.property.name === 'component' || callee.property.name === 'mixin') &&
       node.arguments.length &&
       node.arguments.slice(-1)[0].type === 'ObjectExpression'
 

--- a/tests/lib/utils/vue-component.js
+++ b/tests/lib/utils/vue-component.js
@@ -122,6 +122,12 @@ function invalidTests (ext) {
     },
     {
       filename: `test.${ext}`,
+      code: `Vue.mixin({})`,
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
+      filename: `test.${ext}`,
       code: `
         // @vue/component
         export default { }


### PR DESCRIPTION
This PR adds support for `Vue.mixin` and treat it as components

fixes #136 

pointed out in [chat.vuejs.org](http://chat.vuejs.org)