### PR TITLE
Fix: support ESLint 4.4.0 (fixes #134)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "requireindex": "^1.1.0",
-    "vue-eslint-parser": "2.0.0-beta.5"
+    "vue-eslint-parser": "2.0.0-beta.6"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",


### PR DESCRIPTION
Fixes #134.

This PR fixes the problem that `eslint-plugin-vue` does not work on ESLint 4.4.0 because it has changed a private API that `vue-eslint-parser` depends on.

Diff:

- https://github.com/mysticatea/vue-eslint-parser/commit/40f48bec8ab1d4d2532f677dcca679514451872b

> The root cause is that `vue-eslint-parser` depends on a private API in order to traverse `<template>` separately from the main traversing, but I cannot solve the problem for now.