### PR TITLE
Docs: Delete duplicate sentence

### DIFF
--- a/docs/rules/valid-template-root.md
+++ b/docs/rules/valid-template-root.md
@@ -16,8 +16,6 @@ This rule reports the template root in the following cases:
 
 :-1: Examples of **incorrect** code for this rule:
 
-:-1: Examples of **incorrect** code for this rule:
-
 ```js
 template: ''
 ```


### PR DESCRIPTION
Simply detected and deleted duplicate in a sentence in `/docs/rules/valid-template-root.md`