### PR TITLE
[Fixes #300] Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 |  | [no-duplicate-attributes](./docs/rules/no-duplicate-attributes.md) | disallow duplication of attributes |
 |  | [no-parsing-error](./docs/rules/no-parsing-error.md) | disallow parsing errors in `<template>` |
 |  | [no-reserved-keys](./docs/rules/no-reserved-keys.md) | disallow overwriting reserved keys |
-|  | [no-shared-component-data](./docs/rules/no-shared-component-data.md) | enforce component's data property to be a function |
+| :wrench: | [no-shared-component-data](./docs/rules/no-shared-component-data.md) | enforce component's data property to be a function |
 |  | [no-side-effects-in-computed-properties](./docs/rules/no-side-effects-in-computed-properties.md) | disallow side effects in computed properties |
 |  | [no-template-key](./docs/rules/no-template-key.md) | disallow `key` attribute on `<template>` |
 |  | [no-textarea-mustache](./docs/rules/no-textarea-mustache.md) | disallow mustaches in `<textarea>` |
@@ -181,7 +181,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 
 |    | Rule ID | Description |
 |:---|:--------|:------------|
-|  | [html-quotes](./docs/rules/html-quotes.md) | enforce quotes style of HTML attributes |
+| :wrench: | [html-quotes](./docs/rules/html-quotes.md) | enforce quotes style of HTML attributes |
 |  | [no-confusing-v-for-v-if](./docs/rules/no-confusing-v-for-v-if.md) | disallow confusing `v-for` and `v-if` on the same element |
 |  | [order-in-components](./docs/rules/order-in-components.md) | enforce order of properties in components |
 |  | [this-in-template](./docs/rules/this-in-template.md) | enforce usage of `this` in template |

--- a/docs/rules/html-quotes.md
+++ b/docs/rules/html-quotes.md
@@ -1,5 +1,7 @@
 # enforce quotes style of HTML attributes (html-quotes)
 
+- :wrench: The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
 You can choose quotes of HTML attributes from:
 
 - Double quotes: `<div class="foo">`

--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -9,7 +9,7 @@ This rule aims to enforce a number of attributes per line in templates.
 It checks all the elements in a template and verifies that the number of attributes per line does not exceed the defined maximum.
 An attribute is considered to be in a new line when there is a line break between two attributes.
 
-There is a configurable number of attributes that are acceptable in one-line case (default 3), as well as how many attributes are acceptable per line in multi-line case (default 1).
+There is a configurable number of attributes that are acceptable in one-line case (default 1), as well as how many attributes are acceptable per line in multi-line case (default 1).
 
 :-1: Examples of **incorrect** code for this rule:
 
@@ -48,7 +48,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 ```json
 {
   "vue/max-attributes-per-line": [2, {
-    "singleline": 3,
+    "singleline": 1,
     "multiline": {
       "max": 1,
       "allowFirstLine": false

--- a/docs/rules/no-shared-component-data.md
+++ b/docs/rules/no-shared-component-data.md
@@ -1,5 +1,7 @@
 # enforce component's data property to be a function (no-shared-component-data)
 
+- :wrench: The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
 When using the data property on a component (i.e. anywhere except on `new Vue`), the value must be a function that returns an object.
 
 ## :book: Rule Details


### PR DESCRIPTION
This PR:
- updates default settings in `max-attributes-per-line` rule documentation to be aligned with actual implementation and style guide
- updates `no-shared-component-data` and `html-quotes` docs, so it's clear they're also fixable