### PR TITLE
 [Update] Make `vue/max-attributes-per-line` fixable

### DIFF
--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -9,6 +9,8 @@
 // ------------------------------------------------------------------------------
 const utils = require('../utils')
 
+const LT_CHAR = /[\r\n\u2028\u2029]/
+
 module.exports = {
   meta: {
     docs: {
@@ -139,12 +141,12 @@ module.exports = {
             propName: prop.key.name
           },
           fix: i === 0 ? (fixer) => {
-            const indent = getIndentText(prop)
-            const last = indent[indent.length - 1];
+            let indent = getIndentText(prop)
+            const last = indent[indent.length - 1]
             if (indent[indent.length - 1] === '\t') {
-              indent += '\t';
+              indent += '\t'
             } else {
-              indent += last + last;
+              indent += last + last
             }
             return fixer.insertTextBefore(prop, `\n${indent}`)
           } : undefined
@@ -166,6 +168,7 @@ module.exports = {
 
       return propsPerLine
     }
+
     function getIndentText (node) {
       const text = sourceCode.text
       let indentStart = node.range[0] - 1

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -142,11 +142,13 @@ module.exports = {
           },
           fix: i === 0 ? (fixer) => {
             let indent = getIndentText(prop)
-            const last = indent[indent.length - 1]
-            if (indent[indent.length - 1] === '\t') {
-              indent += '\t'
-            } else {
-              indent += last + last
+            if (prop.loc.start.line === node.loc.start.line) {
+              const last = indent[indent.length - 1]
+              if (indent[indent.length - 1] === '\t') {
+                indent += '\t'
+              } else {
+                indent += last + last
+              }
             }
             return fixer.insertTextBefore(prop, `\n${indent}`)
           } : undefined

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -16,7 +16,7 @@ module.exports = {
       category: 'strongly-recommended',
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v4.2.2/docs/rules/max-attributes-per-line.md'
     },
-    fixable: null,
+    fixable: 'whitespace', // or "code" or "whitespace"
     schema: [
       {
         type: 'object',
@@ -70,6 +70,7 @@ module.exports = {
     const multilineMaximum = configuration.multiline
     const singlelinemMaximum = configuration.singleline
     const canHaveFirstLine = configuration.allowFirstLine
+    const sourceCode = context.getSourceCode()
 
     return utils.defineTemplateBodyVisitor(context, {
       'VStartTag' (node) {
@@ -129,14 +130,24 @@ module.exports = {
     }
 
     function showErrors (attributes, node) {
-      attributes.forEach((prop) => {
+      attributes.forEach((prop, i) => {
         context.report({
           node: prop,
           loc: prop.loc,
           message: 'Attribute "{{propName}}" should be on a new line.',
           data: {
             propName: prop.key.name
-          }
+          },
+          fix: i === 0 ? (fixer) => {
+            const indent = getIndentText(prop)
+            const last = indent[indent.length - 1];
+            if (indent[indent.length - 1] === '\t') {
+              indent += '\t';
+            } else {
+              indent += last + last;
+            }
+            return fixer.insertTextBefore(prop, `\n${indent}`)
+          } : undefined
         })
       })
     }
@@ -154,6 +165,20 @@ module.exports = {
       })
 
       return propsPerLine
+    }
+    function getIndentText (node) {
+      const text = sourceCode.text
+      let indentStart = node.range[0] - 1
+      while (indentStart >= 0 && !LT_CHAR.test(text[indentStart])) {
+        indentStart -= 1
+      }
+      let indentEnd = indentStart + 1
+
+      while (!text[indentEnd].trim()) {
+        indentEnd += 1
+      }
+
+      return text.slice(indentStart + 1, indentEnd)
     }
   }
 }

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -9,8 +9,6 @@
 // ------------------------------------------------------------------------------
 const utils = require('../utils')
 
-const LT_CHAR = /[\r\n\u2028\u2029]/
-
 module.exports = {
   meta: {
     docs: {
@@ -72,7 +70,6 @@ module.exports = {
     const multilineMaximum = configuration.multiline
     const singlelinemMaximum = configuration.singleline
     const canHaveFirstLine = configuration.allowFirstLine
-    const sourceCode = context.getSourceCode()
 
     return utils.defineTemplateBodyVisitor(context, {
       'VStartTag' (node) {
@@ -140,18 +137,7 @@ module.exports = {
           data: {
             propName: prop.key.name
           },
-          fix: i === 0 ? (fixer) => {
-            let indent = getIndentText(prop)
-            if (prop.loc.start.line === node.loc.start.line) {
-              const last = indent[indent.length - 1]
-              if (indent[indent.length - 1] === '\t') {
-                indent += '\t'
-              } else {
-                indent += last + last
-              }
-            }
-            return fixer.insertTextBefore(prop, `\n${indent}`)
-          } : undefined
+          fix: i === 0 ? (fixer) => fixer.insertTextBefore(prop, '\n') : undefined
         })
       })
     }
@@ -169,21 +155,6 @@ module.exports = {
       })
 
       return propsPerLine
-    }
-
-    function getIndentText (node) {
-      const text = sourceCode.text
-      let indentStart = node.range[0] - 1
-      while (indentStart >= 0 && !LT_CHAR.test(text[indentStart])) {
-        indentStart -= 1
-      }
-      let indentEnd = indentStart + 1
-
-      while (!text[indentEnd].trim()) {
-        indentEnd += 1
-      }
-
-      return text.slice(indentStart + 1, indentEnd)
     }
   }
 }

--- a/tests/lib/rules/max-attributes-per-line.js
+++ b/tests/lib/rules/max-attributes-per-line.js
@@ -91,10 +91,18 @@ ruleTester.run('max-attributes-per-line', rule, {
   invalid: [
     {
       code: `<template><component name="John Doe" age="30"></component></template>`,
+      output: `<template><component name="John Doe" 
+age="30"></component></template>`,
       errors: ['Attribute "age" should be on a new line.']
     },
     {
       code: `<template><component job="Vet"
+        name="John Doe"
+        age="30">
+        </component>
+      </template>`,
+      output: `<template><component 
+job="Vet"
         name="John Doe"
         age="30">
         </component>
@@ -108,6 +116,8 @@ ruleTester.run('max-attributes-per-line', rule, {
     {
       code: `<template><component name="John Doe" age="30" job="Vet"></component></template>`,
       options: [{ singleline: { max: 2 }}],
+      output: `<template><component name="John Doe" age="30" 
+job="Vet"></component></template>`,
       errors: [{
         message: 'Attribute "job" should be on a new line.',
         type: 'VAttribute',
@@ -117,6 +127,8 @@ ruleTester.run('max-attributes-per-line', rule, {
     {
       code: `<template><component name="John Doe" age="30" job="Vet"></component></template>`,
       options: [{ singleline: 1, multiline: { max: 1, allowFirstLine: false }}],
+      output: `<template><component name="John Doe" 
+age="30" job="Vet"></component></template>`,
       errors: [{
         message: 'Attribute "age" should be on a new line.',
         type: 'VAttribute',
@@ -133,6 +145,11 @@ ruleTester.run('max-attributes-per-line', rule, {
         </component>
       </template>`,
       options: [{ singleline: 3, multiline: { max: 1, allowFirstLine: false }}],
+      output: `<template><component 
+name="John Doe"
+        age="30">
+        </component>
+      </template>`,
       errors: [{
         message: 'Attribute "name" should be on a new line.',
         type: 'VAttribute',
@@ -146,6 +163,12 @@ ruleTester.run('max-attributes-per-line', rule, {
         </component>
       </template>`,
       options: [{ singleline: 3, multiline: { max: 1, allowFirstLine: false }}],
+      output: `<template><component
+        name="John Doe" 
+age="30"
+        job="Vet">
+        </component>
+      </template>`,
       errors: [{
         message: 'Attribute "age" should be on a new line.',
         type: 'VAttribute',
@@ -159,6 +182,12 @@ ruleTester.run('max-attributes-per-line', rule, {
         </component>
       </template>`,
       options: [{ singleline: 3, multiline: 1 }],
+      output: `<template><component
+        name="John Doe" 
+age="30"
+        job="Vet">
+        </component>
+      </template>`,
       errors: [{
         message: 'Attribute "age" should be on a new line.',
         type: 'VAttribute',
@@ -172,6 +201,12 @@ ruleTester.run('max-attributes-per-line', rule, {
         </component>
       </template>`,
       options: [{ singleline: 3, multiline: { max: 2, allowFirstLine: false }}],
+      output: `<template><component
+        name="John Doe" age="30"
+        job="Vet" pet="dog" 
+petname="Snoopy">
+        </component>
+      </template>`,
       errors: [{
         message: 'Attribute "petname" should be on a new line.',
         type: 'VAttribute',
@@ -185,6 +220,12 @@ ruleTester.run('max-attributes-per-line', rule, {
         </component>
       </template>`,
       options: [{ singleline: 3, multiline: { max: 2, allowFirstLine: false }}],
+      output: `<template><component
+        name="John Doe" age="30"
+        job="Vet" pet="dog" 
+petname="Snoopy" extra="foo">
+        </component>
+      </template>`,
       errors: [{
         message: 'Attribute "petname" should be on a new line.',
         type: 'VAttribute',


### PR DESCRIPTION
This PR makes `vue/max-attributes-per-line` fixable. 
The autofix insert line feed at maximum number of attributes location