### PR TITLE
chore(package): Swap out `requireindex`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,16 @@
 'use strict'
 
 const resolve = require('path').resolve
-const requireIndex = require('requireindex')
+const requireAll = require('require-all')
 
-const rules = requireIndex(resolve(__dirname, 'rules'))
-const configs = requireIndex(resolve(__dirname, 'config'))
+const rules = requireAll({
+  dirname: resolve(__dirname, 'rules'),
+  filter: /^([\w\-]+)\.js$/
+})
+const configs = requireAll({
+  dirname: resolve(__dirname, 'config'),
+  filter: /^([\w\-]+)\.js$/
+})
 
 module.exports = {
   rules,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "^3.18.0 || ^4.0.0"
   },
   "dependencies": {
-    "requireindex": "^1.1.0",
+    "require-all": "^2.2.0",
     "vue-eslint-parser": "^2.0.1-beta.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Swap out `requireindex` dependency with the more recently updated
dependency `require-all`. The old dependency uses deprecated API that
breaks when running in a Jest testing environment.

Fixes #290