### PR TITLE
(Fixes #420) Fix false positive in no-side-effect-in-cp

### DIFF
--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -41,7 +41,7 @@ module.exports = {
         },
         // this.xxx.func()
         'CallExpression' (node) {
-          const code = context.getSourceCode().getText(node)
+          const code = utils.parseMemberOrCallExpression(node)
           const MUTATION_REGEX = /(this.)((?!(concat|slice|map|filter)\().)[^\)]*((push|pop|shift|unshift|reverse|splice|sort|copyWithin|fill)\()/g
 
           if (MUTATION_REGEX.test(code)) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -617,5 +617,42 @@ module.exports = {
       return
     }
     return body.errors.some(error => typeof error.code === 'string' && error.code.startsWith('eof-'))
+  },
+
+  /**
+   * Parse CallExpression or MemberExpression to get simplified version without arguments
+   *
+   * @param  {Object} node The node to parse (MemberExpression | CallExpression)
+   * @return {String} eg. 'this.asd.qwe().map().filter().test.reduce()'
+   */
+  parseMemberOrCallExpression (node) {
+    const parsedCallee = []
+    let n = node
+    let isFunc
+
+    while (n.type === 'MemberExpression' || n.type === 'CallExpression') {
+      if (n.type === 'CallExpression') {
+        n = n.callee
+        isFunc = true
+      } else {
+        if (!n.computed && n.property.type === 'Identifier') {
+          parsedCallee.push(n.property.name + (isFunc ? '()' : ''))
+        } else if (n.property.type === 'Literal') {
+          parsedCallee.push(n.property.value + (isFunc ? '()' : ''))
+        }
+        isFunc = false
+        n = n.object
+      }
+    }
+
+    if (n.type === 'Identifier') {
+      parsedCallee.push(n.name)
+    }
+
+    if (n.type === 'ThisExpression') {
+      parsedCallee.push('this')
+    }
+
+    return parsedCallee.reverse().join('.')
   }
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -635,10 +635,10 @@ module.exports = {
         n = n.callee
         isFunc = true
       } else {
-        if (!n.computed && n.property.type === 'Identifier') {
+        if (n.computed) {
+          parsedCallee.push('[]')
+        } else if (n.property.type === 'Identifier') {
           parsedCallee.push(n.property.name + (isFunc ? '()' : ''))
-        } else if (n.property.type === 'Literal') {
-          parsedCallee.push(n.property.value + (isFunc ? '()' : ''))
         }
         isFunc = false
         n = n.object
@@ -653,6 +653,6 @@ module.exports = {
       parsedCallee.push('this')
     }
 
-    return parsedCallee.reverse().join('.')
+    return parsedCallee.reverse().join('.').replace(/\.\[/g, '[')
   }
 }

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -81,6 +81,22 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             get() {
               return Object.keys(this.a).sort()
             }
+          },
+          test11() {
+            const categories = {}
+
+            this.types.forEach(c => {
+              categories[c.category] = categories[c.category] || []
+              categories[c.category].push(c)
+            })
+
+            return categories
+          },
+          test12() {
+            return this.types.map(t => {
+              // [].push('xxx')
+              return t
+            })
           }
         }
       })`,

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -97,6 +97,9 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
               // [].push('xxx')
               return t
             })
+          },
+          test13 () {
+            this.someArray.forEach(arr => console.log(arr))
           }
         }
       })`,

--- a/tests/lib/utils/index.js
+++ b/tests/lib/utils/index.js
@@ -166,3 +166,29 @@ describe('getStaticPropertyName', () => {
     assert.ok(parsed === 'computed')
   })
 })
+
+describe('parseMemberOrCallExpression', () => {
+  let node
+
+  const parse = function (code) {
+    return babelEslint.parse(code).body[0].declarations[0].init
+  }
+
+  it('should parse CallExpression', () => {
+    node = parse(`const test = this.lorem['ipsum'].map(d => d.id).filter((a, b) => a > b).reduce((acc, d) => acc + d, 0)`)
+    const parsed = utils.parseMemberOrCallExpression(node)
+    assert.equal(parsed, 'this.lorem.ipsum.map().filter().reduce()')
+  })
+
+  it('should parse MemberExpression', () => {
+    node = parse(`const test = this.lorem['ipsum'].map(d => d.id).dolor.reduce((acc, d) => acc + d, 0).sit`)
+    const parsed = utils.parseMemberOrCallExpression(node)
+    assert.equal(parsed, 'this.lorem.ipsum.map().dolor.reduce().sit')
+  })
+
+  it('should ignore computed values', () => {
+    node = parse(`const test = this.lorem[ipsum].dolor.map(d => d.id)['asd']()`)
+    const parsed = utils.parseMemberOrCallExpression(node)
+    assert.equal(parsed, 'this.lorem.dolor.map().asd()')
+  })
+})

--- a/tests/lib/utils/index.js
+++ b/tests/lib/utils/index.js
@@ -177,18 +177,12 @@ describe('parseMemberOrCallExpression', () => {
   it('should parse CallExpression', () => {
     node = parse(`const test = this.lorem['ipsum'].map(d => d.id).filter((a, b) => a > b).reduce((acc, d) => acc + d, 0)`)
     const parsed = utils.parseMemberOrCallExpression(node)
-    assert.equal(parsed, 'this.lorem.ipsum.map().filter().reduce()')
+    assert.equal(parsed, 'this.lorem[].map().filter().reduce()')
   })
 
   it('should parse MemberExpression', () => {
-    node = parse(`const test = this.lorem['ipsum'].map(d => d.id).dolor.reduce((acc, d) => acc + d, 0).sit`)
+    node = parse(`const test = this.lorem['ipsum'][0].map(d => d.id).dolor.reduce((acc, d) => acc + d, 0).sit`)
     const parsed = utils.parseMemberOrCallExpression(node)
-    assert.equal(parsed, 'this.lorem.ipsum.map().dolor.reduce().sit')
-  })
-
-  it('should ignore computed values', () => {
-    node = parse(`const test = this.lorem[ipsum].dolor.map(d => d.id)['asd']()`)
-    const parsed = utils.parseMemberOrCallExpression(node)
-    assert.equal(parsed, 'this.lorem.dolor.map().asd()')
+    assert.equal(parsed, 'this.lorem[][].map().dolor.reduce().sit')
   })
 })


### PR DESCRIPTION
This PR fixes #420, by introducing parser that simplifies given MemberExpression or CallExpression to version that can be properly verified in terms of potential side-effect in the chain.

So for example this kind of code:
```js
this.categories['test']
  .map(c => c.items)
  .sort()[0]
  .anotherProp
  .slice(1)
  .reduce((acc, item) => {
    // item.push(10)
    return acc + item.length;
  }, 0)
  .length
```

Is being simplified to this:
```
this.categories.test.map().sort()[].anotherProp.slice().reduce().length
```

And now we can properly check for potential side-effects in the given chain without potential false-positives hidden in inner scopes.