### PR TITLE
⭐️html-indent: Add "smart-tab" indent type (fixes #426)

### DIFF
--- a/docs/rules/html-indent.md
+++ b/docs/rules/html-indent.md
@@ -75,7 +75,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 - `type` (`number | "tab"`) ... The type of indentation. Default is `2`. If this is a number, it's the number of spaces for one indent. If this is `"tab"`, it uses one tab for one indent.
 - `attribute` (`integer`) ... The multiplier of indentation for attributes. Default is `1`.
 - `closeBracket` (`integer`) ... The multiplier of indentation for right brackets. Default is `0`.
-- `alignAttributesVertically` (`boolean`) ... Condition for whether attributes should be vertically aligned to the first attribute in multiline case or not. Default is `true`
+- `alignAttributesVertically` (`boolean`) ... Condition for whether attributes should be vertically aligned to the first attribute in multiline case or not. Default is `true`.  This setting is ignored (and is effectively `false`) if `type` is `"tab"`.
 - `ignores` (`string[]`) ... The selector to ignore nodes. The AST spec is [here](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md). You can use [esquery](https://github.com/estools/esquery#readme) to select nodes. Default is an empty array.
 
 :+1: Examples of **correct** code for `{attribute: 1, closeBracket: 1}`:

--- a/docs/rules/html-indent.md
+++ b/docs/rules/html-indent.md
@@ -72,7 +72,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 }
 ```
 
-- `type` (`number | "tab"`) ... The type of indentation. Default is `2`. If this is a number, it's the number of spaces for one indent. If this is `"tab"`, it uses one tab for one indent.
+- `type` (`number | "tab" | "smart-tab"`) ... The type of indentation. Default is `2`. If this is a number, it's the number of spaces for one indent. If this is `"tab"`, it uses one tab for one indent.  If this is [`"smart-tab"`](https://www.emacswiki.org/emacs/SmartTabs), it uses one tab for one indent, and spaces for alignment.
 - `attribute` (`integer`) ... The multiplier of indentation for attributes. Default is `1`.
 - `closeBracket` (`integer`) ... The multiplier of indentation for right brackets. Default is `0`.
 - `alignAttributesVertically` (`boolean`) ... Condition for whether attributes should be vertically aligned to the first attribute in multiline case or not. Default is `true`.  This setting is ignored (and is effectively `false`) if `type` is `"tab"`.
@@ -142,5 +142,17 @@ This rule enforces a consistent indentation style in `<template>`. The default s
     class=""
     some-attr=""
   />
+</template>
+```
+
+:+1: Examples of **correct** code for `"smart-tab"`:
+
+```html
+<template>
+	<div id=""
+	     class=""
+	     some-attr="" />
+		Text
+	</div>
 </template>
 ```

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -36,7 +36,7 @@ module.exports = {
       {
         anyOf: [
           { type: 'integer', minimum: 1 },
-          { enum: ['tab'] }
+          { enum: ['tab', 'smart-tab'] }
         ]
       },
       {

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -172,7 +172,6 @@ function indentCmp (a, b) {
 
 function indentEq (a, b) { return indentCmp(a, b) === 0 }
 function indentMin (a, b) { return indentCmp(a, b) < 0 ? a : b }
-function indentMax (a, b) { return indentCmp(a, b) > 0 ? a : b }
 
 /**
  * Adds two indent levels together.
@@ -186,24 +185,6 @@ function indentAdd (a, b) {
   return {
     tabs: a.tabs + b.tabs,
     spaces: (b.tabs ? 0 : a.spaces) + b.spaces
-  }
-}
-
-/**
- * Subtracts two indent levels.
- * @param {{tabs:number,spaces:number}}
- * @param {{tabs:number,spaces:number}}
- * @returns {{tabs:number,spaces:number}}
- */
-function indentSub (a, b) {
-  assert(indentValid(a), "'a' must be a valid indent object")
-  assert(indentValid(b), "'b' must be a valid indent object")
-  if ((a.tabs || b.tabs) && b.spaces > a.spaces) {
-    assert(false, 'weird subtract: ' + JSON.stringify(a) + ' - ' + JSON.stringify(b))
-  }
-  return {
-    tabs: a.tabs - b.tabs,
-    spaces: (b.tabs ? 0 : a.spaces) - b.spaces
   }
 }
 
@@ -967,16 +948,19 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
         // their offsetInfo.baseToken, to easily line up with them.
         if (offsetInfo.baseline) {
           // This is a baseline token, so the expected indent is the column of this token.
-          if (options.indentStyle === 'tabs') {
-            // In hard-tabs mode, it cannot align tokens strictly, so use one additional offset.
-            // But the additional offset isn't needed if it's at the beginning of the line.
-            offsetInfo.expectedIndent = indentAdd(expectedIndent,
-              (token === tokens[0] ? INDENT_ZERO : options.indent))
-          } else {
-            offsetInfo.expectedIndent = indentMax(INDENT_ZERO,
-              indentAdd(indentSub(expectedIndent, actualIndent),
-                { tabs: 0, spaces: token.loc.start.column }))
+          let extra = {
+            tabs: 0,
+            spaces: token.loc.start.column - (actualIndent.tabs + actualIndent.spaces)
           }
+
+          if (options.indentStyle === 'tabs' && extra.spaces > 0) {
+            // In hard-tabs mode, it cannot align tokens strictly, so use one additional offset.
+            extra = options.indent
+          }
+
+          assert(indentCmp(extra, INDENT_ZERO) >= 0)
+          assert(indentCmp(expectedIndent, INDENT_ZERO) >= 0)
+          offsetInfo.expectedIndent = indentAdd(expectedIndent, extra)
           baseline.add(token)
         } else if (baseline.has(offsetInfo.baseToken)) {
           // The base token is a baseline token on this line, so inherit it.

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -58,6 +58,10 @@ function parseOptions (type, options, defaultOptions) {
       ret.indentStyle = 'tabs'
       ret.indent = { tabs: 1, spaces: 0 }
       break
+    case 'smart-tab':
+      ret.indentStyle = 'smart-tabs'
+      ret.indent = { tabs: 1, spaces: 0 }
+      break
     default:
       assert(Number.isSafeInteger(type))
       ret.indentStyle = 'spaces'
@@ -121,6 +125,7 @@ function indentHumanize (indent) {
   }
   return parts.join('+')
 }
+module.exports.indentHumanize = indentHumanize
 
 /**
  * Formats a list of indent objects as a human-friendly string.

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -20,18 +20,30 @@ const LINES = /[^\r\n\u2028\u2029]+(?:$|\r\n|[\r\n\u2028\u2029])/g
 const BLOCK_COMMENT_PREFIX = /^\s*\*/
 const TRIVIAL_PUNCTUATOR = /^[(){}[\],;]$/
 
+const INDENT_MAX = { tabs: Number.MAX_SAFE_INTEGER, spaces: Number.MAX_SAFE_INTEGER }
+const INDENT_ZERO = { tabs: 0, spaces: 0 }
+
 /**
  * Normalize options.
  * @param {number|"tab"|undefined} type The type of indentation.
  * @param {Object} options Other options.
  * @param {Object} defaultOptions The default value of options.
- * @returns {{indentChar:" "|"\t",indentSize:number,baseIndent:number,attribute:number,closeBracket:number,switchCase:number,alignAttributesVertically:boolean,ignores:string[]}} Normalized options.
+ * @returns {{
+ *   indentStyle:string,
+ *   indent:{tabs:number,spaces:number},
+ *   baseIndent:{tabs:number,spaces:number},
+ *   attribute:number,
+ *   closeBracket:number,
+ *   switchCase:number,
+ *   alignAttributesVertically:boolean,
+ *   ignores:string[]
+ * }} Normalized options.
  */
 function parseOptions (type, options, defaultOptions) {
   const ret = Object.assign({
-    indentChar: ' ',
-    indentSize: 2,
-    baseIndent: 0,
+    indentStyle: 'spaces',
+    indent: { tabs: 0, spaces: 2 },
+    baseIndent: INDENT_ZERO,
     attribute: 1,
     closeBracket: 0,
     switchCase: 0,
@@ -39,15 +51,21 @@ function parseOptions (type, options, defaultOptions) {
     ignores: []
   }, defaultOptions)
 
-  if (Number.isSafeInteger(type)) {
-    ret.indentSize = type
-  } else if (type === 'tab') {
-    ret.indentChar = '\t'
-    ret.indentSize = 1
+  switch (type) {
+    case undefined:
+      break
+    case 'tab':
+      ret.indentStyle = 'tabs'
+      ret.indent = { tabs: 1, spaces: 0 }
+      break
+    default:
+      assert(Number.isSafeInteger(type))
+      ret.indentStyle = 'spaces'
+      ret.indent = { tabs: 0, spaces: type }
   }
 
   if (Number.isSafeInteger(options.baseIndent)) {
-    ret.baseIndent = options.baseIndent
+    ret.baseIndent = indentMul(ret.indent, options.baseIndent)
   }
   if (Number.isSafeInteger(options.attribute)) {
     ret.attribute = options.attribute
@@ -153,6 +171,56 @@ function indentCmp (a, b) {
 }
 
 function indentEq (a, b) { return indentCmp(a, b) === 0 }
+function indentMin (a, b) { return indentCmp(a, b) < 0 ? a : b }
+function indentMax (a, b) { return indentCmp(a, b) > 0 ? a : b }
+
+/**
+ * Adds two indent levels together.
+ * @param {{tabs:number,spaces:number}}
+ * @param {{tabs:number,spaces:number}}
+ * @returns {{tabs:number,spaces:number}}
+ */
+function indentAdd (a, b) {
+  assert(indentValid(a), "'a' must be a valid indent object")
+  assert(indentValid(b), "'b' must be a valid indent object")
+  return {
+    tabs: a.tabs + b.tabs,
+    spaces: (b.tabs ? 0 : a.spaces) + b.spaces
+  }
+}
+
+/**
+ * Subtracts two indent levels.
+ * @param {{tabs:number,spaces:number}}
+ * @param {{tabs:number,spaces:number}}
+ * @returns {{tabs:number,spaces:number}}
+ */
+function indentSub (a, b) {
+  assert(indentValid(a), "'a' must be a valid indent object")
+  assert(indentValid(b), "'b' must be a valid indent object")
+  if ((a.tabs || b.tabs) && b.spaces > a.spaces) {
+    assert(false, 'weird subtract: ' + JSON.stringify(a) + ' - ' + JSON.stringify(b))
+  }
+  return {
+    tabs: a.tabs - b.tabs,
+    spaces: (b.tabs ? 0 : a.spaces) - b.spaces
+  }
+}
+
+/**
+ * Multiplies an indent level by a scalar.
+ * @param {{tabs:number,spaces:number}}
+ * @param {number}
+ * @returns {{tabs:number,spaces:number}}
+ */
+function indentMul (indent, n) {
+  assert(indentValid(indent), "'indent' must be a valid indent object")
+  assert(typeof n === 'number', "'n' must be a number")
+  return {
+    tabs: indent.tabs * n,
+    spaces: indent.spaces * n
+  }
+}
 
 /**
  * Turns an indent specification in to a whitespace string.
@@ -606,10 +674,11 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   /**
    * Set the base indentation to a given top-level AST node.
    * @param {Node} node The node to set.
-   * @param {number} expectedIndent The number of expected indent.
+   * @param {{tabs:number,spaces:number} expectedIndent The number of expected indent.
    * @returns {void}
    */
   function processTopLevelNode (node, expectedIndent) {
+    assert(indentValid(expectedIndent))
     const token = tokenStore.getFirstToken(node)
     const offsetInfo = offsets.get(token)
     if (offsetInfo != null) {
@@ -657,11 +726,11 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   /**
    * Calculate correct indentation of the line of the given tokens.
    * @param {Token[]} tokens Tokens which are on the same line.
-   * @returns {number} Correct indentation. If it failed to calculate then `Number.MAX_SAFE_INTEGER`.
+   * @returns {{tabs:number,spaces:number}} Correct indentation. If it failed to calculate then `INDENT_MAX`.
    */
   function getExpectedIndent (tokens) {
     const trivial = isTrivialToken(tokens[0])
-    let expectedIndent = Number.MAX_SAFE_INTEGER
+    let expectedIndent = INDENT_MAX
 
     for (let i = 0; i < tokens.length; ++i) {
       const token = tokens[i]
@@ -670,11 +739,13 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
       // If the first token is not trivial then ignore trivial following tokens.
       if (offsetInfo != null && (trivial || !isTrivialToken(token))) {
         if (offsetInfo.expectedIndent != null) {
-          expectedIndent = Math.min(expectedIndent, offsetInfo.expectedIndent)
+          expectedIndent = indentMin(expectedIndent, offsetInfo.expectedIndent)
         } else {
           const baseOffsetInfo = offsets.get(offsetInfo.baseToken)
           if (baseOffsetInfo != null && baseOffsetInfo.expectedIndent != null && (i === 0 || !baseOffsetInfo.baseline)) {
-            expectedIndent = Math.min(expectedIndent, baseOffsetInfo.expectedIndent + offsetInfo.offset * options.indentSize)
+            expectedIndent = indentMin(expectedIndent,
+              indentAdd(baseOffsetInfo.expectedIndent,
+                indentMul(options.indent, offsetInfo.offset)))
             if (baseOffsetInfo.baseline) {
               break
             }
@@ -801,8 +872,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
    */
   function validateCore (token, acceptableIndents) {
     assert(acceptableIndents.length > 0, "'acceptableIndents' must have at least 1 indentation level")
-    acceptableIndents = acceptableIndents.slice().sort()
-      .map(n => (options.indentChar === '\t') ? { tabs: n, spaces: 0 } : { tabs: 0, spaces: n })
+    acceptableIndents = acceptableIndents.slice().sort(indentCmp)
 
     const actualIndent = getActualIndent(token, acceptableIndents)
     if (actualIndent === null) {
@@ -835,13 +905,13 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
    * @returns {{primary:number|undefined,secondary:number|undefined}}
    */
   function getCommentExpectedIndents (nextToken, nextExpectedIndent, lastExpectedIndent) {
-    if (typeof lastExpectedIndent === 'number' && isClosingToken(nextToken)) {
-      if (nextExpectedIndent === lastExpectedIndent) {
+    if (lastExpectedIndent && isClosingToken(nextToken)) {
+      if (indentEq(nextExpectedIndent, lastExpectedIndent)) {
         // For solo comment. E.g.,
         // <div>
         //    <!-- comment -->
         // </div>
-        return [nextExpectedIndent + options.indentSize]
+        return [indentAdd(nextExpectedIndent, options.indent)]
       }
 
       // For last comment. E.g.,
@@ -870,9 +940,9 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   function validate (tokens, comments, lastToken) {
     // Calculate and save expected indentation.
     const firstToken = tokens[0]
-    const actualIndent = firstToken.loc.start.column
+    const actualIndent = getActualIndent(firstToken)
     const expectedIndent = getExpectedIndent(tokens)
-    if (expectedIndent === Number.MAX_SAFE_INTEGER) {
+    if (indentEq(expectedIndent, INDENT_MAX)) {
       return
     }
 
@@ -897,12 +967,15 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
       if (offsetInfo != null) {
         if (offsetInfo.baseline) {
           // This is a baseline token, so the expected indent is the column of this token.
-          if (options.indentChar === ' ') {
-            offsetInfo.expectedIndent = Math.max(0, token.loc.start.column + expectedIndent - actualIndent)
-          } else {
+          if (options.indentStyle === 'tabs') {
             // In hard-tabs mode, it cannot align tokens strictly, so use one additional offset.
             // But the additional offset isn't needed if it's at the beginning of the line.
-            offsetInfo.expectedIndent = expectedIndent + (token === tokens[0] ? 0 : 1)
+            offsetInfo.expectedIndent = indentAdd(expectedIndent,
+              (token === tokens[0] ? INDENT_ZERO : options.indent))
+          } else {
+            offsetInfo.expectedIndent = indentMax(INDENT_ZERO,
+              indentAdd(indentSub(expectedIndent, actualIndent),
+                { tabs: 0, spaces: token.loc.start.column }))
           }
           baseline.add(token)
         } else if (baseline.has(offsetInfo.baseToken)) {
@@ -1627,14 +1700,14 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
         firstToken.value === '<script>'
       )
       const baseIndent =
-        isScriptTag ? (options.indentSize * options.baseIndent) : 0
+        isScriptTag ? options.baseIndent : INDENT_ZERO
 
       for (const statement of node.body) {
         processTopLevelNode(statement, baseIndent)
       }
     },
     "VElement[parent.type!='VElement']" (node) {
-      processTopLevelNode(node, 0)
+      processTopLevelNode(node, INDENT_ZERO)
     },
 
     // Do validation.

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -70,6 +70,27 @@ function parseOptions (type, options, defaultOptions) {
 }
 
 /**
+ * Formats a list of indent levels as a human-friendly string.
+ * @param {number} The number of characters to indent.
+ * @param {string} The unit name ("tabs" or "spaces") of that number.
+ * @returns {string} The human-friendly string.
+ */
+function indentsHumanize (ns, unit) {
+  switch (ns.length) {
+    case 0:
+      assert(false, 'must have at least one indentation level')
+      break
+    case 1:
+      return ns[0] + ' ' + unit + ((ns[0] === 1) ? '' : 's')
+    case 2:
+      return 'either ' + ns[0] + ' or ' + ns[1] + ' ' + unit + 's'
+    default:
+      ns[ns.length - 1] = 'or ' + ns[ns.length - 1]
+      return 'either ' + ns.join(', ') + ' ' + unit + 's'
+  }
+}
+
+/**
  * Check whether the given token is an arrow.
  * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is an arrow.
@@ -642,11 +663,12 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   /**
    * Validate the given token with the pre-calculated expected indentation.
    * @param {Token} token The token to validate.
-   * @param {number} expectedIndent The expected indentation.
-   * @param {number|undefined} optionalExpectedIndent The optional expected indentation.
+   * @param {number[]} acceptableIndents A list of expected indentations that are considered acceptable.
    * @returns {void}
    */
-  function validateCore (token, expectedIndent, optionalExpectedIndent) {
+  function validateCore (token, acceptableIndents) {
+    acceptableIndents = acceptableIndents.sort()
+    assert(acceptableIndents.length > 0, "'acceptableIndents' must have at least 1 (integer) indentation level")
     const line = token.loc.start.line
     const indentText = getIndentText(token)
 
@@ -672,27 +694,24 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
             expected: JSON.stringify(options.indentChar),
             actual: JSON.stringify(indentText[i])
           },
-          fix: defineFix(token, actualIndent, expectedIndent)
+          fix: (acceptableIndents.length === 1) ? defineFix(token, actualIndent, acceptableIndents[0]) : undefined
         })
         return
       }
     }
 
-    if (actualIndent !== expectedIndent && (optionalExpectedIndent === undefined || actualIndent !== optionalExpectedIndent)) {
+    if (!acceptableIndents.some(acceptableIndent => actualIndent === acceptableIndent)) {
       context.report({
         loc: {
           start: { line, column: 0 },
           end: { line, column: actualIndent }
         },
-        message: 'Expected indentation of {{expectedIndent}} {{unit}}{{expectedIndentPlural}} but found {{actualIndent}} {{unit}}{{actualIndentPlural}}.',
+        message: 'Expected indentation of {{acceptableIndents}} but found {{actualIndent}}.',
         data: {
-          expectedIndent,
-          actualIndent,
-          unit,
-          expectedIndentPlural: (expectedIndent === 1) ? '' : 's',
-          actualIndentPlural: (actualIndent === 1) ? '' : 's'
+          acceptableIndents: indentsHumanize(acceptableIndents, unit),
+          actualIndent: indentsHumanize([actualIndent], unit)
         },
-        fix: defineFix(token, actualIndent, expectedIndent)
+        fix: (acceptableIndents.length === 1) ? defineFix(token, actualIndent, acceptableIndents[0]) : undefined
       })
     }
   }
@@ -711,10 +730,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
         // <div>
         //    <!-- comment -->
         // </div>
-        return {
-          primary: nextExpectedIndent + options.indentSize,
-          secondary: undefined
-        }
+        return [nextExpectedIndent + options.indentSize]
       }
 
       // For last comment. E.g.,
@@ -722,7 +738,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
       //    <div></div>
       //    <!-- comment -->
       // </div>
-      return { primary: lastExpectedIndent, secondary: nextExpectedIndent }
+      return [lastExpectedIndent, nextExpectedIndent]
     }
 
     // Adjust to next normally. E.g.,
@@ -730,7 +746,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
     //    <!-- comment -->
     //    <div></div>
     // </div>
-    return { primary: nextExpectedIndent, secondary: undefined }
+    return [nextExpectedIndent]
   }
 
   /**
@@ -797,9 +813,9 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
 
     // Validate.
     for (const comment of comments) {
-      validateCore(comment, commentExpectedIndents.primary, commentExpectedIndents.secondary)
+      validateCore(comment, commentExpectedIndents)
     }
-    validateCore(firstToken, expectedIndent)
+    validateCore(firstToken, [expectedIndent])
   }
 
   // ------------------------------------------------------------------------------

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -70,24 +70,98 @@ function parseOptions (type, options, defaultOptions) {
 }
 
 /**
- * Formats a list of indent levels as a human-friendly string.
- * @param {number} The number of characters to indent.
- * @param {string} The unit name ("tabs" or "spaces") of that number.
+ * Returns whether an object is a valid indent (has the correct type).
+ * @param {{tabs:number,spaces:number}}
+ * @returns boolean
+ */
+function indentValid (indent) {
+  return indent &&
+    (typeof indent.tabs === 'number') &&
+    (typeof indent.spaces === 'number')
+}
+
+/**
+ * Format an indent object as a human-friendly string.
+ * @param {{tabs:number,spaces:number}} The indentation object.
  * @returns {string} The human-friendly string.
  */
-function indentsHumanize (ns, unit) {
-  switch (ns.length) {
-    case 0:
-      assert(false, 'must have at least one indentation level')
-      break
-    case 1:
-      return ns[0] + ' ' + unit + ((ns[0] === 1) ? '' : 's')
-    case 2:
-      return 'either ' + ns[0] + ' or ' + ns[1] + ' ' + unit + 's'
-    default:
-      ns[ns.length - 1] = 'or ' + ns[ns.length - 1]
-      return 'either ' + ns.join(', ') + ' ' + unit + 's'
+function indentHumanize (indent) {
+  assert(indentValid(indent), "'indent' must be a valid indent object")
+  if (indent.tabs === 0 & indent.spaces === 0) {
+    return '0'
   }
+  const parts = []
+  switch (indent.tabs) {
+    case 0: break
+    case 1: parts.push('1 tab'); break
+    default: parts.push(indent.tabs + ' tabs'); break
+  }
+  switch (indent.spaces) {
+    case 0: break
+    case 1: parts.push('1 space'); break
+    default: parts.push(indent.spaces + ' spaces'); break
+  }
+  return parts.join('+')
+}
+
+/**
+ * Formats a list of indent objects as a human-friendly string.
+ * @param {{tabs:number,spaces:number}} The indentation object.
+ * @returns {string} The human-friendly string.
+ */
+function indentsHumanize (indents) {
+  assert(indents.length > 0, "'indents' must have 1 or more indent objects")
+  assert(indents.every(indentValid), "'indents' must only consist of indent objects")
+  indents = indents.slice() // don't mutate the array passed to us
+
+  if (indents.every(i => i.tabs === 0) || indents.every(i => i.spaces === 0)) {
+    // constant units: we can only say the unit once: "2, 3, or 4 spaces"
+    const last = indentHumanize(indents.pop())
+    indents = indents.map(i => i.tabs + i.spaces)
+    indents.push(last)
+  } else {
+    // non-constant units: we have to say the unit every time: "1 tab, 2 spaces, or 4 spaces"
+    indents = indents.map(indentHumanize)
+  }
+  switch (indents.length) {
+    case 1:
+      return indents[0]
+    case 2:
+      return 'either ' + indents.join(' or ')
+    default:
+      indents[indents.length - 1] = 'or ' + indents[indents.length - 1]
+      return 'either ' + indents.join(', ')
+  }
+}
+
+/**
+ * Compares two indent specifications and indicates which is larger:
+ *  - < 0 if a < b
+ *  - = 0 if a == b
+ *  - > 0 if a > b
+ * @param {{tabs:number,spaces:number}}
+ * @param {{tabs:number,spaces:number}}
+ * @returns {number}
+ */
+function indentCmp (a, b) {
+  assert(indentValid(a), "'a' must be a valid indent object")
+  assert(indentValid(b), "'b' must be a valid indent object")
+  if (a.tabs === b.tabs) {
+    return a.spaces - b.spaces
+  }
+  return a.tabs - b.tabs
+}
+
+function indentEq (a, b) { return indentCmp(a, b) === 0 }
+
+/**
+ * Turns an indent specification in to a whitespace string.
+ * @param {{tabs:number,spaces:number}}
+ * @returns {string}
+ */
+function indentStr (indent) {
+  assert(indentValid(indent), "'indent' must be a valid indent object")
+  return '\t'.repeat(indent.tabs) + ' '.repeat(indent.spaces)
 }
 
 /**
@@ -631,19 +705,21 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   /**
    * Define the function which fixes the problem.
    * @param {Token} token The token to fix.
-   * @param {number} actualIndent The number of actual indentaion.
-   * @param {number} expectedIndent The number of expected indentation.
+   * @param {number} nchars The number of characters to replace.
+   * @param {{tabs:number,spaces:number}} expectedIndent The expected indentation.
    * @returns {Function} The defined function.
    */
-  function defineFix (token, actualIndent, expectedIndent) {
+  function defineFix (token, nchars, expectedIndent) {
+    assert(typeof nchars === 'number', "'nchars' should be a number")
+    assert(indentValid(expectedIndent), "'expectedIndent' must be a valid indent object")
     if (token.type === 'Block' && token.loc.start.line !== token.loc.end.line) {
       // Fix indentation in multiline block comments.
       const lines = sourceCode.getText(token).match(LINES)
       const firstLine = lines.shift()
       if (lines.every(l => BLOCK_COMMENT_PREFIX.test(l))) {
         return fixer => {
-          const range = [token.range[0] - actualIndent, token.range[1]]
-          const indent = options.indentChar.repeat(expectedIndent)
+          const range = [token.range[0] - nchars, token.range[1]]
+          const indent = indentStr(expectedIndent)
 
           return fixer.replaceTextRange(
             range,
@@ -654,10 +730,67 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
     }
 
     return fixer => {
-      const range = [token.range[0] - actualIndent, token.range[0]]
-      const indent = options.indentChar.repeat(expectedIndent)
+      const range = [token.range[0] - nchars, token.range[0]]
+      const indent = indentStr(expectedIndent)
       return fixer.replaceTextRange(range, indent)
     }
+  }
+
+  /**
+   * Creates an indentation object describing a token's indentation.
+   * @param {Token}
+   * @param {{tabs:number,spaces:number}[]|undefined}
+   * @returns {{tabs:number,spaces:number}|null}
+   */
+  function getActualIndent (token, acceptableIndents) {
+    const line = token.loc.start.line
+    const indentText = getIndentText(token)
+
+    // If there is no line terminator after the `<script>` start tag,
+    // `indentText` contains non-whitespace characters.
+    // In that case, do nothing in order to prevent removing the `<script>` tag.
+    if (indentText.trim() !== '') {
+      return null
+    }
+
+    const actualIndent = { tabs: 0, spaces: 0 }
+    let i = 0
+    for (; i < indentText.length && indentText[i] === '\t'; ++i) {
+      actualIndent.tabs++
+    }
+    for (; i < indentText.length && indentText[i] === ' '; ++i) {
+      actualIndent.spaces++
+    }
+    if (i < indentText.length) {
+      if (!acceptableIndents) {
+        // If we weren't given a list of acceptable indents, then we
+        // aren't being called from a place where we're doing error
+        // reporting.
+        return null
+      }
+      if (indentText[i] === '\t') {
+        context.report({
+          loc: { line, column: i },
+          message: 'Mixed spaces and tabs.',
+          fix: (acceptableIndents.length === 1) ? defineFix(token, indentText.length, acceptableIndents[0]) : undefined
+        })
+      } else {
+        context.report({
+          loc: {
+            start: { line, column: i },
+            end: { line, column: i + 1 }
+          },
+          message: 'Expected {{expected}} character, but found {{actual}} character.',
+          data: {
+            expected: actualIndent.spaces > 0 ? '" "' : '"\\t" or " "',
+            actual: JSON.stringify(indentText[i])
+          },
+          fix: (acceptableIndents.length === 1) ? defineFix(token, indentText.length, acceptableIndents[0]) : undefined
+        })
+      }
+      return null
+    }
+    return actualIndent
   }
 
   /**
@@ -667,51 +800,29 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
    * @returns {void}
    */
   function validateCore (token, acceptableIndents) {
-    acceptableIndents = acceptableIndents.sort()
-    assert(acceptableIndents.length > 0, "'acceptableIndents' must have at least 1 (integer) indentation level")
-    const line = token.loc.start.line
-    const indentText = getIndentText(token)
+    assert(acceptableIndents.length > 0, "'acceptableIndents' must have at least 1 indentation level")
+    acceptableIndents = acceptableIndents.slice().sort()
+      .map(n => (options.indentChar === '\t') ? { tabs: n, spaces: 0 } : { tabs: 0, spaces: n })
 
-    // If there is no line terminator after the `<script>` start tag,
-    // `indentText` contains non-whitespace characters.
-    // In that case, do nothing in order to prevent removing the `<script>` tag.
-    if (indentText.trim() !== '') {
+    const actualIndent = getActualIndent(token, acceptableIndents)
+    if (actualIndent === null) {
       return
     }
 
-    const actualIndent = token.loc.start.column
-    const unit = (options.indentChar === '\t' ? 'tab' : 'space')
-
-    for (let i = 0; i < indentText.length; ++i) {
-      if (indentText[i] !== options.indentChar) {
-        context.report({
-          loc: {
-            start: { line, column: i },
-            end: { line, column: i + 1 }
-          },
-          message: 'Expected {{expected}} character, but found {{actual}} character.',
-          data: {
-            expected: JSON.stringify(options.indentChar),
-            actual: JSON.stringify(indentText[i])
-          },
-          fix: (acceptableIndents.length === 1) ? defineFix(token, actualIndent, acceptableIndents[0]) : undefined
-        })
-        return
-      }
-    }
-
-    if (!acceptableIndents.some(acceptableIndent => actualIndent === acceptableIndent)) {
+    if (!acceptableIndents.some(acceptableIndent => indentEq(actualIndent, acceptableIndent))) {
+      assert(indentValid(acceptableIndents[0]))
+      const line = token.loc.start.line
       context.report({
         loc: {
           start: { line, column: 0 },
-          end: { line, column: actualIndent }
+          end: { line, column: (actualIndent.tabs + actualIndent.spaces) }
         },
-        message: 'Expected indentation of {{acceptableIndents}} but found {{actualIndent}}.',
+        message: 'Expected indentation of {{expected}} but found {{actual}}.',
         data: {
-          acceptableIndents: indentsHumanize(acceptableIndents, unit),
-          actualIndent: indentsHumanize([actualIndent], unit)
+          expected: indentsHumanize(acceptableIndents),
+          actual: indentHumanize(actualIndent)
         },
-        fix: (acceptableIndents.length === 1) ? defineFix(token, actualIndent, acceptableIndents[0]) : undefined
+        fix: (acceptableIndents.length === 1) ? defineFix(token, actualIndent.tabs + actualIndent.spaces, acceptableIndents[0]) : undefined
       })
     }
   }

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -438,25 +438,19 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
 
   /**
    * Set offset to the given tokens.
-   * @param {Token|Token[]} token The token to set.
+   * @param {Token|Token[]} tokens The tokens to set.
    * @param {number} offset The offset of the tokens.
    * @param {Token} baseToken The token of the base offset.
    * @param {boolean} [trivial=false] The flag for trivial tokens.
    * @returns {void}
    */
-  function setOffset (token, offset, baseToken) {
+  function setOffset (tokens, offset, baseToken) {
     assert(baseToken != null, "'baseToken' should not be null or undefined.")
 
-    if (Array.isArray(token)) {
-      for (const t of token) {
-        offsets.set(t, {
-          baseToken,
-          offset,
-          baseline: false,
-          expectedIndent: undefined
-        })
-      }
-    } else {
+    if (!Array.isArray(tokens)) {
+      tokens = [tokens]
+    }
+    for (const token of tokens) {
       offsets.set(token, {
         baseToken,
         offset,
@@ -729,15 +723,18 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
    * @returns {{tabs:number,spaces:number}} Correct indentation. If it failed to calculate then `INDENT_MAX`.
    */
   function getExpectedIndent (tokens) {
-    const trivial = isTrivialToken(tokens[0])
+    if (!isTrivialToken(tokens[0])) {
+      // If the first token is not trivial then ignore trivial following tokens.
+      tokens = tokens.filter(t => !isTrivialToken(t))
+    }
+
     let expectedIndent = INDENT_MAX
 
     for (let i = 0; i < tokens.length; ++i) {
       const token = tokens[i]
       const offsetInfo = offsets.get(token)
 
-      // If the first token is not trivial then ignore trivial following tokens.
-      if (offsetInfo != null && (trivial || !isTrivialToken(token))) {
+      if (offsetInfo != null) {
         if (offsetInfo.expectedIndent != null) {
           expectedIndent = indentMin(expectedIndent, offsetInfo.expectedIndent)
         } else {
@@ -965,6 +962,9 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
     for (const token of tokens) {
       const offsetInfo = offsets.get(token)
       if (offsetInfo != null) {
+        // Ensure that offsetInfo.expectedIndent is populated.  We do this even for tokens that
+        // aren't at the beginning of a line, so that tokens on following lines can declare them as
+        // their offsetInfo.baseToken, to easily line up with them.
         if (offsetInfo.baseline) {
           // This is a baseline token, so the expected indent is the column of this token.
           if (options.indentStyle === 'tabs') {

--- a/tests/fixtures/html-indent/smart-tabs-01.vue
+++ b/tests/fixtures/html-indent/smart-tabs-01.vue
@@ -1,0 +1,9 @@
+<!--{"options":["smart-tab"]}-->
+<template>
+	<div v-if="foo"
+	     id="foo"
+	     class="bar">
+		<my-long-tagname src="foo"
+		                 id="bar"/>
+	</div>
+</template>

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -62,7 +62,7 @@ function loadPatterns (additionalValid, additionalInvalid) {
         .map(line =>
           line.indentSize === 0
             ? null
-            : { message: `Expected indentation of ${line.indentSize} ${kind}${line.indentSize === 1 ? '' : 's'} but found 0 ${kind}s.`, line: line.number + 1 }
+            : { message: `Expected indentation of ${line.indentSize} ${kind}${line.indentSize === 1 ? '' : 's'} but found 0.`, line: line.number + 1 }
         )
         .filter(Boolean)
 
@@ -299,7 +299,7 @@ tester.run('html-indent', rule, loadPatterns(
         </template>
       `,
       errors: [
-        { message: 'Expected " " character, but found "\\t" character.', line: 3 }
+        { message: 'Mixed spaces and tabs.', line: 3 }
       ]
     },
     {
@@ -319,7 +319,7 @@ tester.run('html-indent', rule, loadPatterns(
       `,
       options: ['tab'],
       errors: [
-        { message: 'Expected "\\t" character, but found " " character.', line: 3 }
+        { message: 'Expected indentation of 2 tabs but found 1 tab+4 spaces.', line: 3 }
       ]
     },
 
@@ -346,12 +346,12 @@ tester.run('html-indent', rule, loadPatterns(
         </template>
       `,
       errors: [
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 4 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 5 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 6 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 7 }
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 2 },
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 3 },
+        { message: 'Expected indentation of 4 spaces but found 0.', line: 4 },
+        { message: 'Expected indentation of 4 spaces but found 0.', line: 5 },
+        { message: 'Expected indentation of 4 spaces but found 0.', line: 6 },
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 7 }
       ]
     },
     {
@@ -402,11 +402,11 @@ tester.run('html-indent', rule, loadPatterns(
         </template>
       `,
       errors: [
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of either 2 or 4 spaces but found 0 spaces.', line: 4 },
-        { message: 'Expected indentation of either 2 or 4 spaces but found 0 spaces.', line: 5 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 6 }
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 2 },
+        { message: 'Expected indentation of 4 spaces but found 0.', line: 3 },
+        { message: 'Expected indentation of either 2 or 4 spaces but found 0.', line: 4 },
+        { message: 'Expected indentation of either 2 or 4 spaces but found 0.', line: 5 },
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 6 }
       ]
     },
     {
@@ -431,10 +431,10 @@ tester.run('html-indent', rule, loadPatterns(
         </template>
       `,
       errors: [
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of either 2 or 4 spaces but found 0 spaces.', line: 4 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 7 }
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 2 },
+        { message: 'Expected indentation of 4 spaces but found 0.', line: 3 },
+        { message: 'Expected indentation of either 2 or 4 spaces but found 0.', line: 4 },
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 7 }
       ]
     },
 
@@ -520,10 +520,10 @@ tester.run('html-indent', rule, loadPatterns(
         </template>
       `,
       errors: [
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 4 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 8 }
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 2 },
+        { message: 'Expected indentation of 4 spaces but found 0.', line: 3 },
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 4 },
+        { message: 'Expected indentation of 2 spaces but found 0.', line: 8 }
       ]
     }
   ]

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -395,8 +395,8 @@ tester.run('html-indent', rule, loadPatterns(
         <template>
           {{
             message
-            // comment
-            // comment
+        // comment
+        // comment
           }}
         <!-- comment -->
         </template>
@@ -404,8 +404,8 @@ tester.run('html-indent', rule, loadPatterns(
       errors: [
         { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
         { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 4 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 5 },
+        { message: 'Expected indentation of either 2 or 4 spaces but found 0 spaces.', line: 4 },
+        { message: 'Expected indentation of either 2 or 4 spaces but found 0 spaces.', line: 5 },
         { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 6 }
       ]
     },
@@ -424,16 +424,16 @@ tester.run('html-indent', rule, loadPatterns(
         <template>
           {{
             message
-            /*
-             * comment
-             */
+        /*
+         * comment
+         */
           }}
         </template>
       `,
       errors: [
         { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
         { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 4 },
+        { message: 'Expected indentation of either 2 or 4 spaces but found 0 spaces.', line: 4 },
         { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 7 }
       ]
     },

--- a/tests/lib/rules/script-indent.js
+++ b/tests/lib/rules/script-indent.js
@@ -63,7 +63,7 @@ function loadPatterns (additionalValid, additionalInvalid) {
         .map(line =>
           line.indentSize === 0
             ? null
-            : { message: `Expected indentation of ${line.indentSize} ${kind}${line.indentSize === 1 ? '' : 's'} but found 0 ${kind}s.`, line: line.number + 1 }
+            : { message: `Expected indentation of ${line.indentSize} ${kind}${line.indentSize === 1 ? '' : 's'} but found 0.`, line: line.number + 1 }
         )
         .filter(Boolean)
 
@@ -183,7 +183,7 @@ tester.run('script-indent', rule, loadPatterns(
       `,
       options: [4],
       errors: [
-        { message: 'Expected indentation of 0 spaces but found 2 spaces.', line: 2 }
+        { message: 'Expected indentation of 0 but found 2 spaces.', line: 2 }
       ]
     },
 
@@ -202,7 +202,7 @@ tester.run('script-indent', rule, loadPatterns(
         </script>
       `,
       errors: [
-        { message: 'Expected " " character, but found "\\t" character.', line: 3 }
+        { message: 'Expected indentation of 2 spaces but found 1 tab.', line: 3 }
       ]
     },
     {
@@ -224,8 +224,8 @@ tester.run('script-indent', rule, loadPatterns(
       `,
       options: ['tab'],
       errors: [
-        { message: 'Expected "\\t" character, but found " " character.', line: 3 },
-        { message: 'Expected "\\t" character, but found " " character.', line: 4 }
+        { message: 'Expected indentation of 1 tab but found 2 spaces.', line: 3 },
+        { message: 'Expected indentation of 1 tab but found 2 spaces.', line: 4 }
       ]
     }
   ]


### PR DESCRIPTION
This implements the feature requested in #426.  It's a little light on added tests.

The individual commit messages give a good description of the precise changes.

Besides implementing smart-tab, it makes a few changes in message formats:

 - Say "either X or Y spaces" if there are multiple indent levels that it would accept.
 - Say "Mixed spaces and tabs" if that's what the problem is
 - If a line's indentation fits a style, just not the prescribed style,
   say what the found indent was.  "Expected indentation of 1 tab but found
   2 spaces.", instead of the fairly opaque unexpected character message.
 - Have "0" be unitless.  Don't say "0 tabs" or "0 spaces".  Zero is 0.

Additionally, it will no longer offer to fix the indentation if there are multiple indent levels that it would accept.