### PR TITLE
Improve support for spread operator

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -53,7 +53,9 @@ function getOrderMap (order) {
 }
 
 function checkOrder (propertiesNodes, orderMap, context) {
-  const properties = propertiesNodes.map(property => property.key)
+  const properties = propertiesNodes
+    .filter(property => property.type === 'Property')
+    .map(property => property.key)
 
   properties.forEach((property, i) => {
     const propertiesAbove = properties.slice(0, i)

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -323,6 +323,7 @@ module.exports = {
   getComputedProperties (componentObject) {
     const computedPropertiesNode = componentObject.properties
       .find(p =>
+        p.type === 'Property' &&
         p.key.type === 'Identifier' &&
         p.key.name === 'computed' &&
         p.value.type === 'ObjectExpression'

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -480,6 +480,8 @@ module.exports = {
     const nodes = node.properties.filter(p => p.type === 'Property' && groups.has(this.getStaticPropertyName(p.key)))
     for (const item of nodes) {
       const name = this.getStaticPropertyName(item.key)
+      if (!name) continue
+
       if (item.value.type === 'ArrayExpression') {
         yield * this.iterateArrayExpression(item.value, name)
       } else if (item.value.type === 'ObjectExpression') {
@@ -531,7 +533,7 @@ module.exports = {
     assert(node.type === 'FunctionExpression')
     if (node.body.type === 'BlockStatement') {
       for (const item of node.body.body) {
-        if (item.type === 'ReturnStatement' && item.argument.type === 'ObjectExpression') {
+        if (item.type === 'ReturnStatement' && item.argument && item.argument.type === 'ObjectExpression') {
           yield * this.iterateObjectExpression(item.argument, groupName)
         }
       }

--- a/tests/lib/rules/html-end-tags.js
+++ b/tests/lib/rules/html-end-tags.js
@@ -49,21 +49,24 @@ tester.run('html-end-tags', rule, {
     }
   ],
   invalid: [
-        // {
-        //     filename: "test.vue",
-        //     code: "<template><div><hr></hr></div></template>",
-        //     errors: ["'<hr>' should not have end tag."],
-        // },
-        // {
-        //     filename: "test.vue",
-        //     code: "<template><div><img></img></div></template>",
-        //     errors: ["'<img>' should not have end tag."],
-        // },
-        // {
-        //     filename: "test.vue",
-        //     code: "<template><div><input></input></div></template>",
-        //     errors: ["'<input>' should not have end tag."],
-        // },
+    // {
+    //   filename: 'test.vue',
+    //   code: '<template><div><hr></hr></div></template>',
+    //   output: '<template><div><hr></template>',
+    //   errors: ["'<hr>' should not have end tag."]
+    // },
+    // {
+    //   filename: 'test.vue',
+    //   code: '<template><div><img></img></div></template>',
+    //   output: '<template><div><img></template>',
+    //   errors: ["'<img>' should not have end tag."]
+    // },
+    // {
+    //   filename: 'test.vue',
+    //   code: '<template><div><input></input></div></template>',
+    //   output: '<template><div><input></template>',
+    //   errors: ["'<input>' should not have end tag."]
+    // },
     {
       filename: 'test.vue',
       code: '<template><div><div></div></template>',

--- a/tests/lib/rules/name-property-casing.js
+++ b/tests/lib/rules/name-property-casing.js
@@ -17,7 +17,8 @@ const RuleTester = require('eslint').RuleTester
 
 const parserOptions = {
   ecmaVersion: 6,
-  sourceType: 'module'
+  sourceType: 'module',
+  ecmaFeatures: { experimentalObjectRestSpread: true }
 }
 
 const ruleTester = new RuleTester()
@@ -28,6 +29,16 @@ ruleTester.run('name-property-casing', rule, {
       filename: 'test.vue',
       code: `
         export default {
+        }
+      `,
+      options: ['camelCase'],
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          ...name
         }
       `,
       options: ['camelCase'],

--- a/tests/lib/rules/no-async-in-computed-properties.js
+++ b/tests/lib/rules/no-async-in-computed-properties.js
@@ -36,6 +36,7 @@ ruleTester.run('no-async-in-computed-properties', rule, {
       filename: 'test.vue',
       code: `
         export default {
+          ...foo,
           computed: {
             ...mapGetters({
               test: 'getTest'

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -32,6 +32,9 @@ ruleTester.run('no-dupe-keys', rule, {
               dat: null
             }
           },
+          data () {
+            return
+          },
           methods: {
             _foo () {},
             test () {
@@ -68,7 +71,12 @@ ruleTester.run('no-dupe-keys', rule, {
             ...foo(),
             test () {
             }
-          }
+          },
+          data () {
+            return {
+              ...dat
+            }
+          },
         }
       `,
       parserOptions: { ecmaVersion: 8, sourceType: 'module', ecmaFeatures: { experimentalObjectRestSpread: true }}

--- a/tests/lib/rules/no-reservered-keys.js
+++ b/tests/lib/rules/no-reservered-keys.js
@@ -11,6 +11,12 @@
 const rule = require('../../../lib/rules/no-reservered-keys')
 const RuleTester = require('eslint').RuleTester
 
+const parserOptions = {
+  ecmaVersion: 7,
+  sourceType: 'module',
+  ecmaFeatures: { experimentalObjectRestSpread: true }
+}
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -39,7 +45,7 @@ ruleTester.run('no-reservered-keys', rule, {
           }
         }
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+      parserOptions
     }
   ],
 

--- a/tests/lib/rules/no-shared-component-data.js
+++ b/tests/lib/rules/no-shared-component-data.js
@@ -36,6 +36,24 @@ ruleTester.run('no-shared-component-data', rule, {
       filename: 'test.js',
       code: `
         new Vue({
+          ...data,
+          data () {
+            return {
+              foo: 'bar'
+            }
+          }
+        })
+      `,
+      parserOptions: {
+        ecmaVersion: 7,
+        sourceType: 'module',
+        ecmaFeatures: { experimentalObjectRestSpread: true }
+      }
+    },
+    {
+      filename: 'test.js',
+      code: `
+        new Vue({
           data: {
             foo: 'bar'
           }

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -26,6 +26,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
   valid: [
     {
       code: `Vue.component('test', {
+        ...foo,
         computed: {
           ...test0({}),
           test1() {

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -9,6 +9,12 @@ const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester()
 
+const parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module',
+  ecmaFeatures: { experimentalObjectRestSpread: true }
+}
+
 ruleTester.run('order-in-components', rule, {
 
   valid: [
@@ -20,6 +26,7 @@ ruleTester.run('order-in-components', rule, {
           props: {
             propA: Number,
           },
+          ...a,
           data () {
             return {
               msg: 'Welcome to Your Vue.js App'
@@ -27,21 +34,21 @@ ruleTester.run('order-in-components', rule, {
           },
         }
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+      parserOptions
     },
     {
       filename: 'test.vue',
       code: `
         export default {}
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+      parserOptions
     },
     {
       filename: 'test.vue',
       code: `
         export default 'example-text'
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+      parserOptions
     },
     {
       filename: 'test.jsx',
@@ -55,7 +62,7 @@ ruleTester.run('order-in-components', rule, {
           },
         }
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+      parserOptions
     },
     {
       filename: 'test.js',
@@ -136,7 +143,7 @@ ruleTester.run('order-in-components', rule, {
           },
         }
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions,
       errors: [{
         message: 'The "props" property should be above the "data" property on line 4.',
         line: 9
@@ -268,7 +275,7 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 16
@@ -284,7 +291,7 @@ ruleTester.run('order-in-components', rule, {
           test: 'ok'
         };
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parserOptions,
       options: [{ order: ['data', 'test', 'name'] }],
       errors: [{
         message: 'The "test" property should be above the "name" property on line 5.',

--- a/tests/lib/rules/require-prop-types.js
+++ b/tests/lib/rules/require-prop-types.js
@@ -24,6 +24,7 @@ ruleTester.run('require-prop-types', rule, {
       filename: 'test.vue',
       code: `
         export default {
+          ...foo,
           props: {
             ...test(),
             foo: String

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -26,6 +26,7 @@ ruleTester.run('require-render-return', rule, {
   valid: [
     {
       code: `Vue.component('test', {
+        ...foo,
         render() {
           return {}
         }

--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -13,7 +13,8 @@ const RuleTester = require('eslint').RuleTester
 
 const parserOptions = {
   ecmaVersion: 6,
-  sourceType: 'module'
+  sourceType: 'module',
+  ecmaFeatures: { experimentalObjectRestSpread: true, jsx: true }
 }
 
 function errorMessage (type) {
@@ -32,6 +33,13 @@ const ruleTester = new RuleTester()
 ruleTester.run('require-valid-default-prop', rule, {
 
   valid: [
+    {
+      filename: 'test.vue',
+      code: `export default {
+        ...foo
+      }`,
+      parserOptions
+    },
     {
       filename: 'test.vue',
       code: `export default {

--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -36,7 +36,8 @@ ruleTester.run('require-valid-default-prop', rule, {
     {
       filename: 'test.vue',
       code: `export default {
-        ...foo
+        ...foo,
+        props: { ...foo }
       }`,
       parserOptions
     },
@@ -73,8 +74,13 @@ ruleTester.run('require-valid-default-prop', rule, {
           foo: null,
           foo: Number,
           foo: [String, Number],
+          foo: { },
+          foo: { type: String },
           foo: { type: Number, default: VAR_BAR },
           foo: { type: Number, default: 100 },
+          foo: { type: Number, default: Number.MAX_VALUE },
+          foo: { type: Number, default: Foo.BAR },
+          foo: { type: {}, default: '' },
           foo: { type: [String, Number], default: '' },
           foo: { type: [String, Number], default: 0 },
           foo: { type: String, default: '' },
@@ -88,6 +94,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           foo: { type: Symbol, default () { } },
           foo: { type: Array, default () { } },
           foo: { type: Symbol, default: Symbol('a') },
+          foo: { type: String, default: \`Foo\` },
+          foo: { type: Foo, default: Foo('a') },
           foo: { type: String, default: \`Foo\` }
         }
       })`,

--- a/tests/lib/rules/valid-v-for.js
+++ b/tests/lib/rules/valid-v-for.js
@@ -78,6 +78,10 @@ tester.run('valid-v-for', rule, {
     {
       filename: 'test.vue',
       code: '<template v-for="x of list"><slot name="item" /></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template v-for="x of list">foo<div></div></template>'
     }
   ],
   invalid: [
@@ -170,6 +174,11 @@ tester.run('valid-v-for', rule, {
       filename: 'test.vue',
       code: '<template><div><template v-for="x in list" :key="x"><custom-component></custom-component></template></div></template>',
       errors: ["Custom elements in iteration require 'v-bind:key' directives."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><template v-for="xin list"><div></div></template></div></template>',
+      errors: ["'v-for' directives require that attribute value."]
     }
   ]
 })


### PR DESCRIPTION
Fix issues with trying to access undefined properties
- `Cannot read property 'type' of null` when `return` has no argument

Improvements:
- `iterateProperties` - utils
- `checkOrder` - order-in-components
- `getComputedProperties` - utils
- `iterateFunctionExpression` - utils
- add more tests

This changes provide spread operator support support for all rules.