### PR TITLE
Idea to allow eslint to skip over and allow <script lang="coffee"> in *.vue files

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -3,8 +3,17 @@
  */
 'use strict'
 
+// detect <script lang="coffee">
+const coffee = /^<script\s+lang=["']coffee[^]*^<\/script>/m
+
 module.exports = {
   preprocess (code) {
+
+    // do not lint coffeescript
+    code = code.replace(coffee, source => {
+      source.replace(/[^\n]/g, '')
+    })
+
     return [code]
   },
 


### PR DESCRIPTION
I'd like to use eslint in my *.vue files, but it bombs out with coffeescript, when using <script lang="coffee">.

Instead of disabling eslint for all *.vue files, this change skips over the coffeescript.

This is probably a terrible approach, but perhaps there's a way that the preprocess function could be overridden by user config?