### PR TITLE
Upgrade vue eslint parser

### DIFF
--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -63,7 +63,7 @@ module.exports = {
       description: 'enforce specific casing for the Prop name in Vue components',
       category: undefined // 'strongly-recommended'
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: null, // or "code" or "whitespace"
     schema: [
       {
         enum: allowedCaseOptions

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^3.18.0 || ^4.0.0"
   },
   "dependencies": {
-    "vue-eslint-parser": "^2.0.1"
+    "vue-eslint-parser": "^2.0.3"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",

--- a/tests/lib/rules/no-parsing-error.js
+++ b/tests/lib/rules/no-parsing-error.js
@@ -206,7 +206,8 @@ tester.run('no-parsing-error', rule, {
       code: '<template><div xmlns=""></template>',
       options: [{ 'x-invalid-namespace': false }]
     },
-    '<template><div/></template>'
+    '<template><div/></template>',
+    '<template><div v-show="">hello</div></template>'
   ],
   invalid: [
     {
@@ -238,7 +239,7 @@ tester.run('no-parsing-error', rule, {
     },
     {
       filename: 'test.vue',
-      code: '<template><div v-show="">hello</div></template>',
+      code: '<template><div v-show=" ">hello</div></template>',
       errors: [
         { message: 'Parsing error: Expected to be an expression, but got empty.', column: 24 }
       ]

--- a/tests/lib/rules/valid-v-show.js
+++ b/tests/lib/rules/valid-v-show.js
@@ -47,6 +47,11 @@ tester.run('valid-v-show', rule, {
       filename: 'test.vue',
       code: '<template><div v-show></div></template>',
       errors: ["'v-show' directives require that attribute value."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div v-show=""></div></template>',
+      errors: ["'v-show' directives require that attribute value."]
     }
   ]
 })


### PR DESCRIPTION
This PR upgrades `vue-eslint-parser` to `2.0.3` and fixes some tests.

Additionally, fixes a linting error of `no-multi-spaces` rule.