### PR TITLE
Fix: fix script-indent to prevent removing <script> tag (fixes #367)

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -631,8 +631,16 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
    */
   function validateCore (token, expectedIndent, optionalExpectedIndent) {
     const line = token.loc.start.line
-    const actualIndent = token.loc.start.column
     const indentText = getIndentText(token)
+
+    // If there is no line terminator after the `<script>` start tag,
+    // `indentText` contains non-whitespace characters.
+    // In that case, do nothing in order to prevent removing the `<script>` tag.
+    if (indentText.trim() !== '') {
+      return
+    }
+
+    const actualIndent = token.loc.start.column
     const unit = (options.indentChar === '\t' ? 'tab' : 'space')
 
     for (let i = 0; i < indentText.length; ++i) {

--- a/tests/fixtures/script-indent/no-linebreak-script.vue
+++ b/tests/fixtures/script-indent/no-linebreak-script.vue
@@ -1,0 +1,3 @@
+<!--{}-->
+<script>var a
+</script>


### PR DESCRIPTION
Fixes #367.

This PR fixes the bug that `vue/script-indent` rule removes the first `<script>` tag if there is no line terminator after the tag: [online demo](https://mysticatea.github.io/vue-eslint-demo/#eJw1jUEKwjAURK8is44IXYYilIIX0AuEZBYBScP/aVFL726CcTdvBt7s8EsgLEb1EnO5bk5Obrx0goGsTyrsjm1lr88xBaYCOxwGv3yPn2oZ/vh45ybV7DyrgyGWRXrZDqcUbvHFMLdzg+xEKXWjZiFxfAFldDPz).

