### PR TITLE
Fix: unintentional disabling

### DIFF
--- a/lib/rules/comment-directive.js
+++ b/lib/rules/comment-directive.js
@@ -8,8 +8,8 @@
 // Helpers
 // -----------------------------------------------------------------------------
 
-const COMMENT_DIRECTIVE_B = /^\s*(eslint-(?:en|dis)able)\s*(?:(\S|\S[\s\S]*\S)\s*)?$/
-const COMMENT_DIRECTIVE_L = /^\s*(eslint-disable(?:-next)?-line)\s*(?:(\S|\S[\s\S]*\S)\s*)?$/
+const COMMENT_DIRECTIVE_B = /^\s*(eslint-(?:en|dis)able)(?:\s+(\S|\S[\s\S]*\S))?\s*$/
+const COMMENT_DIRECTIVE_L = /^\s*(eslint-disable(?:-next)?-line)(?:\s+(\S|\S[\s\S]*\S))?\s*$/
 
 /**
  * Parse a given comment.

--- a/tests/lib/rules/comment-directive.js
+++ b/tests/lib/rules/comment-directive.js
@@ -191,5 +191,22 @@ describe('comment-directive', () => {
       assert.deepEqual(messages[0].ruleId, 'vue/no-parsing-error')
       assert.deepEqual(messages[1].ruleId, 'vue/no-duplicate-attributes')
     })
+
+    it('should affect only the next line', () => {
+      const code = `
+        <template>
+          <!-- eslint-disable-next-line vue/no-parsing-error, vue/no-duplicate-attributes -->
+          <div id id="a">Hello</div>
+          <div id id="b">Hello</div>
+        </template>
+      `
+      const messages = linter.executeOnText(code, 'test.vue').results[0].messages
+
+      assert.deepEqual(messages.length, 2)
+      assert.deepEqual(messages[0].ruleId, 'vue/no-parsing-error')
+      assert.deepEqual(messages[0].line, 5)
+      assert.deepEqual(messages[1].ruleId, 'vue/no-duplicate-attributes')
+      assert.deepEqual(messages[1].line, 5)
+    })
   })
 })


### PR DESCRIPTION
`<!-- eslint-disable-line foo -->` was parsed to `<!-- eslint-disable -line foo -->` (i.e. disable 2 rules `-line` and `foo` after the comment) wrongly. This PR fixes the bug -- it requires one or more spaces between `eslint-disable` and the first rule name.

This is a bug fix which increases warnings, so needs `semver-minor`.
  