### PR TITLE
fix a typo in number of configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you want to disallow `eslint-disable` functionality, please disable [vue/comm
 
 ## :gear: Configs
 
-This plugin provides two predefined configs:
+This plugin provides four predefined configs:
 - `plugin:vue/base` - Settings and rules to enable correct ESLint parsing
 - `plugin:vue/essential` - Above, plus rules to prevent errors or unintended behavior
 - `plugin:vue/strongly-recommended` - Above, plus rules to considerably improve code readability and/or dev experience


### PR DESCRIPTION
It sure looks to me like there are four configurations in the list, not two. 