### PR TITLE
[Fixes #306] Update REGEX in no-side-effects-in-computed-properties

### DIFF
--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -27,7 +27,7 @@ function create (context) {
       // this.xxx.func()
       'CallExpression' (node) {
         const code = context.getSourceCode().getText(node)
-        const MUTATION_REGEX = /(this.)((?!(concat|slice|map|filter)\().)*((push|pop|shift|unshift|reverse|splice|sort|copyWithin|fill)\()/g
+        const MUTATION_REGEX = /(this.)((?!(concat|slice|map|filter)\().)[^\)]*((push|pop|shift|unshift|reverse|splice|sort|copyWithin|fill)\()/g
 
         if (MUTATION_REGEX.test(code)) {
           forbiddenNodes.push(node)

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -73,6 +73,14 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
                 test: 'example'
               }
             }
+          },
+          test9() {
+            return Object.keys(this.a).sort()
+          },
+          test10: {
+            get() {
+              return Object.keys(this.a).sort()
+            }
           }
         }
       })`,
@@ -144,6 +152,9 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             this.something[index] = thing[index]
             return this.something
           },
+          test6() {
+            return this.something.keys.sort()
+          }
         }
       })`,
       parserOptions,
@@ -165,6 +176,9 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       }, {
         line: 21,
         message: 'Unexpected side effect in "test5" computed property.'
+      }, {
+        line: 25,
+        message: 'Unexpected side effect in "test6" computed property.'
       }]
     },
     {


### PR DESCRIPTION
This PR updates REGEX to check whether `this.xxx` haven't been used as an argument in an expression. If yes - don't throw a warning.