### PR TITLE
[Update] Make `vue/no-shared-component-data` fixable

### DIFF
--- a/lib/rules/no-shared-component-data.js
+++ b/lib/rules/no-shared-component-data.js
@@ -6,10 +6,16 @@
 
 const utils = require('../utils')
 
+function isOpenParen (token) {
+  return token.type === 'Punctuator' && token.value === '('
+}
+
+function isCloseParen (token) {
+  return token.type === 'Punctuator' && token.value === ')'
+}
+
 function create (context) {
-  // ----------------------------------------------------------------------
-  // Public
-  // ----------------------------------------------------------------------
+  const sourceCode = context.getSourceCode()
 
   return utils.executeOnVueComponent(context, (obj) => {
     obj.properties
@@ -21,10 +27,33 @@ function create (context) {
         p.value.type !== 'ArrowFunctionExpression' &&
         p.value.type !== 'Identifier'
       )
-      .forEach(cp => {
+      .forEach(p => {
         context.report({
-          node: cp.value,
-          message: '`data` property in component must be a function'
+          node: p,
+          message: '`data` property in component must be a function',
+          fix (fixer) {
+            let first = sourceCode.getFirstToken(p.value)
+            let last = sourceCode.getLastToken(p.value)
+
+            // If the value enclosed by parentheses, update the 'first' and 'last' by the parentheses.
+            let t = null
+            let u = null
+            while (isOpenParen(t = sourceCode.getTokenBefore(first)) && isCloseParen(u = sourceCode.getTokenAfter(last))) {
+              first = t
+              last = u
+            }
+
+            // If we can upgrade requirements to `eslint@>4.1.0`, this code can be replaced by:
+            //     return [
+            //       fixer.insertTextBefore(first, 'function() {\nreturn '),
+            //       fixer.insertTextAfter(last, ';\n}')
+            //     ]
+            // See: https://eslint.org/blog/2017/06/eslint-v4.1.0-released#applying-multiple-autofixes-simultaneously
+            const range = [first.range[0], last.range[1]]
+            const valueText = sourceCode.text.slice(range[0], range[1])
+            const replacement = `function() {\nreturn ${valueText};\n}`
+            return fixer.replaceTextRange(range, replacement)
+          }
         })
       })
   })
@@ -40,7 +69,7 @@ module.exports = {
       description: "enforce component's data property to be a function",
       category: 'essential'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: 'code',
     schema: []
   },
 

--- a/lib/rules/no-shared-component-data.js
+++ b/lib/rules/no-shared-component-data.js
@@ -14,6 +14,23 @@ function isCloseParen (token) {
   return token.type === 'Punctuator' && token.value === ')'
 }
 
+function getFirstAndLastTokens (node, sourceCode) {
+  let first = sourceCode.getFirstToken(node)
+  let last = sourceCode.getLastToken(node)
+
+  // If the value enclosed by parentheses, update the 'first' and 'last' by the parentheses.
+  while (true) {
+    const prev = sourceCode.getTokenBefore(first)
+    const next = sourceCode.getTokenAfter(last)
+    if (isOpenParen(prev) && isCloseParen(next)) {
+      first = prev
+      last = next
+    } else {
+      return { first, last }
+    }
+  }
+}
+
 function create (context) {
   const sourceCode = context.getSourceCode()
 
@@ -32,24 +49,15 @@ function create (context) {
           node: p,
           message: '`data` property in component must be a function',
           fix (fixer) {
-            let first = sourceCode.getFirstToken(p.value)
-            let last = sourceCode.getLastToken(p.value)
-
-            // If the value enclosed by parentheses, update the 'first' and 'last' by the parentheses.
-            let t = null
-            let u = null
-            while (isOpenParen(t = sourceCode.getTokenBefore(first)) && isCloseParen(u = sourceCode.getTokenAfter(last))) {
-              first = t
-              last = u
-            }
+            const tokens = getFirstAndLastTokens(p.value, sourceCode)
 
             // If we can upgrade requirements to `eslint@>4.1.0`, this code can be replaced by:
             //     return [
-            //       fixer.insertTextBefore(first, 'function() {\nreturn '),
-            //       fixer.insertTextAfter(last, ';\n}')
+            //       fixer.insertTextBefore(tokens.first, 'function() {\nreturn '),
+            //       fixer.insertTextAfter(tokens.last, ';\n}')
             //     ]
             // See: https://eslint.org/blog/2017/06/eslint-v4.1.0-released#applying-multiple-autofixes-simultaneously
-            const range = [first.range[0], last.range[1]]
+            const range = [tokens.first.range[0], tokens.last.range[1]]
             const valueText = sourceCode.text.slice(range[0], range[1])
             const replacement = `function() {\nreturn ${valueText};\n}`
             return fixer.replaceTextRange(range, replacement)

--- a/tests/lib/rules/no-shared-component-data.js
+++ b/tests/lib/rules/no-shared-component-data.js
@@ -130,6 +130,15 @@ ruleTester.run('no-shared-component-data', rule, {
           }
         })
       `,
+      output: `
+        Vue.component('some-comp', {
+          data: function() {
+return {
+            foo: 'bar'
+          };
+}
+        })
+      `,
       parserOptions,
       errors: [{
         message: '`data` property in component must be a function',
@@ -143,6 +152,39 @@ ruleTester.run('no-shared-component-data', rule, {
           data: {
             foo: 'bar'
           }
+        }
+      `,
+      output: `
+        export default {
+          data: function() {
+return {
+            foo: 'bar'
+          };
+}
+        }
+      `,
+      parserOptions,
+      errors: [{
+        message: '`data` property in component must be a function',
+        line: 3
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          data: /*a*/ (/*b*/{
+            foo: 'bar'
+          })
+        }
+      `,
+      output: `
+        export default {
+          data: /*a*/ function() {
+return (/*b*/{
+            foo: 'bar'
+          });
+}
         }
       `,
       parserOptions,


### PR DESCRIPTION
This PR makes `vue/no-shared-component-data` fixable. The autofix wraps the `data` property's value by a function expression.

At first glance, the unit tests make wrong indentations, but this is intentional. This strategy is same as core rules; one rule does one thing. A combination of rules will make correct autofix.

![image](https://user-images.githubusercontent.com/1937871/33514999-327b146e-d7a0-11e7-88a8-f069bc437bbd.png)
