### PR TITLE
Fix max-attributes-per-line example json configuration

### DIFF
--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -45,11 +45,11 @@ There is a configurable number of attributes that are acceptable in one-line cas
 
 ```
 {
-  "vue/max-attributes-per-line": [{
+  "vue/max-attributes-per-line": [2, {
     "singleline": 3,
     "multiline": {
-      max: 1,
-      allowFirstLine: false
+      "max": 1,
+      "allowFirstLine": false
     }
   }]
 }


### PR DESCRIPTION
The first value of the array is expected to be the severity.
Keys must be in double quotes.