### PR TITLE
Fix: ignore PUG (fixes #165)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "requireindex": "^1.1.0",
-    "vue-eslint-parser": "^2.0.1-beta.0"
+    "vue-eslint-parser": "^2.0.1-beta.1"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",

--- a/tests/lib/rules/valid-template-root.js
+++ b/tests/lib/rules/valid-template-root.js
@@ -70,6 +70,10 @@ tester.run('valid-template-root', rule, {
     {
       filename: 'test.vue',
       code: '<template><table><custom-thead></custom-thead></table></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template lang="pug">test</template>'
     }
   ],
   invalid: [


### PR DESCRIPTION
Fixes #165.

I updated `vue-eslint-parser` to ignore PUG template: https://github.com/mysticatea/vue-eslint-parser/commit/4b264ad8b94599822c09855ac0d0db7dad28db55
This PR applies the patch to this plugin.
