### PR TITLE
[Fixes #319] Add Vue.extend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ module.exports = {
 All component-related rules are being applied to code that passes any of the following checks:
 
 * `Vue.component()` expression
+* `Vue.extend()` expression
+* `Vue.mixin()` expression
 * `export default {}` in `.vue` or `.jsx` file
 
 If you however want to take advantage of our rules in any of your custom objects that are Vue components, you might need to use special comment `// @vue/component` that marks object in the next line as a Vue component in any file, e.g.:

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -384,7 +384,7 @@ module.exports = {
       callee.object.type === 'Identifier' &&
       callee.object.name === 'Vue' &&
       callee.property.type === 'Identifier' &&
-      (callee.property.name === 'component' || callee.property.name === 'mixin') &&
+      ['component', 'mixin', 'extend'].indexOf(callee.property.name) > -1 &&
       node.arguments.length &&
       node.arguments.slice(-1)[0].type === 'ObjectExpression'
 

--- a/tests/lib/utils/vue-component.js
+++ b/tests/lib/utils/vue-component.js
@@ -128,6 +128,12 @@ function invalidTests (ext) {
     },
     {
       filename: `test.${ext}`,
+      code: `Vue.extend({})`,
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
+      filename: `test.${ext}`,
       code: `
         // @vue/component
         export default { }


### PR DESCRIPTION
#319

This PR adds support for detecting `Vue.extend` as components, also it adds missing information about `Vue.mixin` in readme.

Unfortunately I think it should be merged once we're ready to release new major version, as it might potentially break some CI builds.