### PR TITLE
Update example config to use essential rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ Example **.eslintrc.js**:
 ```js
 module.exports = {
   extends: [
-    'eslint:recommended',
-    'plugin:vue/recommended' // or 'plugin:vue/base'
+    // add more generic rulesets here, such as:
+    // 'eslint:recommended',
+    'plugin:vue/essential'
   ],
   rules: {
-    // override/add rules' settings here
-    'vue/valid-v-if': 'error'
+    // override/add rules settings here, such as:
+    // 'vue/no-unused-vars': 'error'
   }
 }
 ```


### PR DESCRIPTION
I think the `essential` rules make the most sense as a default implied recommendation, as they're the most universally useful, without anything opinionated.

I also updated the comments slightly and commented out the base config and example rule, so that users blindly copying and pasting don't add anything unnecessary. Without it commented out, some users may also assume that `eslint:recommended` is required for the plugin to work.