### PR TITLE
Adjust html-indent default doc to reflect 0a1237b

### DIFF
--- a/docs/rules/html-indent.md
+++ b/docs/rules/html-indent.md
@@ -4,7 +4,7 @@
 
 ## :book: Rule Details
 
-This rule enforces a consistent indentation style in `<template>`. The default style is 4 spaces as same as [the core indent rule](http://eslint.org/docs/rules/indent).
+This rule enforces a consistent indentation style in `<template>`. The default style is 2 spaces.
 
 - This rule checks all tags, also all expressions in directives and mustaches.
 - In the expressions, this rule supports ECMAScript 2017 syntaxes. It ignores unknown AST nodes, but it might be confused by non-standard syntaxes.


### PR DESCRIPTION
Cross-reference: https://github.com/vuejs/eslint-plugin-vue/pull/205#issuecomment-344459432