### PR TITLE
Fix: unintentional disabling

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -43,6 +43,12 @@ module.exports = {
               state[group].disableRules.delete(rule)
             }
             break
+          case 'clear':
+            state.block.disableAll = false
+            state.block.disableRules.clear()
+            state.line.disableAll = false
+            state.line.disableRules.clear()
+            break
         }
         return false
       } else {

--- a/lib/rules/comment-directive.js
+++ b/lib/rules/comment-directive.js
@@ -107,11 +107,21 @@ function processLine (context, comment) {
 function create (context) {
   return {
     Program (node) {
-      const comments = (node.templateBody && node.templateBody.comments) || []
-      for (const comment of comments) {
+      if (!node.templateBody) {
+        return
+      }
+
+      // Send directives to the post-process.
+      for (const comment of node.templateBody.comments) {
         processBlock(context, comment)
         processLine(context, comment)
       }
+
+      // Send a clear mark to the post-process.
+      context.report({
+        loc: node.templateBody.loc.end,
+        message: 'clear'
+      })
     }
   }
 }

--- a/tests/lib/rules/comment-directive.js
+++ b/tests/lib/rules/comment-directive.js
@@ -26,6 +26,7 @@ const linter = new eslint.CLIEngine({
   },
   plugins: ['vue'],
   rules: {
+    'no-unused-vars': 'error',
     'vue/comment-directive': 'error',
     'vue/no-parsing-error': 'error',
     'vue/no-duplicate-attributes': 'error'
@@ -107,6 +108,22 @@ describe('comment-directive', () => {
       assert.deepEqual(messages.length, 1)
       assert.deepEqual(messages[0].ruleId, 'vue/no-duplicate-attributes')
       assert.deepEqual(messages[0].line, 6)
+    })
+
+    it('should not affect to the code in <script>.', () => {
+      const code = `
+        <template>
+          <!-- eslint-disable -->
+          <div id id="a">Hello</div>
+        </template>
+        <script>
+          var a
+        </script>
+      `
+      const messages = linter.executeOnText(code, 'test.vue').results[0].messages
+
+      assert.strictEqual(messages.length, 1)
+      assert.strictEqual(messages[0].ruleId, 'no-unused-vars')
     })
   })
 


### PR DESCRIPTION
I noticed that `<!-- eslint-disable -->` affects to the code in `<script>` element.
This PR fixes `vue/comment-directive` rule to clear state at the end of `<template>` element.

```html
<template>
  <!-- eslint-disable -->
  <div id id="a">Hello</div>
</template>
<script>
  var a // `no-unused-vars` rule didn't trigger.
</script>
```

.... Or I wonder if people expect to share the state between `<template>` and `<script>`? I thought no.

```html
<template>
  <!-- eslint-disable -->
  <div id id="a">Hello</div>
</template>
<script>
  /* eslint-enable */
  var a
</script>
```
