### PR TITLE
Fix: don't use internal APIs of ESLint (fixes #171)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,12 +4,12 @@ machine:
 
 dependencies:
   pre:
-    - nvm install 7
+    - nvm install 6
     - nvm install 8
 
 test:
   override:
-    - npm test
+    - nvm use 4 && npm test
     - nvm use 6 && npm test
-    - nvm use 7 && npm test
     - nvm use 8 && npm test
+    - nvm use 8 && npm i eslint@3.18.0 --no-save && npm run -s test:base

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -43,7 +43,7 @@ function create (context) {
   // Public
   // ----------------------------------------------------------------------
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     VAttribute (node) {
       if (!utils.isCustomComponent(node.parent.parent)) return
 
@@ -53,8 +53,6 @@ function create (context) {
       reportIssue(node, name)
     }
   })
-
-  return {}
 }
 
 module.exports = {

--- a/lib/rules/html-end-tags.js
+++ b/lib/rules/html-end-tags.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     VElement (node) {
       const name = node.name
       const isVoid = utils.isHtmlVoidElementName(name)
@@ -48,8 +48,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/html-no-self-closing.js
+++ b/lib/rules/html-no-self-closing.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     'VElement' (node) {
       if (utils.isSvgElementNode(node)) {
         return
@@ -42,8 +42,6 @@ function create (context) {
       })
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/html-quotes.js
+++ b/lib/rules/html-quotes.js
@@ -27,7 +27,7 @@ function create (context) {
   const quoteChar = double ? '"' : "'"
   const quoteName = double ? 'double quotes' : 'single quotes'
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     'VAttribute[value!=null]' (node) {
       const text = sourceCode.getText(node.value)
       const firstChar = text[0]
@@ -41,8 +41,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/html-self-closing.js
+++ b/lib/rules/html-self-closing.js
@@ -89,7 +89,7 @@ function create (context) {
   const sourceCode = context.getSourceCode()
   const options = parseOptions(context.options[0])
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     'VElement' (node) {
       const elementType = getElementType(node)
       const mode = options[elementType]
@@ -132,8 +132,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -71,7 +71,7 @@ module.exports = {
     const singlelinemMaximum = configuration.singleline
     const canHaveFirstLine = configuration.allowFirstLine
 
-    utils.registerTemplateBodyVisitor(context, {
+    return utils.defineTemplateBodyVisitor(context, {
       'VStartTag' (node) {
         const numberOfAttributes = node.attributes.length
 
@@ -155,7 +155,5 @@ module.exports = {
 
       return propsPerLine
     }
-
-    return {}
   }
 }

--- a/lib/rules/mustache-interpolation-spacing.js
+++ b/lib/rules/mustache-interpolation-spacing.js
@@ -65,7 +65,7 @@ module.exports = {
     // Public
     // ----------------------------------------------------------------------
 
-    utils.registerTemplateBodyVisitor(context, {
+    return utils.defineTemplateBodyVisitor(context, {
       'VExpressionContainer[expression!=null]' (node) {
         const tokens = template.getTokens(node, {
           includeComments: true,
@@ -85,7 +85,5 @@ module.exports = {
         }
       }
     })
-
-    return { }
   }
 }

--- a/lib/rules/no-confusing-v-for-v-if.js
+++ b/lib/rules/no-confusing-v-for-v-if.js
@@ -37,7 +37,7 @@ function isUsingIterationVar (vIf) {
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='if']" (node) {
       const element = node.parent.parent
 
@@ -50,8 +50,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -51,7 +51,7 @@ function create (context) {
     return directiveNames.has(name) || attributeNames.has(name)
   }
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     'VStartTag' () {
       directiveNames.clear()
       attributeNames.clear()
@@ -78,8 +78,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-bind.js
+++ b/lib/rules/no-invalid-v-bind.js
@@ -24,7 +24,7 @@ const VALID_MODIFIERS = new Set(['prop', 'camel', 'sync'])
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='bind']" (node) {
       for (const modifier of node.key.modifiers) {
         if (!VALID_MODIFIERS.has(modifier)) {
@@ -46,8 +46,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-cloak.js
+++ b/lib/rules/no-invalid-v-cloak.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='cloak']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-else-if.js
+++ b/lib/rules/no-invalid-v-else-if.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='else-if']" (node) {
       const element = node.parent.parent
 
@@ -70,8 +70,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-else.js
+++ b/lib/rules/no-invalid-v-else.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='else']" (node) {
       const element = node.parent.parent
 
@@ -70,8 +70,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-for.js
+++ b/lib/rules/no-invalid-v-for.js
@@ -79,7 +79,7 @@ function checkKey (context, vFor, element) {
 function create (context) {
   const sourceCode = context.getSourceCode()
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='for']" (node) {
       const element = node.parent.parent
 
@@ -151,8 +151,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-html.js
+++ b/lib/rules/no-invalid-v-html.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='html']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-if.js
+++ b/lib/rules/no-invalid-v-if.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='if']" (node) {
       const element = node.parent.parent
 
@@ -63,8 +63,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-model.js
+++ b/lib/rules/no-invalid-v-model.js
@@ -80,7 +80,7 @@ function getVariable (name, leafNode) {
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='model']" (node) {
       const element = node.parent.parent
       const name = element.name
@@ -164,8 +164,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-on.js
+++ b/lib/rules/no-invalid-v-on.js
@@ -31,7 +31,7 @@ const VERB_MODIFIERS = new Set([
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='on']" (node) {
       for (const modifier of node.key.modifiers) {
         if (!VALID_MODIFIERS.has(modifier) && !Number.isInteger(parseInt(modifier, 10))) {
@@ -52,8 +52,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-once.js
+++ b/lib/rules/no-invalid-v-once.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='once']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-pre.js
+++ b/lib/rules/no-invalid-v-pre.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='pre']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-show.js
+++ b/lib/rules/no-invalid-v-show.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='show']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-invalid-v-text.js
+++ b/lib/rules/no-invalid-v-text.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='text']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-template-key.js
+++ b/lib/rules/no-template-key.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VElement[name='template']" (node) {
       if (utils.hasAttribute(node, 'key') || utils.hasDirective(node, 'bind', 'key')) {
         context.report({
@@ -33,8 +33,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VElement[name='textarea'] VExpressionContainer" (node) {
       if (node.parent.type !== 'VElement') {
         return
@@ -35,8 +35,6 @@ function create (context) {
       })
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/require-component-is.js
+++ b/lib/rules/require-component-is.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VElement[name='component']" (node) {
       if (!utils.hasDirective(node, 'bind', 'is')) {
         context.report({
@@ -33,8 +33,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/require-v-for-key.js
+++ b/lib/rules/require-v-for-key.js
@@ -43,13 +43,11 @@ function checkKey (context, element) {
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='for']" (node) {
       checkKey(context, node.parent.parent)
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/this-in-template.js
+++ b/lib/rules/this-in-template.js
@@ -43,7 +43,7 @@ module.exports = {
       nodes: []
     }
 
-    utils.registerTemplateBodyVisitor(context, Object.assign({
+    return utils.defineTemplateBodyVisitor(context, Object.assign({
       VElement (node) {
         scope = {
           parent: scope,
@@ -97,7 +97,5 @@ module.exports = {
         }
       }
     ))
-
-    return {}
   }
 }

--- a/lib/rules/v-bind-style.js
+++ b/lib/rules/v-bind-style.js
@@ -24,7 +24,7 @@ const utils = require('../utils')
 function create (context) {
   const shorthand = context.options[0] !== 'longform'
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='bind'][key.argument!=null]" (node) {
       if (node.key.shorthand === shorthand) {
         return
@@ -42,8 +42,6 @@ function create (context) {
       })
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/v-on-style.js
+++ b/lib/rules/v-on-style.js
@@ -24,7 +24,7 @@ const utils = require('../utils')
 function create (context) {
   const shorthand = context.options[0] !== 'longform'
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='on'][key.argument!=null]" (node) {
       if (node.key.shorthand === shorthand) {
         return
@@ -43,8 +43,6 @@ function create (context) {
       })
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-bind.js
+++ b/lib/rules/valid-v-bind.js
@@ -24,7 +24,7 @@ const VALID_MODIFIERS = new Set(['prop', 'camel', 'sync'])
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='bind']" (node) {
       for (const modifier of node.key.modifiers) {
         if (!VALID_MODIFIERS.has(modifier)) {
@@ -46,8 +46,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-cloak.js
+++ b/lib/rules/valid-v-cloak.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='cloak']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-else-if.js
+++ b/lib/rules/valid-v-else-if.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='else-if']" (node) {
       const element = node.parent.parent
 
@@ -70,8 +70,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-else.js
+++ b/lib/rules/valid-v-else.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='else']" (node) {
       const element = node.parent.parent
 
@@ -70,8 +70,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-for.js
+++ b/lib/rules/valid-v-for.js
@@ -106,7 +106,7 @@ function checkKey (context, vFor, element) {
 function create (context) {
   const sourceCode = context.getSourceCode()
 
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='for']" (node) {
       const element = node.parent.parent
 
@@ -178,8 +178,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-html.js
+++ b/lib/rules/valid-v-html.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='html']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-if.js
+++ b/lib/rules/valid-v-if.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='if']" (node) {
       const element = node.parent.parent
 
@@ -63,8 +63,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-model.js
+++ b/lib/rules/valid-v-model.js
@@ -80,7 +80,7 @@ function getVariable (name, leafNode) {
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='model']" (node) {
       const element = node.parent.parent
       const name = element.name
@@ -164,8 +164,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-on.js
+++ b/lib/rules/valid-v-on.js
@@ -31,7 +31,7 @@ const VERB_MODIFIERS = new Set([
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='on']" (node) {
       for (const modifier of node.key.modifiers) {
         if (!VALID_MODIFIERS.has(modifier) && !Number.isInteger(parseInt(modifier, 10))) {
@@ -52,8 +52,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-once.js
+++ b/lib/rules/valid-v-once.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='once']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-pre.js
+++ b/lib/rules/valid-v-pre.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='pre']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-show.js
+++ b/lib/rules/valid-v-show.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='show']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/valid-v-text.js
+++ b/lib/rules/valid-v-text.js
@@ -22,7 +22,7 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
-  utils.registerTemplateBodyVisitor(context, {
+  return utils.defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='text']" (node) {
       if (node.key.argument) {
         context.report({
@@ -47,8 +47,6 @@ function create (context) {
       }
     }
   })
-
-  return {}
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -25,17 +25,19 @@ module.exports = {
    * this generates a warning.
    *
    * @param {RuleContext} context The rule context to use parser services.
-   * @param {Object} visitor The visitor.
+   * @param {Object} templateBodyVisitor The visitor to traverse the template body.
+   * @param {Object} scriptVisitor The visitor to traverse the script.
+   * @returns {Object} The merged visitor.
    */
-  registerTemplateBodyVisitor (context, visitor) {
-    if (context.parserServices.registerTemplateBodyVisitor == null) {
+  defineTemplateBodyVisitor (context, templateBodyVisitor, scriptVisitor) {
+    if (context.parserServices.defineTemplateBodyVisitor == null) {
       context.report({
         loc: { line: 1, column: 0 },
         message: 'Use the latest vue-eslint-parser. See also https://github.com/vuejs/eslint-plugin-vue#what-is-the-use-the-latest-vue-eslint-parser-error'
       })
       return
     }
-    context.parserServices.registerTemplateBodyVisitor(context, visitor)
+    return context.parserServices.defineTemplateBodyVisitor(templateBodyVisitor, scriptVisitor)
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Official ESLint plugin for Vue.js",
   "main": "lib/index.js",
   "scripts": {
-    "start": "npm run test:simple -- --watch --growl",
-    "test:base": "mocha \"tests/lib/**/*.js\"",
-    "test:simple": "npm run test:base -- --reporter dot",
+    "start": "npm run test:base -- --watch --growl",
+    "test:base": "mocha \"tests/lib/**/*.js\" --reporter dot",
     "test": "nyc npm run test:base -- \"tests/integrations/*.js\" --timeout 60000",
     "lint": "eslint .",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "requireindex": "^1.1.0",
-    "vue-eslint-parser": "2.0.0-beta.10"
+    "vue-eslint-parser": "^2.0.1-beta.0"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",


### PR DESCRIPTION
Fixes #171.

This PR makes `eslint-plugin-vue` not using internal APIs of ESLint.
This is helpful to prevent broken by internal changes in ESLint.

For this, I changed `parserServices.registerTemplateBodyVisitor` to `parserServices.defineTemplateBodyVisitor`.
The `parserServices.registerTemplateBodyVisitor` had been registering the visitor to ESLint with internal API.
New `parserServices.defineTemplateBodyVisitor` returns a normal visitor which has a handler to call the given visitor. Rules must return the normal visitor to register it to ESLint.