### PR TITLE
Fix: `html-indent` for solo comment (fixes #330)

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -673,6 +673,42 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   }
 
   /**
+   * Get the expected indent of comments.
+   * @param {Token|null} nextToken The next token of comments.
+   * @param {number|undefined} nextExpectedIndent The expected indent of the next token.
+   * @param {number|undefined} lastExpectedIndent The expected indent of the last token.
+   * @returns {{primary:number|undefined,secondary:number|undefined}}
+   */
+  function getCommentExpectedIndents (nextToken, nextExpectedIndent, lastExpectedIndent) {
+    if (typeof lastExpectedIndent === 'number' && isClosingToken(nextToken)) {
+      if (nextExpectedIndent === lastExpectedIndent) {
+        // For solo comment. E.g.,
+        // <div>
+        //    <!-- comment -->
+        // </div>
+        return {
+          primary: nextExpectedIndent + options.indentSize,
+          secondary: undefined
+        }
+      }
+
+      // For last comment. E.g.,
+      // <div>
+      //    <div></div>
+      //    <!-- comment -->
+      // </div>
+      return { primary: lastExpectedIndent, secondary: nextExpectedIndent }
+    }
+
+    // Adjust to next normally. E.g.,
+    // <div>
+    //    <!-- comment -->
+    //    <div></div>
+    // </div>
+    return { primary: nextExpectedIndent, secondary: undefined }
+  }
+
+  /**
    * Validate indentation of the line that the given tokens are on.
    * @param {Token[]} tokens The tokens on the same line to validate.
    * @param {Token[]} comments The comments which are on the immediately previous lines of the tokens.
@@ -732,9 +768,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
     // It allows the same indent level with the previous line.
     const lastOffsetInfo = offsets.get(lastToken)
     const lastExpectedIndent = lastOffsetInfo && lastOffsetInfo.expectedIndent
-    const commentExpectedIndents = (typeof lastExpectedIndent === 'number' && isClosingToken(firstToken))
-      ? { primary: lastExpectedIndent, secondary: expectedIndent }
-      : { primary: expectedIndent, secondary: undefined }
+    const commentExpectedIndents = getCommentExpectedIndents(firstToken, expectedIndent, lastExpectedIndent)
 
     // Validate.
     for (const comment of comments) {

--- a/tests/fixtures/html-indent/solo-html-comment-01.vue
+++ b/tests/fixtures/html-indent/solo-html-comment-01.vue
@@ -1,0 +1,6 @@
+<!--{}-->
+<template>
+  <div>
+    <!-- comment -->
+  </div>
+</template>

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -191,6 +191,28 @@ tester.run('html-indent', rule, loadPatterns(
         }}
       </template>
     `,
+    unIndent`
+      <template>
+        <div>
+          <!-- this comment is ignored because the next token doesn't exist. -->
+    `,
+    unIndent`
+      <template>
+        <div>
+          <div></div>
+          <!-- this comment is ignored because the next token doesn't exist. -->
+    `,
+    unIndent`
+      <template>
+        <div>
+      <!-- this comment is ignored because the next token doesn't exist. -->
+    `,
+    unIndent`
+      <template>
+        <div>
+          <div></div>
+      <!-- this comment is ignored because the next token doesn't exist. -->
+    `,
 
     // Ignores
     {


### PR DESCRIPTION
Fixes #330.

This PR includes #309 to avoid confliction.

This PR changes the indentation of comments. If it detects solo comment (the next token is closing token and primary expected indentation and secondary expected indentation are same), then makes +1 indentation for the comment. See https://github.com/vuejs/eslint-plugin-vue/pull/333/commits/7fd45c4ae3ce741ed99d0d4000316ca5e39d48e5 for details.

This change needs `semver-minor` because it's a bug fix which can increase warnings.
  