### PR TITLE
Docs: add playground link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Please try it and report any issues that you might have encountered.
 
 If you want to check previous releases [go here](https://github.com/vuejs/eslint-plugin-vue/releases).
 
+## :art: Playground on the Web
+
+You can try this plugin on the Web.
+
+- https://mysticatea.github.io/vue-eslint-demo/
+
 ## :grey_exclamation: Requirements
 
 - [ESLint](http://eslint.org/) `>=3.18.0`.


### PR DESCRIPTION
This PR adds a link to the playground. I expect this to help potential users to try this plugin quickly.