### PR TITLE
(Fixes #436) Fix 'getComputedProperties'

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -344,6 +344,7 @@ module.exports = {
         } else if (cp.value.type === 'ObjectExpression') {
           value = cp.value.properties
             .filter(p =>
+              p.type === 'Property' &&
               p.key.type === 'Identifier' &&
               p.key.name === 'get' &&
               p.value.type === 'FunctionExpression'

--- a/tests/lib/rules/no-async-in-computed-properties.js
+++ b/tests/lib/rules/no-async-in-computed-properties.js
@@ -51,10 +51,14 @@ ruleTester.run('no-async-in-computed-properties', rule, {
                 return bar
               }
             },
-            foo2: {
+            bar: {
               set () {
                 new Promise((resolve, reject) => {})
               }
+            },
+            baz: {
+              ...mapGetters({ get: 'getBaz' }),
+              ...mapActions({ set: 'setBaz' })
             }
           }
         }

--- a/tests/lib/utils/index.js
+++ b/tests/lib/utils/index.js
@@ -120,6 +120,28 @@ describe('getComputedProperties', () => {
 
     assert.ok(computedProperties[0].value)
   })
+
+  it('should not collide with object spread operator inside CP', () => {
+    node = parse(`const test = {
+      name: 'test',
+      computed: {
+        foo: {
+          ...mapGetters({ get: 'getFoo' }),
+          ...mapActions({ set: 'setFoo' })
+        }
+      }
+    }`)
+
+    const computedProperties = utils.getComputedProperties(node)
+
+    assert.equal(
+      computedProperties.length,
+      1,
+      'it detects all computed properties'
+    )
+
+    assert.notOk(computedProperties[0].value)
+  })
 })
 
 describe('getStaticPropertyName', () => {


### PR DESCRIPTION
This PR fixes #436 by adding extra check to allow using object rest spread operator inside CP.