### PR TITLE
[Fixes #293] Update indent rule

### DIFF
--- a/docs/rules/html-indent.md
+++ b/docs/rules/html-indent.md
@@ -35,7 +35,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
     Hello.
   </div>
   <div class="foo"
-    :foo="bar"
+       :foo="bar"
   >
     World.
   </div>
@@ -65,6 +65,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
   "vue/html-indent": ["error", type, {
     "attribute": 1,
     "closeBracket": 0,
+    "alignAttributesVertically": true,
     "ignores": []
   }]
 }
@@ -73,6 +74,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 - `type` (`number | "tab"`) ... The type of indentation. Default is `2`. If this is a number, it's the number of spaces for one indent. If this is `"tab"`, it uses one tab for one indent.
 - `attribute` (`integer`) ... The multiplier of indentation for attributes. Default is `1`.
 - `closeBracket` (`integer`) ... The multiplier of indentation for right brackets. Default is `0`.
+- `alignAttributesVertically` (`boolean`) ... Condition for whether attributes should be vertically aligned to the first attribute in multiline case or not. Default is `true`
 - `ignores` (`string[]`) ... The selector to ignore nodes. The AST spec is [here](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md). You can use [esquery](https://github.com/estools/esquery#readme) to select nodes. Default is an empty array.
 
 :+1: Examples of **correct** code for `{attribute: 1, closeBracket: 1}`:
@@ -116,6 +118,28 @@ This rule enforces a consistent indentation style in `<template>`. The default s
   <div
   id=""
     class=""
+  />
+</template>
+```
+
+:+1: Examples of **correct** code for `{alignAttributesVertically: true}`:
+
+```html
+<template>
+  <div id=""
+       class=""
+       some-attr=""
+  />
+</template>
+```
+
+:+1: Examples of **correct** code for `{alignAttributesVertically: false}`:
+
+```html
+<template>
+  <div id=""
+    class=""
+    some-attr=""
   />
 </template>
 ```

--- a/docs/rules/html-indent.md
+++ b/docs/rules/html-indent.md
@@ -23,33 +23,38 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ```html
 <template>
-    <div class="foo">
-        Hello.
-    </div>
+  <div class="foo">
+    Hello.
+  </div>
 </template>
 ```
 
 ```html
 <template>
-    <div class="foo">
-        Hello.
-    </div>
-    <div
-        id="a"
-        class="b"
-        :other-attr="{
-            aaa: 1,
-            bbb: 2
-        }"
-        @other-attr2="
-            foo();
-            bar();
-        "
-    >
-        {{
-            displayMessage
-        }}
-    </div>
+  <div class="foo">
+    Hello.
+  </div>
+  <div class="foo"
+    :foo="bar"
+  >
+    World.
+  </div>
+  <div
+    id="a"
+    class="b"
+    :other-attr="{
+      aaa: 1,
+      bbb: 2
+    }"
+    @other-attr2="
+      foo();
+      bar();
+    "
+  >
+    {{
+      displayMessage
+    }}
+  </div>
 </template>
 ```
 
@@ -57,11 +62,11 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ```json
 {
-    "vue/html-indent": ["error", type, {
-        "attribute": 1,
-        "closeBracket": 0,
-        "ignores": []
-    }]
+  "vue/html-indent": ["error", type, {
+    "attribute": 1,
+    "closeBracket": 0,
+    "ignores": []
+  }]
 }
 ```
 
@@ -74,16 +79,16 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ```html
 <template>
-    <div
-        id="a"
-        class="b"
-        other-attr=
-            "{longname: longvalue}"
-        other-attr2
-            ="{longname: longvalue}"
-        >
-        Text
-    </div>
+  <div
+    id="a"
+    class="b"
+    other-attr=
+      "{longname: longvalue}"
+    other-attr2
+      ="{longname: longvalue}"
+    >
+    Text
+  </div>
 </template>
 ```
 
@@ -91,16 +96,16 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ```html
 <template>
-    <div
-            id="a"
-            class="b"
-            other-attr=
-                "{longname: longvalue}"
-            other-attr2
-                ="{longname: longvalue}"
-        >
-        Text
-    </div>
+  <div
+      id="a"
+      class="b"
+      other-attr=
+        "{longname: longvalue}"
+      other-attr2
+        ="{longname: longvalue}"
+    >
+    Text
+  </div>
 </template>
 ```
 
@@ -108,9 +113,9 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ```html
 <template>
