### PR TITLE
Fix html-self-closing example json

### DIFF
--- a/docs/rules/html-self-closing.md
+++ b/docs/rules/html-self-closing.md
@@ -16,7 +16,7 @@ This rule has options which specify self-closing style for each context.
 
 ```json
 {
-  "html-self-closing": ["error", {
+  "vue/html-self-closing": ["error", {
     "html": {
       "void": "never",
       "normal": "always",


### PR DESCRIPTION
`vue/html-self-closing` must be used as a key in the eslint config to
make it work correctly. Also this is consitent with the example json for
other rules.