### PR TITLE
Fix: Allow props with `validator` without `type` in `vue/require-prop-types`

### DIFF
--- a/docs/rules/require-prop-types.md
+++ b/docs/rules/require-prop-types.md
@@ -17,24 +17,24 @@ props: ['status']
 :+1: Examples of **correct** code for this rule:
 
 ```js
+// Without options, just type reference
 props: {
   status: String
 }
 ```
 
 ```js
+// With options with type field
 props: {
   status: {
     type: String,
     required: true,
-    validate: function (value) {
-      return ['syncing', 'synced', 'version-conflict', 'error'].indexOf(value) !== -1
-    }
   }
 }
 ```
 
 ```js
+// With options without type field but with validator field
 props: {
   status: {
     required: true,

--- a/docs/rules/require-prop-types.md
+++ b/docs/rules/require-prop-types.md
@@ -34,6 +34,20 @@ props: {
 }
 ```
 
+```js
+props: {
+  status: {
+    required: true,
+    validator: function (value) {
+      return (
+        value === null ||
+        Array.isArray(value) && value.length > 0
+      )
+    }
+  }
+}
+```
+
 ## :wrench: Options
 
 Nothing.

--- a/lib/rules/require-prop-types.js
+++ b/lib/rules/require-prop-types.js
@@ -37,7 +37,9 @@ module.exports = {
             p.value.elements.length > 0
           )
         )
-      return Boolean(typeProperty)
+      const validatorProperty = node.properties
+        .find(p => utils.getStaticPropertyName(p.key) === 'validator')
+      return Boolean(typeProperty || validatorProperty)
     }
 
     function checkProperties (items) {

--- a/tests/lib/rules/require-prop-types.js
+++ b/tests/lib/rules/require-prop-types.js
@@ -74,6 +74,32 @@ ruleTester.run('require-prop-types', rule, {
       filename: 'test.vue',
       code: `
         export default {
+          props: {
+            foo: {
+              validator: v => v
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: {
+            foo: {
+              ['validator']: v => v
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
           props
         }
       `,


### PR DESCRIPTION
According to [the docs](https://vuejs.org/v2/guide/components-props.html#Prop-Validation), if the `type` property is insufficient and more complex type-checking is required, one can use the `validator` property. Currently `eslint-plugin-vue` reports an error in such cases.