### PR TITLE
[Fix] Incorrect errors in invalid EOF cases (fixes #268)

### DIFF
--- a/lib/rules/html-end-tags.js
+++ b/lib/rules/html-end-tags.js
@@ -22,22 +22,19 @@ const utils = require('../utils')
  * @returns {Object} AST event handlers.
  */
 function create (context) {
+  let hasInvalidEOF = false
+
   return utils.defineTemplateBodyVisitor(context, {
     VElement (node) {
+      if (hasInvalidEOF) {
+        return
+      }
+
       const name = node.name
       const isVoid = utils.isHtmlVoidElementName(name)
       const isSelfClosing = node.startTag.selfClosing
       const hasEndTag = node.endTag != null
 
-      if (isVoid && hasEndTag) {
-        context.report({
-          node: node.endTag,
-          loc: node.endTag.loc,
-          message: "'<{{name}}>' should not have end tag.",
-          data: { name },
-          fix: (fixer) => fixer.remove(node.endTag)
-        })
-      }
       if (!isVoid && !hasEndTag && !isSelfClosing) {
         context.report({
           node: node.startTag,
@@ -47,6 +44,10 @@ function create (context) {
           fix: (fixer) => fixer.insertTextAfter(node, `</${name}>`)
         })
       }
+    }
+  }, {
+    Program (node) {
+      hasInvalidEOF = utils.hasInvalidEOF(node)
     }
   })
 }

--- a/lib/rules/html-self-closing.js
+++ b/lib/rules/html-self-closing.js
@@ -88,9 +88,14 @@ function isEmpty (node, sourceCode) {
 function create (context) {
   const sourceCode = context.getSourceCode()
   const options = parseOptions(context.options[0])
+  let hasInvalidEOF = false
 
   return utils.defineTemplateBodyVisitor(context, {
     'VElement' (node) {
+      if (hasInvalidEOF) {
+        return
+      }
+
       const elementType = getElementType(node)
       const mode = options[elementType]
 
@@ -130,6 +135,10 @@ function create (context) {
           }
         })
       }
+    }
+  }, {
+    Program (node) {
+      hasInvalidEOF = utils.hasInvalidEOF(node)
     }
   })
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -601,5 +601,18 @@ module.exports = {
    */
   isSingleLine (node) {
     return node.loc.start.line === node.loc.end.line
+  },
+
+  /**
+   * Check whether the templateBody of the program has invalid EOF or not.
+   * @param {Program} node The program node to check.
+   * @returns {boolean} `true` if it has invalid EOF.
+   */
+  hasInvalidEOF (node) {
+    const body = node.templateBody
+    if (body == null || body.errors == null) {
+      return
+    }
+    return body.errors.some(error => typeof error.code === 'string' && error.code.startsWith('eof-'))
   }
 }

--- a/tests/lib/rules/html-end-tags.js
+++ b/tests/lib/rules/html-end-tags.js
@@ -54,27 +54,21 @@ tester.run('html-end-tags', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><div/></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div a="b>test</div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><!--</div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><svg><![CDATA[test</svg></div></template>'
     }
   ],
   invalid: [
-    // {
-    //   filename: 'test.vue',
-    //   code: '<template><div><hr></hr></div></template>',
-    //   output: '<template><div><hr></template>',
-    //   errors: ["'<hr>' should not have end tag."]
-    // },
-    // {
-    //   filename: 'test.vue',
-    //   code: '<template><div><img></img></div></template>',
-    //   output: '<template><div><img></template>',
-    //   errors: ["'<img>' should not have end tag."]
-    // },
-    // {
-    //   filename: 'test.vue',
-    //   code: '<template><div><input></input></div></template>',
-    //   output: '<template><div><input></template>',
-    //   errors: ["'<input>' should not have end tag."]
-    // },
     {
       filename: 'test.vue',
       code: '<template><div><div></div></template>',

--- a/tests/lib/rules/html-self-closing.js
+++ b/tests/lib/rules/html-self-closing.js
@@ -65,7 +65,11 @@ tester.run('html-self-closing', rule, {
       code: '<template><div><!-- comment --></div></template>',
       output: null,
       options: [{ html: { normal: 'always' }}]
-    }
+    },
+
+    // Invalid EOF
+    '<template><div a=">test</div></template>',
+    '<template><div><!--test</div></template>'
 
     // other cases are in `invalid` tests.
   ],


### PR DESCRIPTION
This PR fixes #268 and some similar cases:

- [Case 1](https://mysticatea.github.io/vue-eslint-demo/#eyJjb2RlIjoiPHRlbXBsYXRlPlxuICA8ZGl2PjwhLS1cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuIiwicnVsZXMiOnsidnVlL2h0bWwtZW5kLXRhZ3MiOjIsInZ1ZS9uby1wYXJzaW5nLWVycm9yIjoyfX0=)
- [Case 2](https://mysticatea.github.io/vue-eslint-demo/#eyJjb2RlIjoiPHRlbXBsYXRlPlxuICA8ZGl2PlxuICAgIDxzdmc+XG4gICAgICA8IVtDREFUQVt0ZXN0XG4gIDwvZGl2PlxuPC90ZW1wbGF0ZT5cbiIsInJ1bGVzIjp7InZ1ZS9odG1sLWVuZC10YWdzIjoyLCJ2dWUvbm8tcGFyc2luZy1lcnJvciI6Mn19)
- [Case 3](https://mysticatea.github.io/vue-eslint-demo/#eyJjb2RlIjoiPHRlbXBsYXRlPlxuICA8ZGl2PlxuICAgIDwhLS1cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuIiwicnVsZXMiOnsidnVlL2h0bWwtZW5kLXRhZ3MiOjIsInZ1ZS9uby1wYXJzaW5nLWVycm9yIjoyfX0=)
- [Case 4](https://mysticatea.github.io/vue-eslint-demo/#eyJjb2RlIjoiPHRlbXBsYXRlPlxuICA8ZGl2PlxuICAgIDwhLS1cbiAgPC9kaXY+XG48L3RlbXBsYXRlPlxuIiwicnVsZXMiOnsidnVlL2h0bWwtc2VsZi1jbG9zaW5nIjoyLCJ2dWUvbm8tcGFyc2luZy1lcnJvciI6Mn19)

I.e. some rules are confused in invalid EOF. This PR fixes some rules to not report errors if the code has invalid EOF.