### PR TITLE
[Fix] Crash with babel-eslint

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,4 +12,5 @@ test:
     - nvm use 4 && npm test
     - nvm use 6 && npm test
     - nvm use 8 && npm test
-    - nvm use 8 && npm i eslint@3.18.0 --no-save && npm run -s test:base
+    # Test for the minimum version we are supporting.
+    - nvm use 8 && npm i eslint@3.18.0 --no-save && $(npm bin)/mocha tests/lib/rules/*.js --reporter dot

--- a/eslint-internal-rules/consistent-docs-description.js
+++ b/eslint-internal-rules/consistent-docs-description.js
@@ -43,7 +43,7 @@ function getPropertyFromObject (property, node) {
  */
 function checkMetaDocsDescription (context, exportsNode) {
   if (exportsNode.type !== 'ObjectExpression') {
-        // if the exported node is not the correct format, "internal-no-invalid-meta" will already report this.
+    // if the exported node is not the correct format, "internal-no-invalid-meta" will already report this.
     return
   }
 
@@ -52,7 +52,7 @@ function checkMetaDocsDescription (context, exportsNode) {
   const metaDocsDescription = metaDocs && getPropertyFromObject('description', metaDocs.value)
 
   if (!metaDocsDescription) {
-        // if there is no `meta.docs.description` property, "internal-no-invalid-meta" will already report this.
+    // if there is no `meta.docs.description` property, "internal-no-invalid-meta" will already report this.
     return
   }
 

--- a/lib/rules/name-property-casing.js
+++ b/lib/rules/name-property-casing.js
@@ -51,7 +51,7 @@ module.exports = {
       description: 'enforce specific casing for the name property in Vue components',
       category: 'strongly-recommended'
     },
-    fixable: 'code',  // or "code" or "whitespace"
+    fixable: 'code', // or "code" or "whitespace"
     schema: [
       {
         enum: allowedCaseOptions

--- a/lib/rules/no-confusing-v-for-v-if.js
+++ b/lib/rules/no-confusing-v-for-v-if.js
@@ -23,11 +23,11 @@ const utils = require('../utils')
 function isUsingIterationVar (vIf) {
   const element = vIf.parent.parent
   return vIf.value.references.some(reference =>
-        element.variables.some(variable =>
-            variable.id.name === reference.id.name &&
-            variable.kind === 'v-for'
-        )
+    element.variables.some(variable =>
+      variable.id.name === reference.id.name &&
+      variable.kind === 'v-for'
     )
+  )
 }
 
 /**

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -49,7 +49,7 @@ module.exports = {
       description: 'disallow duplication of field names',
       category: 'essential'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: null, // or "code" or "whitespace"
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -14,7 +14,7 @@ module.exports = {
       description: 'disallow multiple spaces',
       category: 'strongly-recommended'
     },
-    fixable: 'whitespace',  // or "code" or "whitespace"
+    fixable: 'whitespace', // or "code" or "whitespace"
     schema: []
   },
 

--- a/lib/rules/no-shared-component-data.js
+++ b/lib/rules/no-shared-component-data.js
@@ -40,7 +40,7 @@ module.exports = {
       description: "enforce component's data property to be a function",
       category: 'essential'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: null, // or "code" or "whitespace"
     schema: []
   },
 

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -16,7 +16,7 @@ module.exports = {
       description: 'require default value for props',
       category: 'strongly-recommended'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: null, // or "code" or "whitespace"
     schema: []
   },
 

--- a/lib/rules/require-prop-types.js
+++ b/lib/rules/require-prop-types.js
@@ -83,7 +83,7 @@ module.exports = {
       description: 'require type definitions in props',
       category: 'strongly-recommended'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: null, // or "code" or "whitespace"
     schema: [
       // fill in your schema
     ]

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -46,7 +46,7 @@ module.exports = {
       description: 'enforce render function to always return value',
       category: 'essential'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: null, // or "code" or "whitespace"
     schema: []
   },
 

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -50,7 +50,7 @@ module.exports = {
       description: 'enforce that a return statement is present in computed property',
       category: 'essential'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: null, // or "code" or "whitespace"
     schema: [
       {
         type: 'object',

--- a/lib/rules/v-bind-style.js
+++ b/lib/rules/v-bind-style.js
@@ -34,11 +34,11 @@ function create (context) {
         node,
         loc: node.loc,
         message: shorthand
-                    ? "Unexpected 'v-bind' before ':'."
-                    : "Expected 'v-bind' before ':'.",
+          ? "Unexpected 'v-bind' before ':'."
+          : "Expected 'v-bind' before ':'.",
         fix: (fixer) => shorthand
-                    ? fixer.removeRange([node.range[0], node.range[0] + 6])
-                    : fixer.insertTextBefore(node, 'v-bind')
+          ? fixer.removeRange([node.range[0], node.range[0] + 6])
+          : fixer.insertTextBefore(node, 'v-bind')
       })
     }
   })

--- a/lib/rules/v-on-style.js
+++ b/lib/rules/v-on-style.js
@@ -35,11 +35,11 @@ function create (context) {
         node,
         loc: node.loc,
         message: shorthand
-                    ? "Expected '@' instead of 'v-on:'."
-                    : "Expected 'v-on:' instead of '@'.",
+          ? "Expected '@' instead of 'v-on:'."
+          : "Expected 'v-on:' instead of '@'.",
         fix: (fixer) => shorthand
-                    ? fixer.replaceTextRange([pos, pos + 5], '@')
-                    : fixer.replaceTextRange([pos, pos + 1], 'v-on:')
+          ? fixer.replaceTextRange([pos, pos + 5], '@')
+          : fixer.replaceTextRange([pos, pos + 1], 'v-on:')
       })
     }
   })

--- a/lib/rules/valid-v-for.js
+++ b/lib/rules/valid-v-for.js
@@ -28,11 +28,11 @@ function isUsingIterationVar (vFor, vBindKey) {
   const references = vBindKey.value.references
   const variables = vFor.parent.parent.variables
   return references.some(reference =>
-        variables.some(variable =>
-            variable.id.name === reference.id.name &&
+    variables.some(variable =>
+      variable.id.name === reference.id.name &&
             variable.kind === 'v-for'
-        )
     )
+  )
 }
 
 /**
@@ -48,11 +48,11 @@ function checkChildKey (context, vFor, child) {
     const childForRefs = childFor.value.references
     const variables = vFor.parent.parent.variables
     const usedInFor = childForRefs.some(cref =>
-           variables.some(variable =>
-               cref.id.name === variable.id.name &&
-               variable.kind === 'v-for'
-           )
+      variables.some(variable =>
+        cref.id.name === variable.id.name &&
+        variable.kind === 'v-for'
       )
+    )
     // if parent iterator is used, skip other checks
     // iterator usage will be checked later by child v-for
     if (usedInFor) {

--- a/lib/rules/valid-v-model.js
+++ b/lib/rules/valid-v-model.js
@@ -25,16 +25,16 @@ const VALID_MODIFIERS = new Set(['lazy', 'number', 'trim'])
 function isValidElement (node) {
   const name = node.name
   return (
-        name === 'input' ||
-        name === 'select' ||
-        name === 'textarea' ||
-        (
-            name !== 'keep-alive' &&
-            name !== 'slot' &&
-            name !== 'transition' &&
-            name !== 'transition-group' &&
-            utils.isCustomComponent(node)
-        )
+    name === 'input' ||
+    name === 'select' ||
+    name === 'textarea' ||
+    (
+      name !== 'keep-alive' &&
+      name !== 'slot' &&
+      name !== 'transition' &&
+      name !== 'transition-group' &&
+      utils.isCustomComponent(node)
+    )
   )
 }
 
@@ -45,9 +45,9 @@ function isValidElement (node) {
  */
 function isLhs (node) {
   return node != null && (
-        node.type === 'Identifier' ||
-        node.type === 'MemberExpression'
-    )
+    node.type === 'Identifier' ||
+    node.type === 'MemberExpression'
+  )
 }
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -85,13 +85,13 @@ module.exports = {
   hasAttribute (node, name, value) {
     assert(node && node.type === 'VElement')
     return node.startTag.attributes.some(a =>
-            !a.directive &&
-            a.key.name === name &&
-            (
-                value === undefined ||
-                (a.value != null && a.value.value === value)
-            )
-        )
+      !a.directive &&
+      a.key.name === name &&
+      (
+        value === undefined ||
+        (a.value != null && a.value.value === value)
+      )
+    )
   },
 
   /**
@@ -104,10 +104,10 @@ module.exports = {
   hasDirective (node, name, argument) {
     assert(node && node.type === 'VElement')
     return node.startTag.attributes.some(a =>
-            a.directive &&
-            a.key.name === name &&
-            (argument === undefined || a.key.argument === argument)
-        )
+      a.directive &&
+      a.key.name === name &&
+      (argument === undefined || a.key.argument === argument)
+    )
   },
 
   /**
@@ -118,8 +118,8 @@ module.exports = {
   hasAttributeValue (node) {
     assert(node && node.type === 'VAttribute')
     return (
-            node.value != null &&
-            (node.value.expression != null || node.value.syntaxError != null)
+      node.value != null &&
+      (node.value.expression != null || node.value.syntaxError != null)
     )
   },
 
@@ -133,13 +133,13 @@ module.exports = {
   getAttribute (node, name, value) {
     assert(node && node.type === 'VElement')
     return node.startTag.attributes.find(a =>
-            !a.directive &&
-            a.key.name === name &&
-            (
-                value === undefined ||
-                (a.value != null && a.value.value === value)
-            )
-        )
+      !a.directive &&
+      a.key.name === name &&
+      (
+        value === undefined ||
+        (a.value != null && a.value.value === value)
+      )
+    )
   },
 
   /**
@@ -152,10 +152,10 @@ module.exports = {
   getDirective (node, name, argument) {
     assert(node && node.type === 'VElement')
     return node.startTag.attributes.find(a =>
-            a.directive &&
-            a.key.name === name &&
-            (argument === undefined || a.key.argument === argument)
-        )
+      a.directive &&
+      a.key.name === name &&
+      (argument === undefined || a.key.argument === argument)
+    )
   },
 
   /**
@@ -168,11 +168,11 @@ module.exports = {
 
     const prev = this.prevSibling(node)
     return (
-            prev != null &&
-            prev.startTag.attributes.some(a =>
-                a.directive &&
-                (a.key.name === 'if' || a.key.name === 'else-if')
-            )
+      prev != null &&
+      prev.startTag.attributes.some(a =>
+        a.directive &&
+        (a.key.name === 'if' || a.key.name === 'else-if')
+      )
     )
   },
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -35,7 +35,7 @@ module.exports = {
         loc: { line: 1, column: 0 },
         message: 'Use the latest vue-eslint-parser. See also https://github.com/vuejs/eslint-plugin-vue#what-is-the-use-the-latest-vue-eslint-parser-error'
       })
-      return
+      return {}
     }
     return context.parserServices.defineTemplateBodyVisitor(templateBodyVisitor, scriptVisitor)
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "chai": "^4.1.0",
     "eslint": "^4.12.1",
     "eslint-plugin-eslint-plugin": "^0.8.0",
+    "eslint-plugin-html": "^4.0.1",
     "eslint-plugin-vue-libs": "^2.0.0",
     "mocha": "^3.2.0",
     "nyc": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chai": "^4.1.0",
     "eslint": "^4.12.1",
     "eslint-plugin-eslint-plugin": "^0.8.0",
-    "eslint-plugin-vue-libs": "^1.2.0",
+    "eslint-plugin-vue-libs": "^2.0.0",
     "mocha": "^3.2.0",
     "nyc": "^11.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^4.2.16",
     "babel-eslint": "^7.2.3",
     "chai": "^4.1.0",
-    "eslint": "^3.19.0",
+    "eslint": "^4.12.1",
     "eslint-plugin-eslint-plugin": "^0.8.0",
     "eslint-plugin-vue-libs": "^1.2.0",
     "mocha": "^3.2.0",

--- a/tests/lib/rules-without-vue-eslint-parser.js
+++ b/tests/lib/rules-without-vue-eslint-parser.js
@@ -1,0 +1,29 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const Linter = require('eslint').Linter
+const rules = require('../..').rules
+
+describe("Don't crash even if without vue-eslint-parser.", () => {
+  const code = '<template><div>TEST</div></template>'
+
+  for (const key of Object.keys(rules)) {
+    const ruleId = `vue/${key}`
+
+    it(ruleId, () => {
+      const linter = new Linter()
+      const config = {
+        parser: 'babel-eslint',
+        parserOptions: { ecmaVersion: 2015 },
+        rules: {
+          [ruleId]: 'error'
+        }
+      }
+      linter.defineRule(ruleId, rules[key])
+      linter.verifyAndFix(code, config, 'test.vue')
+    })
+  }
+})

--- a/tools/update-rules.js
+++ b/tools/update-rules.js
@@ -79,7 +79,7 @@ const deprecatedRules = rules
 let rulesTableContent = categories.map(category => `
 ### ${categoryTitles[category]}
 ${
-category === 'uncategorized' ? '' : `
+  category === 'uncategorized' ? '' : `
 Enforce all the rules in this category, as well as all higher priority rules, with:
 
 \`\`\` json
@@ -123,17 +123,17 @@ if (deprecatedRules.length) {
   | Rule ID | Replaced by |
   |:--------|:------------|
   ${
-    rules
-      .filter(entry => entry[1].meta.deprecated)
-      .map(entry => {
-        const name = entry[0]
-        const meta = entry[1].meta
-        const link = `[${name}](./docs/rules/${name}.md)`
-        const replacedBy = (meta.docs.replacedBy || []).map(id => `[${id}](./docs/rules/${id}.md)`).join(', ') || '(no replacement)'
-        return `| ${link} | ${replacedBy} |`
-      })
-      .join('\n')
-  }
+  rules
+    .filter(entry => entry[1].meta.deprecated)
+    .map(entry => {
+      const name = entry[0]
+      const meta = entry[1].meta
+      const link = `[${name}](./docs/rules/${name}.md)`
+      const replacedBy = (meta.docs.replacedBy || []).map(id => `[${id}](./docs/rules/${id}.md)`).join(', ') || '(no replacement)'
+      return `| ${link} | ${replacedBy} |`
+    })
+    .join('\n')
+}
   `
 }
 


### PR DESCRIPTION
Fixes #213.

It intended to show the message "Use the latest vue-eslint-parser", but it crashes.

This PR fixes the crash and adds tests to check that rules don't crash with `babel-eslint`.