-    <div
-    id=""
-      class=""
-    />
+  <div
+  id=""
+    class=""
+  />
 </template>
 ```

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -308,7 +308,7 @@ function create (context) {
    * @param {number} offset The offset to set.
    * @returns {void}
    */
-  function processNodeList (nodeList, leftToken, rightToken, offset, rootNode) {
+  function processNodeList (nodeList, leftToken, rightToken, offset, alignVertically = true) {
     let t
 
     if (nodeList.length >= 1) {
@@ -358,13 +358,14 @@ function create (context) {
           setBaseline(baseToken)
         }
 
-        if (!options.alignAttributesVertically && rootNode) {
-          // Align tokens relatively to passed root node
-          // So it's possible to force proper position for VAttributes
-          setOffset(alignTokens, offset, template.getFirstToken(rootNode))
-        } else {
+        if (alignVertically) {
           // Align the rest tokens to the first token.
           setOffset(alignTokens, 0, baseToken)
+        } else {
+          // Align tokens relatively to passed root node
+          // So it's possible to force proper position for VAttributes
+          const rootNode = nodeList && nodeList[0].parent
+          setOffset(alignTokens, offset, template.getFirstToken(rootNode))
         }
       }
     }
@@ -772,7 +773,7 @@ function create (context) {
       const openToken = template.getFirstToken(node)
       const closeToken = template.getLastToken(node)
 
-      processNodeList(node.attributes, openToken, null, options.attribute, node)
+      processNodeList(node.attributes, openToken, null, options.attribute, options.alignAttributesVertically)
       if (closeToken != null && closeToken.type.endsWith('TagClose')) {
         setOffset(closeToken, options.closeBracket, openToken)
       }

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -34,6 +34,7 @@ function parseOptions (type, options) {
     attribute: 1,
     closeBracket: 0,
     switchCase: 0,
+    alignAttributesVertically: true,
     ignores: []
   }
 
@@ -52,6 +53,9 @@ function parseOptions (type, options) {
   }
   if (Number.isSafeInteger(options.switchCase)) {
     ret.switchCase = options.switchCase
+  }
+  if (options.alignAttributesVertically != null) {
+    ret.alignAttributesVertically = options.alignAttributesVertically
   }
   if (options.ignores != null) {
     ret.ignores = options.ignores
@@ -354,7 +358,7 @@ function create (context) {
           setBaseline(baseToken)
         }
 
-        if (rootNode) {
+        if (!options.alignAttributesVertically && rootNode) {
           // Align tokens relatively to passed root node
           // So it's possible to force proper position for VAttributes
           setOffset(alignTokens, offset, template.getFirstToken(rootNode))
@@ -1302,6 +1306,7 @@ module.exports = {
           'attribute': { type: 'integer', minimum: 0 },
           'closeBracket': { type: 'integer', minimum: 0 },
           'switchCase': { type: 'integer', minimum: 0 },
+          'alignAttributesVertically': { type: 'boolean' },
           'ignores': {
             type: 'array',
             items: {

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -304,7 +304,7 @@ function create (context) {
    * @param {number} offset The offset to set.
    * @returns {void}
    */
-  function processNodeList (nodeList, leftToken, rightToken, offset) {
+  function processNodeList (nodeList, leftToken, rightToken, offset, rootNode) {
     let t
 
     if (nodeList.length >= 1) {
@@ -349,11 +349,19 @@ function create (context) {
           setOffset(baseToken, offset, leftToken)
         }
 
-        // Align the rest tokens to the first token.
+        // Set baseline
         if (nodeList.some(isBeginningOfLine)) {
           setBaseline(baseToken)
         }
-        setOffset(alignTokens, 0, baseToken)
+
+        if (rootNode) {
+          // Align tokens relatively to passed root node
+          // So it's possible to force proper position for VAttributes
+          setOffset(alignTokens, offset, template.getFirstToken(rootNode))
+        } else {
+          // Align the rest tokens to the first token.
+          setOffset(alignTokens, 0, baseToken)
+        }
       }
     }
 
@@ -760,7 +768,7 @@ function create (context) {
       const openToken = template.getFirstToken(node)
       const closeToken = template.getLastToken(node)
 
-      processNodeList(node.attributes, openToken, null, options.attribute)
+      processNodeList(node.attributes, openToken, null, options.attribute, node)
       if (closeToken != null && closeToken.type.endsWith('TagClose')) {
         setOffset(closeToken, options.closeBracket, openToken)
       }

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -308,8 +308,9 @@ function create (context) {
    * @param {number} offset The offset to set.
    * @returns {void}
    */
-  function processNodeList (nodeList, leftToken, rightToken, offset, alignVertically = true) {
+  function processNodeList (nodeList, leftToken, rightToken, offset, alignVertically) {
     let t
+    alignVertically = alignVertically != null ? alignVertically : true
 
     if (nodeList.length >= 1) {
       let lastToken = leftToken

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -90,14 +90,14 @@ tester.run('html-indent', rule, {
     unIndent`
       <template>
         <div a="a"
-             b="b"
-             c=
-               "c"
-             d
-               ="d"
-             e
-             f
-               =
+          b="b"
+          c=
+            "c"
+          d
+            ="d"
+          e
+          f
+            =
         ></div>
       </template>
     `,
@@ -1466,6 +1466,28 @@ tester.run('html-indent', rule, {
             )
           "
         />
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div a="a"
+          :b="b"
+          c="c"
+        ></div>
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div
+          a="a"
+          b="b"
+        ></div>
+      </template>
+    `,
+    unIndent`
+      <template>
+        <div a="a" b="b">
+        </div>
       </template>
     `
   ],

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -1542,6 +1542,40 @@ tester.run('html-indent', rule, {
         { message: 'Expected indentation of 12 spaces but found 10 spaces.', line: 11 }
       ]
     },
