### PR TITLE
html-end-tags: don't fail for self-closing elements

### DIFF
--- a/docs/rules/html-end-tags.md
+++ b/docs/rules/html-end-tags.md
@@ -36,6 +36,7 @@ This rule reports the following elements:
         <div></div>
         <p></p>
         <p></p>
+        <div />
         <input>
         <br>
     </div>

--- a/lib/rules/html-end-tags.js
+++ b/lib/rules/html-end-tags.js
@@ -27,6 +27,7 @@ function create (context) {
       const name = node.name
       const isVoid = utils.isHtmlVoidElementName(name)
       const hasEndTag = node.endTag != null
+      const isSelfClosing = node.startTag.selfClosing
 
       if (isVoid && hasEndTag) {
         context.report({
@@ -37,7 +38,7 @@ function create (context) {
           fix: (fixer) => fixer.remove(node.endTag)
         })
       }
-      if (!isVoid && !hasEndTag) {
+      if (!isVoid && !(hasEndTag || isSelfClosing)) {
         context.report({
           node: node.startTag,
           loc: node.startTag.loc,

--- a/tests/lib/rules/html-end-tags.js
+++ b/tests/lib/rules/html-end-tags.js
@@ -46,6 +46,10 @@ tester.run('html-end-tags', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><img></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><div /></div></template>'
     }
   ],
   invalid: [


### PR DESCRIPTION
Fixes #217 