### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -59,7 +59,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce attribute naming style in template',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/attribute-hyphenation.md'
     },
     fixable: 'code',
     schema: [

--- a/lib/rules/comment-directive.js
+++ b/lib/rules/comment-directive.js
@@ -124,7 +124,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'support comment-directives in `<template>`', // eslint-disable-line consistent-docs-description
-      category: 'base'
+      category: 'base',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/comment-directive.md'
     },
     schema: []
   },

--- a/lib/rules/html-closing-bracket-newline.js
+++ b/lib/rules/html-closing-bracket-newline.js
@@ -77,7 +77,8 @@ module.exports = {
   meta: {
     docs: {
       description: "require or disallow a line break before tag's closing brackets",
-      category: undefined
+      category: undefined,
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/html-closing-bracket-newline.md'
     },
     fixable: 'whitespace',
     schema: [{

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -52,7 +52,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'require or disallow a space before tag\'s closing brackets',
-      category: undefined
+      category: undefined,
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/html-closing-bracket-spacing.md'
     },
     schema: [{
       type: 'object',

--- a/lib/rules/html-end-tags.js
+++ b/lib/rules/html-end-tags.js
@@ -61,7 +61,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce end tag style',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/html-end-tags.md'
     },
     fixable: 'code',
     schema: []

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -28,7 +28,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce consistent indentation in `<template>`',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/html-indent.md'
     },
     fixable: 'whitespace',
     schema: [

--- a/lib/rules/html-quotes.js
+++ b/lib/rules/html-quotes.js
@@ -70,7 +70,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce quotes style of HTML attributes',
-      category: 'recommended'
+      category: 'recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/html-quotes.md'
     },
     fixable: 'code',
     schema: [

--- a/lib/rules/html-self-closing.js
+++ b/lib/rules/html-self-closing.js
@@ -152,7 +152,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce self-closing style',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/html-self-closing.md'
     },
     fixable: 'code',
     schema: {

--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -38,7 +38,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'prevent variables used in JSX to be marked as unused', // eslint-disable-line consistent-docs-description
-      category: 'base'
+      category: 'base',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/jsx-uses-vars.md'
     },
     schema: []
   },

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -13,7 +13,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce the maximum number of attributes per line',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/max-attributes-per-line.md'
     },
     fixable: null,
     schema: [

--- a/lib/rules/mustache-interpolation-spacing.js
+++ b/lib/rules/mustache-interpolation-spacing.js
@@ -18,7 +18,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce unified spacing in mustache interpolations',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/mustache-interpolation-spacing.md'
     },
     fixable: 'whitespace',
     schema: [

--- a/lib/rules/name-property-casing.js
+++ b/lib/rules/name-property-casing.js
@@ -49,7 +49,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce specific casing for the name property in Vue components',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/name-property-casing.md'
     },
     fixable: 'code', // or "code" or "whitespace"
     schema: [

--- a/lib/rules/no-async-in-computed-properties.js
+++ b/lib/rules/no-async-in-computed-properties.js
@@ -148,7 +148,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow asynchronous actions in computed properties',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-async-in-computed-properties.md'
     },
     fixable: null,
     schema: []

--- a/lib/rules/no-confusing-v-for-v-if.js
+++ b/lib/rules/no-confusing-v-for-v-if.js
@@ -61,7 +61,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow confusing `v-for` and `v-if` on the same element',
-      category: 'recommended'
+      category: 'recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-confusing-v-for-v-if.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -48,7 +48,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow duplication of field names',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-dupe-keys.md'
     },
     fixable: null, // or "code" or "whitespace"
     schema: [

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -89,7 +89,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow duplication of attributes',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-duplicate-attributes.md'
     },
     fixable: false,
 

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -12,7 +12,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow multiple spaces',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-multi-spaces.md'
     },
     fixable: 'whitespace', // or "code" or "whitespace"
     schema: []

--- a/lib/rules/no-parsing-error.js
+++ b/lib/rules/no-parsing-error.js
@@ -94,7 +94,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow parsing errors in `<template>`',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-parsing-error.md'
     },
     fixable: false,
     schema: [

--- a/lib/rules/no-reserved-keys.js
+++ b/lib/rules/no-reserved-keys.js
@@ -50,7 +50,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow overwriting reserved keys',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-reserved-keys.md'
     },
     fixable: null,
     schema: [

--- a/lib/rules/no-shared-component-data.js
+++ b/lib/rules/no-shared-component-data.js
@@ -75,7 +75,8 @@ module.exports = {
   meta: {
     docs: {
       description: "enforce component's data property to be a function",
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-shared-component-data.md'
     },
     fixable: 'code',
     schema: []

--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -64,7 +64,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow side effects in computed properties',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-side-effects-in-computed-properties.md'
     },
     fixable: null,
     schema: []

--- a/lib/rules/no-template-key.js
+++ b/lib/rules/no-template-key.js
@@ -44,7 +44,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow `key` attribute on `<template>`',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-template-key.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -46,7 +46,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow mustaches in `<textarea>`',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-textarea-mustache.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -43,7 +43,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow unused variable definitions of v-for directives or scope attributes',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/no-unused-vars.md'
     },
     fixable: null,
     schema: []

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -100,7 +100,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce order of properties in components',
-      category: 'recommended'
+      category: 'recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/order-in-components.md'
     },
     fixable: null,
     schema: [

--- a/lib/rules/require-component-is.js
+++ b/lib/rules/require-component-is.js
@@ -44,7 +44,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'require `v-bind:is` of `<component>` elements',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/require-component-is.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -14,7 +14,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'require default value for props',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/require-default-prop.md'
     },
     fixable: null, // or "code" or "whitespace"
     schema: []

