### PR TITLE
Fix small mistake in `require-valid-default-prop`

### DIFF
--- a/lib/rules/require-valid-default-prop.js
+++ b/lib/rules/require-valid-default-prop.js
@@ -102,22 +102,17 @@ module.exports = {
 
       for (const prop of properties) {
         const type = getPropertyNode(prop.value, 'type')
-        if (!type) {
-          continue
-        }
+        if (!type) continue
 
         const typeNames = new Set(getTypes(type.value)
           .map(item => item === 'Object' || item === 'Array' ? 'Function' : item) // Object and Array require function
           .filter(item => NATIVE_TYPES.has(item)))
 
-        if (typeNames.size === 0) { // There is no native types detected
-          continue
-        }
+        // There is no native types detected
+        if (typeNames.size === 0) continue
 
         const def = getPropertyNode(prop.value, 'default')
-        if (!def) {
-          continue
-        }
+        if (!def) continue
 
         const defType = getValueType(def.value)
         if (!defType || typeNames.has(defType)) continue

--- a/lib/rules/require-valid-default-prop.js
+++ b/lib/rules/require-valid-default-prop.js
@@ -103,7 +103,7 @@ module.exports = {
       for (const prop of properties) {
         const type = getPropertyNode(prop.value, 'type')
         if (!type) {
-          return
+          continue
         }
 
         const typeNames = new Set(getTypes(type.value)
@@ -111,14 +111,16 @@ module.exports = {
           .filter(item => NATIVE_TYPES.has(item)))
 
         if (typeNames.size === 0) { // There is no native types detected
-          return
+          continue
         }
 
         const def = getPropertyNode(prop.value, 'default')
-        if (!def) return
+        if (!def) {
+          continue
+        }
 
         const defType = getValueType(def.value)
-        if (typeNames.has(defType)) return
+        if (!defType || typeNames.has(defType)) continue
 
         context.report({
           node: def,

--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -65,6 +65,7 @@ ruleTester.run('require-valid-default-prop', rule, {
           foo: null,
           foo: Number,
           foo: [String, Number],
+          foo: { type: Number, default: VAR_BAR },
           foo: { type: Number, default: 100 },
           foo: { type: [String, Number], default: '' },
           foo: { type: [String, Number], default: 0 },


### PR DESCRIPTION
- Improve coverage for FunctionExpression and ArrowFunctionExpression
- Fix traversing over many types (return -> continue)