### PR TITLE
(Fixes #416) Allow "default" key to be used also as a Literal

### DIFF
--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -50,7 +50,10 @@ module.exports = {
      */
     function propHasDefault (prop) {
       const propDefaultNode = prop.value.properties
-        .find(p => p.key && p.key.name === 'default')
+        .find(p =>
+          p.key &&
+          (p.key.name === 'default' || p.key.value === 'default')
+        )
 
       return Boolean(propDefaultNode)
     }

--- a/tests/lib/rules/require-default-prop.js
+++ b/tests/lib/rules/require-default-prop.js
@@ -39,11 +39,16 @@ ruleTester.run('require-default-prop', rule, {
             },
             c: {
               type: Number,
-              default: 0,
-              required: false
+              required: false,
+              default: 0
+            },
+            d: {
+              type: String,
+              required: false,
+              'default': 'lorem'
             },
             // eslint-disable-next-line require-default-prop
-            d: Number
+            e: Number
           }
         }
       `,


### PR DESCRIPTION
This PR fixes #416 by allowing users to use `default` key not only as Identifier, but also as a Literal in `require-default-prop` rule:
```
{
  'default': 0,
}
```