### PR TITLE
[Fixes #294] Fix no-unused-vars rule

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -8,9 +8,9 @@ This rule report variable definitions of v-for directives or scope attributes if
 
 ```html
 <template>
-    <ol v-for="i in 5"><!-- "i" is defined but never used. -->
-        <li>item</li>
-    </ol>
+  <ol v-for="i in 5"><!-- "i" is defined but never used. -->
+    <li>item</li>
+  </ol>
 </template>
 ```
 
@@ -18,9 +18,9 @@ This rule report variable definitions of v-for directives or scope attributes if
 
 ```html
 <template>
-    <ol v-for="i in 5">
-        <li>{{i}}</li><!-- "i" is defined and used. -->
-    </ol>
+  <ol v-for="i in 5">
+    <li>{{i}}</li><!-- "i" is defined and used. -->
+  </ol>
 </template>
 ```
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -15,18 +15,20 @@ const utils = require('../utils')
 function create (context) {
   return utils.defineTemplateBodyVisitor(context, {
     VElement (node) {
-      const lastVariable = node.variables.slice(-1)[0]
-      if (!lastVariable || lastVariable.references.length) return
+      const { variables } = node
 
-      for (const variable of node.variables) {
-        if (variable.references.length === 0) {
-          context.report({
-            node: variable.id,
-            loc: variable.id.loc,
-            message: `'{{name}}' is defined but never used.`,
-            data: variable.id
-          })
-        }
+      for (
+        let i = variables.length - 1;
+        i >= 0 && !variables[i].references.length;
+        i--
+      ) {
+        const variable = variables[i]
+        context.report({
+          node: variable.id,
+          loc: variable.id.loc,
+          message: `'{{name}}' is defined but never used.`,
+          data: variable.id
+        })
       }
     }
   })

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -15,7 +15,7 @@ const utils = require('../utils')
 function create (context) {
   return utils.defineTemplateBodyVisitor(context, {
     VElement (node) {
-      const { variables } = node
+      const variables = node.variables
 
       for (
         let i = variables.length - 1;

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -15,6 +15,9 @@ const utils = require('../utils')
 function create (context) {
   return utils.defineTemplateBodyVisitor(context, {
     VElement (node) {
+      const lastVariable = node.variables.slice(-1)[0]
+      if (!lastVariable || lastVariable.references.length) return
+
       for (const variable of node.variables) {
         if (variable.references.length === 0) {
           context.report({

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -66,12 +66,16 @@ tester.run('no-unused-vars', rule, {
       errors: ["'f' is defined but never used."]
     },
     {
-      code: '<template><div v-for="(v, i, c) in foo"></div></template>',
-      errors: ["'v' is defined but never used.", "'i' is defined but never used.", "'c' is defined but never used."]
+      code: '<template><div v-for="(a, b, c) in foo"></div></template>',
+      errors: ["'a' is defined but never used.", "'b' is defined but never used.", "'c' is defined but never used."]
     },
     {
-      code: '<template><div v-for="(v, i, c) in foo">{{i}}</div></template>',
-      errors: ["'v' is defined but never used.", "'c' is defined but never used."]
+      code: '<template><div v-for="(a, b, c) in foo">{{a}}</div></template>',
+      errors: ["'b' is defined but never used.", "'c' is defined but never used."]
+    },
+    {
+      code: '<template><div v-for="(a, b, c) in foo">{{b}}</div></template>',
+      errors: ["'c' is defined but never used."]
     },
     {
       code: '<template><div v-for="(item, key) in items" :key="item.id">{{item.name}}</div></template>',

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -40,28 +40,42 @@ tester.run('no-unused-vars', rule, {
     },
     {
       code: '<template scope="props"><span v-if="props"></span></template>'
+    },
+    {
+      code: '<template><div v-for="(item, key) in items" :key="key">{{item.name}}</div></template>'
+    },
+    {
+      code: '<template><div v-for="(v, i, c) in foo">{{c}}</div></template>'
     }
   ],
   invalid: [
     {
       code: '<template><ol v-for="i in 5"><li></li></ol></template>',
-      errors: ['\'i\' is defined but never used.']
+      errors: ["'i' is defined but never used."]
     },
     {
       code: '<template scope="props"></template>',
-      errors: ['\'props\' is defined but never used.']
+      errors: ["'props' is defined but never used."]
     },
     {
       code: '<template v-for="i in 5"><comp v-for="j in 10">{{i}}{{i}}</comp></template>',
-      errors: ['\'j\' is defined but never used.']
+      errors: ["'j' is defined but never used."]
     },
     {
       code: '<template><ol v-for="i in data"><li v-for="f in i"></li></ol></template>',
-      errors: ['\'f\' is defined but never used.']
+      errors: ["'f' is defined but never used."]
     },
     {
       code: '<template><div v-for="(v, i, c) in foo"></div></template>',
-      errors: ['\'v\' is defined but never used.', '\'i\' is defined but never used.', '\'c\' is defined but never used.']
+      errors: ["'v' is defined but never used.", "'i' is defined but never used.", "'c' is defined but never used."]
+    },
+    {
+      code: '<template><div v-for="(v, i, c) in foo">{{i}}</div></template>',
+      errors: ["'v' is defined but never used.", "'c' is defined but never used."]
+    },
+    {
+      code: '<template><div v-for="(item, key) in items" :key="item.id">{{item.name}}</div></template>',
+      errors: ["'key' is defined but never used."]
     }
   ]
 })


### PR DESCRIPTION
This PR fixes `no-unused-vars` rule, so it doesn't throw a warning, when some of the properties are not used even when the last property was used.

As pointed in #294 currently code like this throws warnings:
```html
<template>
  <!-- 'v'  is defined but never used, 'i' ..., 'c' ... -->
  <div v-for="(v, i, c) in foo">{{c}}</div>
</template>
```

In this PR I'm checking if the last property was referenced anywhere. If yes then we simply ignore other properties, if not -> we check references of all properties as before.