### PR TITLE
fixed a JSON formatting error in the options example

### DIFF
--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -46,7 +46,7 @@ If you want you can change the order providing the optional configuration in you
 
 ``` json
 "vue/order-in-components": ["error", {
-  order: [
+  "order": [
     "el",
     "name",
     "parent",


### PR DESCRIPTION
Because the instructions say these options should be added to the `.eslintrc` file the format must be JSON. Therefore I have added the missing quotes in the snippet. Hope this is OK, (my first PR).