### PR TITLE
[Update] Make `vue/order-in-components` fixable

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -56,6 +56,10 @@ function getOrderMap (order) {
   return orderMap
 }
 
+function isComma (node) {
+  return node.type === 'Punctuator' && node.value === ','
+}
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -67,7 +71,7 @@ module.exports = {
       category: 'recommended',
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v4.2.2/docs/rules/order-in-components.md'
     },
-    fixable: null,
+    fixable: 'code', // null or "code" or "whitespace"
     schema: [
       {
         type: 'object',
@@ -86,6 +90,7 @@ module.exports = {
     const order = options.order || defaultOrder
     const extendedOrder = order.map(property => groups[property] || property)
     const orderMap = getOrderMap(extendedOrder)
+    const sourceCode = context.getSourceCode()
 
     function checkOrder (propertiesNodes, orderMap) {
       const properties = propertiesNodes
@@ -109,6 +114,21 @@ module.exports = {
               name: property.name,
               firstUnorderedPropertyName: firstUnorderedProperty.name,
               line
+            },
+            fix (fixer) {
+              const propertyNode = property.parent
+              const comma = sourceCode.getTokenAfter(propertyNode)
+              const hasAfterComma = isComma(comma)
+
+              const codeStart = sourceCode.getTokenBefore(propertyNode).range[1] // to include comments
+              const codeEnd = hasAfterComma ? comma.range[1] : propertyNode.range[1]
+
+              const propertyCode = sourceCode.text.slice(codeStart, codeEnd) + (hasAfterComma ? '' : ',')
+              const insertTarget = sourceCode.getTokenBefore(firstUnorderedProperty.parent)
+              return [
+                fixer.removeRange([codeStart, codeEnd]),
+                fixer.insertTextAfter(insertTarget, propertyCode)
+              ]
             }
           })
         }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -91,7 +91,7 @@ const LOGICAL_OPERATORS = ['&&', '||']
  */
 function isNotSideEffectsNode (node, visitorKeys) {
   let result = true
-  Traverser.traverse(node, {
+  new Traverser().traverse(node, {
     visitorKeys,
     enter (node, parent) {
       if (

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
+const Traverser = require('eslint/lib/util/traverser')
 
 const defaultOrder = [
   'el',
@@ -63,15 +64,14 @@ function isComma (node) {
 const ARITHMETIC_OPERATORS = ['+', '-', '*', '/', '%', '**']
 const BITWISE_OPERATORS = ['&', '|', '^', '~', '<<', '>>', '>>>']
 const COMPARISON_OPERATORS = ['==', '!=', '===', '!==', '>', '>=', '<', '<=']
-const LOGICAL_OPERATORS = ['&&', '||']
 const RELATIONAL_OPERATORS = ['in', 'instanceof']
-const ALL_OPERATORS = [].concat(
+const ALL_BINARY_OPERATORS = [].concat(
   ARITHMETIC_OPERATORS,
   BITWISE_OPERATORS,
   COMPARISON_OPERATORS,
-  LOGICAL_OPERATORS,
   RELATIONAL_OPERATORS
 )
+const LOGICAL_OPERATORS = ['&&', '||']
 
 /*
  * Result `true` if the node is sure that there are no side effects
@@ -85,50 +85,45 @@ const ALL_OPERATORS = [].concat(
  * node.type === 'TaggedTemplateExpression'
  * node.type === 'UnaryExpression' && node.operator === 'delete'
  *
- * @param  {Token} node target node
+ * @param  {ASTNode} node target node
+ * @param  {Object} visitorKeys sourceCode.visitorKey
  * @returns {Boolean} no side effects
  */
-function isNotSideEffectsNode (node) {
-  if (node.type === 'FunctionExpression' ||
-    node.type === 'Identifier' ||
-    node.type === 'Literal' ||
-    // es2015
-    node.type === 'ArrowFunctionExpression' ||
-    node.type === 'TemplateElement'
-  ) {
-    return true
-  }
-  if (node.type === 'Property') {
-    return [node.value, node.key].every(isNotSideEffectsNode)
-  }
-  if (node.type === 'ObjectExpression') {
-    return node.properties.every(isNotSideEffectsNode)
-  }
-  if (node.type === 'ArrayExpression') {
-    return node.elements.every(isNotSideEffectsNode)
-  }
-  if (node.type === 'UnaryExpression' && ['!', '~', '+', '-', 'typeof'].indexOf(node.operator) > -1) {
-    return isNotSideEffectsNode(node.argument)
-  }
-  if (/^(?:Binary|Logical)Expression$/.test(node.type) && ALL_OPERATORS.indexOf(node.operator) > -1) {
-    return [node.left, node.right].every(isNotSideEffectsNode)
-  }
-  if (node.type === 'MemberExpression') {
-    return isNotSideEffectsNode(node.object)
-  }
-  if (node.type === 'ConditionalExpression') {
-    return [node.test, node.consequent, node.alternate].every(isNotSideEffectsNode)
-  }
-  // es2015
-  if (node.type === 'SpreadElement') {
-    return isNotSideEffectsNode(node.argument)
-  }
-  if (node.type === 'TemplateLiteral') {
-    return [].concat(node.quasis, node.expressions).every(isNotSideEffectsNode)
-  }
-
-  // Can not be sure that a node has no side effects
-  return false
+function isNotSideEffectsNode (node, visitorKeys) {
+  let result = true
+  Traverser.traverse(node, {
+    visitorKeys,
+    enter (node, parent) {
+      if (
+        node.type === 'FunctionExpression' ||
+        node.type === 'Identifier' ||
+        node.type === 'Literal' ||
+        // es2015
+        node.type === 'ArrowFunctionExpression' ||
+        node.type === 'TemplateElement'
+      ) {
+        // no side effects node
+        this.skip()
+      } else if (
+        node.type !== 'Property' &&
+        node.type !== 'ObjectExpression' &&
+        node.type !== 'ArrayExpression' &&
+        (node.type !== 'UnaryExpression' || ['!', '~', '+', '-', 'typeof'].indexOf(node.operator) < 0) &&
+        (node.type !== 'BinaryExpression' || ALL_BINARY_OPERATORS.indexOf(node.operator) < 0) &&
+        (node.type !== 'LogicalExpression' || LOGICAL_OPERATORS.indexOf(node.operator) < 0) &&
+        node.type !== 'MemberExpression' &&
+        node.type !== 'ConditionalExpression' &&
+        // es2015
+        node.type !== 'SpreadElement' &&
+        node.type !== 'TemplateLiteral'
+      ) {
+        // Can not be sure that a node has no side effects
+        result = false
+        this.break()
+      }
+    }
+  })
+  return result
 }
 
 // ------------------------------------------------------------------------------
@@ -194,7 +189,7 @@ module.exports = {
                   propertiesNodes.indexOf(firstUnorderedPropertyNode),
                   propertiesNodes.indexOf(propertyNode) + 1
                 )
-                .some((property) => !isNotSideEffectsNode(property))
+                .some((property) => !isNotSideEffectsNode(property, sourceCode.visitorKeys))
               if (hasSideEffectsPossibility) {
                 return undefined
               }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -60,6 +60,77 @@ function isComma (node) {
   return node.type === 'Punctuator' && node.value === ','
 }
 
+const ARITHMETIC_OPERATORS = ['+', '-', '*', '/', '%', '**']
+const BITWISE_OPERATORS = ['&', '|', '^', '~', '<<', '>>', '>>>']
+const COMPARISON_OPERATORS = ['==', '!=', '===', '!==', '>', '>=', '<', '<=']
+const LOGICAL_OPERATORS = ['&&', '||']
+const RELATIONAL_OPERATORS = ['in', 'instanceof']
+const ALL_OPERATORS = [].concat(
+  ARITHMETIC_OPERATORS,
+  BITWISE_OPERATORS,
+  COMPARISON_OPERATORS,
+  LOGICAL_OPERATORS,
+  RELATIONAL_OPERATORS
+)
+
+/*
+ * Result `true` if the node is sure that there are no side effects
+ *
+ * Currently known side effects types
+ *
+ * node.type === 'CallExpression'
+ * node.type === 'NewExpression'
+ * node.type === 'UpdateExpression'
+ * node.type === 'AssignmentExpression'
+ * node.type === 'TaggedTemplateExpression'
+ * node.type === 'UnaryExpression' && node.operator === 'delete'
+ *
+ * @param  {Token} node target node
+ * @returns {Boolean} no side effects
+ */
+function isNotSideEffectsNode (node) {
+  if (node.type === 'FunctionExpression' ||
+    node.type === 'Identifier' ||
+    node.type === 'Literal' ||
+    // es2015
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'TemplateElement'
+  ) {
+    return true
+  }
+  if (node.type === 'Property') {
+    return [node.value, node.key].every(isNotSideEffectsNode)
+  }
+  if (node.type === 'ObjectExpression') {
+    return node.properties.every(isNotSideEffectsNode)
+  }
+  if (node.type === 'ArrayExpression') {
+    return node.elements.every(isNotSideEffectsNode)
+  }
+  if (node.type === 'UnaryExpression' && ['!', '~', '+', '-', 'typeof'].indexOf(node.operator) > -1) {
+    return isNotSideEffectsNode(node.argument)
+  }
+  if (/^(?:Binary|Logical)Expression$/.test(node.type) && ALL_OPERATORS.indexOf(node.operator) > -1) {
+    return [node.left, node.right].every(isNotSideEffectsNode)
+  }
+  if (node.type === 'MemberExpression') {
+    return isNotSideEffectsNode(node.object)
+  }
+  if (node.type === 'ConditionalExpression') {
+    return [node.test, node.consequent, node.alternate].every(isNotSideEffectsNode)
+  }
+  // es2015
+  if (node.type === 'SpreadElement') {
+    return isNotSideEffectsNode(node.argument)
+  }
+  if (node.type === 'TemplateLiteral') {
+    return [...node.quasis, ...node.expressions].every(isNotSideEffectsNode)
+  }
+
+  // Can not be sure that a node has no side effects
+  return false
+}
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -117,6 +188,16 @@ module.exports = {
             },
             fix (fixer) {
               const propertyNode = property.parent
+              const firstUnorderedPropertyNode = firstUnorderedProperty.parent
+              const hasSideEffectsPossibility = propertiesNodes
+                .slice(
+                  propertiesNodes.indexOf(firstUnorderedPropertyNode),
+                  propertiesNodes.indexOf(propertyNode) + 1
+                )
+                .some((property) => !isNotSideEffectsNode(property))
+              if (hasSideEffectsPossibility) {
+                return undefined
+              }
               const comma = sourceCode.getTokenAfter(propertyNode)
               const hasAfterComma = isComma(comma)
 
@@ -124,7 +205,7 @@ module.exports = {
               const codeEnd = hasAfterComma ? comma.range[1] : propertyNode.range[1]
 
               const propertyCode = sourceCode.text.slice(codeStart, codeEnd) + (hasAfterComma ? '' : ',')
-              const insertTarget = sourceCode.getTokenBefore(firstUnorderedProperty.parent)
+              const insertTarget = sourceCode.getTokenBefore(firstUnorderedPropertyNode)
               // If we can upgrade requirements to `eslint@>4.1.0`, this code can be replaced by:
               // return [
               //   fixer.removeRange([codeStart, codeEnd]),

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -125,10 +125,14 @@ module.exports = {
 
               const propertyCode = sourceCode.text.slice(codeStart, codeEnd) + (hasAfterComma ? '' : ',')
               const insertTarget = sourceCode.getTokenBefore(firstUnorderedProperty.parent)
-              return [
-                fixer.removeRange([codeStart, codeEnd]),
-                fixer.insertTextAfter(insertTarget, propertyCode)
-              ]
+              // If we can upgrade requirements to `eslint@>4.1.0`, this code can be replaced by:
+              // return [
+              //   fixer.removeRange([codeStart, codeEnd]),
+              //   fixer.insertTextAfter(insertTarget, propertyCode)
+              // ]
+              const insertStart = insertTarget.range[1]
+              const newCode = propertyCode + sourceCode.text.slice(insertStart, codeStart)
+              return fixer.replaceTextRange([insertStart, codeEnd], newCode)
             }
           })
         }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -124,7 +124,7 @@ function isNotSideEffectsNode (node) {
     return isNotSideEffectsNode(node.argument)
   }
   if (node.type === 'TemplateLiteral') {
-    return [...node.quasis, ...node.expressions].every(isNotSideEffectsNode)
+    return [].concat(node.quasis, node.expressions).every(isNotSideEffectsNode)
   }
 
   // Can not be sure that a node has no side effects

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -432,14 +432,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: obj.fn(),
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -457,14 +450,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: new MyClass(),
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -482,14 +468,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: i++,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -507,14 +486,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: i = 0,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -532,14 +504,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: template\`\${foo}\`,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -557,14 +522,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          [obj.fn()]: 'test',
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -582,14 +540,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: {test: obj.fn()},
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -607,14 +558,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: [obj.fn(), 1],
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -632,14 +576,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: obj.fn().prop,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -657,14 +594,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: delete obj.prop,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -682,14 +612,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: fn() + a + b,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -707,14 +630,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: a ? fn() : null,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6
@@ -732,14 +648,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
-      output: `
-        export default {
-          data() {
-          },
-          test: \`test \${fn()} \${a}\`,
-          name: 'burger',
-        };
-      `,
+      output: null,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 6

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -419,6 +419,395 @@ ruleTester.run('order-in-components', rule, {
         message: 'The "name" property should be above the "data" property on line 1.',
         line: 1
       }]
+    },
+    {
+      // side-effects CallExpression
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: obj.fn(),
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: obj.fn(),
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects NewExpression
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: new MyClass(),
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: new MyClass(),
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects UpdateExpression
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: i++,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: i++,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects AssignmentExpression
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: i = 0,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: i = 0,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects TaggedTemplateExpression
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: template\`\${foo}\`,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: template\`\${foo}\`,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects key
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          [obj.fn()]: 'test',
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          [obj.fn()]: 'test',
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects object deep props
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: {test: obj.fn()},
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: {test: obj.fn()},
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects array elements
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: [obj.fn(), 1],
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: [obj.fn(), 1],
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects call at middle
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: obj.fn().prop,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: obj.fn().prop,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects delete
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: delete obj.prop,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: delete obj.prop,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects within BinaryExpression
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: fn() + a + b,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: fn() + a + b,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects within ConditionalExpression
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: a ? fn() : null,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: a ? fn() : null,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // side-effects within TemplateLiteral
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          test: \`test \${fn()} \${a}\`,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: \`test \${fn()} \${a}\`,
+          name: 'burger',
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 6
+      }]
+    },
+    {
+      // without side-effects
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          name: 'burger',
+          test: fn(),
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          name: 'burger',
+          data() {
+          },
+          test: fn(),
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 5
+      }]
+    },
+    {
+      // don't side-effects
+      filename: 'example.vue',
+      code: `
+        export default {
+          data() {
+          },
+          testArray: [1, 2, 3, true, false, 'a', 'b', 'c'],
+          testRegExp: /[a-z]*/,
+          testSpreadElement: [...array],
+          testOperator: (!!(a - b + c * d / e % f)) || (a && b),
+          testArrow: (a) => a,
+          testConditional: a ? b : c,
+          testYield: function* () {},
+          testTemplate: \`a:\${a},b:\${b},c:\${c}.\`,
+          name: 'burger',
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          name: 'burger',
+          data() {
+          },
+          testArray: [1, 2, 3, true, false, 'a', 'b', 'c'],
+          testRegExp: /[a-z]*/,
+          testSpreadElement: [...array],
+          testOperator: (!!(a - b + c * d / e % f)) || (a && b),
+          testArrow: (a) => a,
+          testConditional: a ? b : c,
+          testYield: function* () {},
+          testTemplate: \`a:\${a},b:\${b},c:\${c}.\`,
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 3.',
+        line: 13
+      }]
     }
   ]
 })

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -144,6 +144,19 @@ ruleTester.run('order-in-components', rule, {
         }
       `,
       parserOptions,
+      output: `
+        export default {
+          name: 'app',
+          props: {
+            propA: Number,
+          },
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+        }
+      `,
       errors: [{
         message: 'The "props" property should be above the "data" property on line 4.',
         line: 9
@@ -170,6 +183,24 @@ ruleTester.run('order-in-components', rule, {
         }
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module', ecmaFeatures: { jsx: true }},
+      output: `
+        export default {
+          name: 'app',
+          render (h) {
+            return (
+              <span>{ this.msg }</span>
+            )
+          },
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          props: {
+            propA: Number,
+          },
+        }
+      `,
       errors: [{
         message: 'The "name" property should be above the "render" property on line 3.',
         line: 8
@@ -196,6 +227,18 @@ ruleTester.run('order-in-components', rule, {
         })
       `,
       parserOptions: { ecmaVersion: 6 },
+      output: `
+        Vue.component('smart-list', {
+          name: 'app',
+          components: {},
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          template: '<div></div>'
+        })
+      `,
       errors: [{
         message: 'The "components" property should be above the "data" property on line 4.',
         line: 9
@@ -217,6 +260,19 @@ ruleTester.run('order-in-components', rule, {
         })
       `,
       parserOptions: { ecmaVersion: 6 },
+      output: `
+        const { component } = Vue;
+        component('smart-list', {
+          name: 'app',
+          components: {},
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          template: '<div></div>'
+        })
+      `,
       errors: [{
         message: 'The "components" property should be above the "data" property on line 5.',
         line: 10
@@ -238,6 +294,19 @@ ruleTester.run('order-in-components', rule, {
         })
       `,
       parserOptions: { ecmaVersion: 6 },
+      output: `
+        new Vue({
+          el: '#app',
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          components: {},
+          template: '<div></div>'
+        })
+      `,
       errors: [{
         message: 'The "el" property should be above the "name" property on line 3.',
         line: 4
@@ -267,6 +336,24 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
+      output: `
+        export default {
+          name: 'burger',
+          data() {
+            return {
+              isActive: false,
+            };
+          },
+          methods: {
+            toggleMenu() {
+              this.isActive = !this.isActive;
+            },
+            closeMenu() {
+              this.isActive = false;
+            }
+          },
+        };
+      `,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 3.',
         line: 16
@@ -283,10 +370,54 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       parserOptions,
+      output: `
+        export default {
+          data() {
+          },
+          test: 'ok',
+          name: 'burger',
+        };
+      `,
       options: [{ order: ['data', 'test', 'name'] }],
       errors: [{
         message: 'The "test" property should be above the "name" property on line 5.',
         line: 6
+      }]
+    },
+    {
+      filename: 'example.vue',
+      code: `
+        export default {
+          /** data provider */
+          data() {
+          },
+          /** name of vue component */
+          name: 'burger'
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          /** name of vue component */
+          name: 'burger',
+          /** data provider */
+          data() {
+          },
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 4.',
+        line: 7
+      }]
+    },
+    {
+      filename: 'example.vue',
+      code: `export default {data(){},name:'burger'};`,
+      parserOptions,
+      output: `export default {name:'burger',data(){},};`,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 1.',
+        line: 1
       }]
     }
   ]


### PR DESCRIPTION
This PR makes `vue/order-in-components` fixable. #299
In case of `The "A" property should be above the "B" property` error, autofix will move A before B