--- a/lib/rules/require-prop-types.js
+++ b/lib/rules/require-prop-types.js
@@ -83,7 +83,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'require type definitions in props',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/require-prop-types.md'
     },
     fixable: null, // or "code" or "whitespace"
     schema: [

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -44,7 +44,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce render function to always return value',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/require-render-return.md'
     },
     fixable: null, // or "code" or "whitespace"
     schema: []

--- a/lib/rules/require-v-for-key.js
+++ b/lib/rules/require-v-for-key.js
@@ -59,7 +59,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'require `v-bind:key` with `v-for` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/require-v-for-key.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/require-valid-default-prop.js
+++ b/lib/rules/require-valid-default-prop.js
@@ -23,7 +23,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce props default values to be valid',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/require-valid-default-prop.md'
     },
     fixable: null,
     schema: []

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -48,7 +48,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce that a return statement is present in computed property',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/return-in-computed-property.md'
     },
     fixable: null, // or "code" or "whitespace"
     schema: [

--- a/lib/rules/script-indent.js
+++ b/lib/rules/script-indent.js
@@ -21,7 +21,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce consistent indentation in `<script>`',
-      category: undefined
+      category: undefined,
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/script-indent.md'
     },
     fixable: 'whitespace',
     schema: [

--- a/lib/rules/this-in-template.js
+++ b/lib/rules/this-in-template.js
@@ -19,7 +19,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce usage of `this` in template',
-      category: 'recommended'
+      category: 'recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/this-in-template.md'
     },
     fixable: null,
     schema: [

--- a/lib/rules/v-bind-style.js
+++ b/lib/rules/v-bind-style.js
@@ -53,7 +53,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce `v-bind` directive style',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/v-bind-style.md'
     },
     fixable: 'code',
     schema: [

--- a/lib/rules/v-on-style.js
+++ b/lib/rules/v-on-style.js
@@ -54,7 +54,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce `v-on` directive style',
-      category: 'strongly-recommended'
+      category: 'strongly-recommended',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/v-on-style.md'
     },
     fixable: 'code',
     schema: [

--- a/lib/rules/valid-template-root.js
+++ b/lib/rules/valid-template-root.js
@@ -113,7 +113,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid template root',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-template-root.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-bind.js
+++ b/lib/rules/valid-v-bind.js
@@ -57,7 +57,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-bind` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-bind.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-cloak.js
+++ b/lib/rules/valid-v-cloak.js
@@ -58,7 +58,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-cloak` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-cloak.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-else-if.js
+++ b/lib/rules/valid-v-else-if.js
@@ -81,7 +81,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-else-if` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-else-if.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-else.js
+++ b/lib/rules/valid-v-else.js
@@ -81,7 +81,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-else` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-else.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-for.js
+++ b/lib/rules/valid-v-for.js
@@ -189,7 +189,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-for` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-for.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-html.js
+++ b/lib/rules/valid-v-html.js
@@ -58,7 +58,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-html` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-html.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-if.js
+++ b/lib/rules/valid-v-if.js
@@ -74,7 +74,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-if` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-if.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-model.js
+++ b/lib/rules/valid-v-model.js
@@ -166,7 +166,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-model` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-model.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-on.js
+++ b/lib/rules/valid-v-on.js
@@ -63,7 +63,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-on` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-on.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-once.js
+++ b/lib/rules/valid-v-once.js
@@ -58,7 +58,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-once` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-once.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-pre.js
+++ b/lib/rules/valid-v-pre.js
@@ -58,7 +58,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-pre` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-pre.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-show.js
+++ b/lib/rules/valid-v-show.js
@@ -58,7 +58,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-show` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-show.md'
     },
     fixable: false,
     schema: []

--- a/lib/rules/valid-v-text.js
+++ b/lib/rules/valid-v-text.js
@@ -58,7 +58,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce valid `v-text` directives',
-      category: 'essential'
+      category: 'essential',
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/valid-v-text.md'
     },
     fixable: false,
     schema: []


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can know where their documentation is without having to resort to external packages to guess.