### PR TITLE
Fix: vue/html-indent ignores `<pre>` (fixes #365)

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -798,10 +798,12 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
 
     VElement (node) {
       const startTagToken = tokenStore.getFirstToken(node)
-      const childTokens = node.children.map(n => tokenStore.getFirstToken(n))
       const endTagToken = node.endTag && tokenStore.getFirstToken(node.endTag)
 
-      setOffset(childTokens, 1, startTagToken)
+      if (node.name !== 'pre') {
+        const childTokens = node.children.map(n => tokenStore.getFirstToken(n))
+        setOffset(childTokens, 1, startTagToken)
+      }
       setOffset(endTagToken, 0, startTagToken)
     },
 

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -230,6 +230,19 @@ tester.run('html-indent', rule, loadPatterns(
         // Ignore all :D
         ignores: ['*']
       }]
+    },
+
+    // Pre
+    {
+      code: unIndent`
+        <template>
+          <pre>
+        aaa
+          bbb
+            ccc
+          </pre>
+        </template>
+      `
     }
   ],
 
@@ -479,6 +492,38 @@ tester.run('html-indent', rule, loadPatterns(
         { message: 'Expected indentation of 8 spaces but found 6 spaces.', line: 3 },
         { message: 'Expected indentation of 12 spaces but found 8 spaces.', line: 4 },
         { message: 'Expected indentation of 12 spaces but found 8 spaces.', line: 6 }
+      ]
+    },
+
+    // Pre
+    {
+      code: unIndent`
+        <template>
+        <pre
+        style=""
+        >
+        aaa
+          bbb
+            ccc
+        </pre>
+        </template>
+      `,
+      output: unIndent`
+        <template>
+          <pre
+            style=""
+          >
+        aaa
+          bbb
+            ccc
+          </pre>
+        </template>
+      `,
+      errors: [
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
+        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 4 },
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 8 }
       ]
     }
   ]


### PR DESCRIPTION
Fixes #365.

`<pre>` element reserves whitespaces in itself, so `html-indent` rule shouldn't change those whitespaces.
This PR fixes `html-indent` rule to ignore inside of `<pre>` elements.