+    {
+      code: unIndent`
+        <template>
+            <div a="a"
+                b="b"
+                c=
+                    "c"
+            >
+                Text
+            </div>
+        </template>
+      `,
+      output: unIndent`
+        <template>
+          <div a="a"
+            b="b"
+            c=
+              "c"
+          >
+            Text
+          </div>
+        </template>
+      `,
+      options: [2],
+      errors: [
+        { message: 'Expected indentation of 2 spaces but found 4 spaces.', line: 2 },
+        { message: 'Expected indentation of 4 spaces but found 8 spaces.', line: 3 },
+        { message: 'Expected indentation of 4 spaces but found 8 spaces.', line: 4 },
+        { message: 'Expected indentation of 6 spaces but found 12 spaces.', line: 5 },
+        { message: 'Expected indentation of 2 spaces but found 4 spaces.', line: 6 },
+        { message: 'Expected indentation of 4 spaces but found 8 spaces.', line: 7 },
+        { message: 'Expected indentation of 2 spaces but found 4 spaces.', line: 8 }
+      ]
+    },
 
     // VEndTag
     {

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -90,14 +90,14 @@ tester.run('html-indent', rule, {
     unIndent`
       <template>
         <div a="a"
-          b="b"
-          c=
-            "c"
-          d
-            ="d"
-          e
-          f
-            =
+             b="b"
+             c=
+               "c"
+             d
+               ="d"
+             e
+             f
+               =
         ></div>
       </template>
     `,
@@ -1269,6 +1269,40 @@ tester.run('html-indent', rule, {
       options: [4, { switchCase: 1 }]
     },
 
+    // options.alignAttributesVertically
+    {
+      code: unIndent`
+        <template>
+          <div a="a"
+            b="b"
+            c=
+              "c"
+            d
+              ="d"
+            e
+            f
+              =
+          ></div>
+        </template>
+      `,
+      options: [2, {
+        alignAttributesVertically: false
+      }]
+    },
+    {
+      code: unIndent`
+        <template>
+          <div a="a"
+            :b="b"
+            c="c"
+          ></div>
+        </template>
+      `,
+      options: [2, {
+        alignAttributesVertically: false
+      }]
+    },
+
     // Comments
     unIndent`
       <template>
@@ -1471,8 +1505,8 @@ tester.run('html-indent', rule, {
     unIndent`
       <template>
         <div a="a"
-          :b="b"
-          c="c"
+             :b="b"
+             c="c"
         ></div>
       </template>
     `,
@@ -1557,6 +1591,40 @@ tester.run('html-indent', rule, {
       output: unIndent`
         <template>
           <div a="a"
+               b="b"
+               c=
+                 "c"
+          >
+            Text
+          </div>
+        </template>
+      `,
+      options: [2],
+      errors: [
+        { message: 'Expected indentation of 2 spaces but found 4 spaces.', line: 2 },
+        { message: 'Expected indentation of 7 spaces but found 8 spaces.', line: 3 },
+        { message: 'Expected indentation of 7 spaces but found 8 spaces.', line: 4 },
+        { message: 'Expected indentation of 9 spaces but found 12 spaces.', line: 5 },
+        { message: 'Expected indentation of 2 spaces but found 4 spaces.', line: 6 },
+        { message: 'Expected indentation of 4 spaces but found 8 spaces.', line: 7 },
+        { message: 'Expected indentation of 2 spaces but found 4 spaces.', line: 8 }
+      ]
+    },
+    {
+      code: unIndent`
+        <template>
+            <div a="a"
+                b="b"
+                c=
+                    "c"
+            >
+                Text
+            </div>
+        </template>
+      `,
+      output: unIndent`
+        <template>
+          <div a="a"
             b="b"
             c=
               "c"
@@ -1565,7 +1633,9 @@ tester.run('html-indent', rule, {
           </div>
         </template>
       `,
-      options: [2],
+      options: [2, {
+        alignAttributesVertically: false
+      }],
       errors: [
         { message: 'Expected indentation of 2 spaces but found 4 spaces.', line: 2 },
         { message: 'Expected indentation of 4 spaces but found 8 spaces.', line: 3 },


### PR DESCRIPTION
As pointed in #293 currently indent rule requires attributes to be aligned as the first one:
```html
<div id="foo"
     class="abc"
     style="font-color: red;"
>
</div>
```

It's not that common I think, and most people prefer to use it like this:
```html
<div id="foo"
  class="abc"
  style="font-color: red;"
>
</div>
```

This PR updates indent rule to force the second version.

Though I'm thinking whether we shouldn't add an optional setting to make it possible to align to the first token if needed.

What do you think guys? @mysticatea @chrisvfritz 
