### PR TITLE
Fix: html-indent about binary expressions (fixes #264)

### DIFF
--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -388,12 +388,19 @@ function create (context) {
   }
 
   /**
-   * Check whether a given token is the first token of a statement.
+   * Check whether a given token is the first token of:
+   *
+   * - ExpressionStatement
+   * - VExpressionContainer
+   * - A parameter of CallExpression/NewExpression
+   * - An element of ArrayExpression
+   * - An expression of SequenceExpression
+   *
    * @param {Token} token The token to check.
    * @param {Node} belongingNode The node that the token is belonging to.
-   * @returns {boolean} `true` if the token is the first token of a statement.
+   * @returns {boolean} `true` if the token is the first token of an element.
    */
-  function isFirstOfStatement (token, belongingNode) {
+  function isBeginningOfElement (token, belongingNode) {
     let node = belongingNode
 
     while (node != null) {
@@ -404,6 +411,23 @@ function create (context) {
       }
       if (t === 'VExpressionContainer') {
         return node.range[0] === token.range[0]
+      }
+      if (t === 'CallExpression' || t === 'NewExpression') {
+        const openParen = template.getTokenAfter(parent.callee, isNotRightParen)
+        return parent.arguments.some(param =>
+          getFirstAndLastTokens(param, openParen.range[1]).firstToken.range[0] === token.range[0]
+        )
+      }
+      if (t === 'ArrayExpression') {
+        return parent.elements.some(element =>
+          element != null &&
+          getFirstAndLastTokens(element).firstToken.range[0] === token.range[0]
+        )
+      }
+      if (t === 'SequenceExpression') {
+        return parent.expressions.some(expr =>
+          getFirstAndLastTokens(expr).firstToken.range[0] === token.range[0]
+        )
       }
 
       node = parent
@@ -751,7 +775,7 @@ function create (context) {
       const shouldIndent = (
         prevToken == null ||
         prevToken.loc.end.line === leftToken.loc.start.line ||
-        isFirstOfStatement(leftToken, node)
+        isBeginningOfElement(leftToken, node)
       )
 
       setOffset([opToken, rightToken], shouldIndent ? 1 : 0, leftToken)

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -388,6 +388,31 @@ function create (context) {
   }
 
   /**
+   * Check whether a given token is the first token of a statement.
+   * @param {Token} token The token to check.
+   * @param {Node} belongingNode The node that the token is belonging to.
+   * @returns {boolean} `true` if the token is the first token of a statement.
+   */
+  function isFirstOfStatement (token, belongingNode) {
+    let node = belongingNode
+
+    while (node != null) {
+      const parent = node.parent
+      const t = parent && parent.type
+      if (t != null && (t.endsWith('Statement') || t.endsWith('Declaration'))) {
+        return parent.range[0] === token.range[0]
+      }
+      if (t === 'VExpressionContainer') {
+        return node.range[0] === token.range[0]
+      }
+
+      node = parent
+    }
+
+    return false
+  }
+
+  /**
    * Ignore all tokens of the given node.
    * @param {Node} node The node to ignore.
    * @returns {void}
@@ -722,8 +747,14 @@ function create (context) {
       const leftToken = getChainHeadToken(node)
       const opToken = template.getTokenAfter(node.left, isNotRightParen)
       const rightToken = template.getTokenAfter(opToken)
+      const prevToken = template.getTokenBefore(leftToken)
+      const shouldIndent = (
+        prevToken == null ||
+        prevToken.loc.end.line === leftToken.loc.start.line ||
+        isFirstOfStatement(leftToken, node)
+      )
 
-      setOffset([opToken, rightToken], 1, leftToken)
+      setOffset([opToken, rightToken], shouldIndent ? 1 : 0, leftToken)
     },
 
     'AwaitExpression, RestElement, SpreadElement, UnaryExpression' (node) {

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -1342,6 +1342,91 @@ tester.run('html-indent', rule, {
           }"
         />
       </template>
+    `,
+    unIndent`
+      <template>
+        <div
+          :class="
+            [
+              a
+                +
+                b,
+              c
+                +
+                d
+            ]
+          "
+        />
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div
+          :class="
+            foo(
+              a
+                +
+                b,
+              c
+                +
+                d
+            )
+          "
+        />
+        <div
+          :class="
+            new Foo(
+              a
+                +
+                b,
+              c
+                +
+                d
+            )
+          "
+        />
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div
+          :class="
+            a
+              +
+              b,
+            c
+              +
+              d
+          "
+        />
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div
+          :class="
+            foo(
+              a
+                +
+                b
+            )
+          "
+        />
+        <div
+          :class="
+            foo(
+              (
+                a +
+                b
+              ),
+              (
+                c +
+                d
+              )
+            )
+          "
+        />
+      </template>
     `
   ],
 

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -255,10 +255,10 @@ tester.run('html-indent', rule, {
             a
               =
               b
-                +
-                c
-                +
-                d
+              +
+              c
+              +
+              d
           "
         ></div>
       </template>
@@ -1307,7 +1307,42 @@ tester.run('html-indent', rule, {
         // Ignore all :D
         ignores: ['*']
       }]
-    }
+    },
+
+    // https://github.com/vuejs/eslint-plugin-vue/issues/264
+    unIndent`
+      <template>
+        <div
+          :class="{
+            foo: (
+              a === b &&
+              c === d
+            )
+          }"
+        />
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div
+          :class="{
+            foo:
+              a === b &&
+              c === d
+          }"
+        />
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div
+          :class="{
+            foo: a === b &&
+              c === d
+          }"
+        />
+      </template>
+    `
   ],
 
   invalid: [
@@ -1779,10 +1814,10 @@ tester.run('html-indent', rule, {
                     a
                         =
                         b
-                            +
-                            c
-                            +
-                            d
+                        +
+                        c
+                        +
+                        d
                 "
             ></div>
         </template>
@@ -1800,10 +1835,10 @@ tester.run('html-indent', rule, {
         { message: 'Expected indentation of 12 spaces but found 10 spaces.', line: 16 },
         { message: 'Expected indentation of 16 spaces but found 10 spaces.', line: 17 },
         { message: 'Expected indentation of 16 spaces but found 10 spaces.', line: 18 },
-        { message: 'Expected indentation of 20 spaces but found 10 spaces.', line: 19 },
-        { message: 'Expected indentation of 20 spaces but found 10 spaces.', line: 20 },
-        { message: 'Expected indentation of 20 spaces but found 10 spaces.', line: 21 },
-        { message: 'Expected indentation of 20 spaces but found 10 spaces.', line: 22 }
+        { message: 'Expected indentation of 16 spaces but found 10 spaces.', line: 19 },
+        { message: 'Expected indentation of 16 spaces but found 10 spaces.', line: 20 },
+        { message: 'Expected indentation of 16 spaces but found 10 spaces.', line: 21 },
+        { message: 'Expected indentation of 16 spaces but found 10 spaces.', line: 22 }
       ]
     },
 


### PR DESCRIPTION
Fixes #264.

This PR fixes `vue/html-indent` rule about the indentation of binary expressions.

Before, the second line of binary expressions always has 1 indent from the first line.
After this PR, the second line of binary expressions has the same indentation as the first line in *except* the following cases:

- The first token of the binary expression is on the same line as the previous token.
    ```js
    {
      foo: a
        + b
    }
    ```
- The first token of the binary expression is the first token of the statement.
    ```js
    a
        + b
    ```

EDIT: additionally:

- The first token of the binary expression is the first token of an argument of `CallExpression`/`NewExpression`.
    ```js
    foo(
        a
            + b,
        c
            + d
    )
    ```
- The first token of the binary expression is the first token of an element of `ArrayExpression`.
    ```js
    [
        a
            + b,
        c
            + d
    ]
    ```
- The first token of the binary expression is the first token of an expression of `SequenceExpression`.
    ```js
    (
        a
            + b,
        c
            + d
    )
    ```
