### PR TITLE
⭐️ New: Support ESLint 5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
 
 test:
   override:
-    - nvm use 4 && npm test
+    - nvm use 4 && npm i eslint@4.19.1 --no-save && npm test
     - nvm use 6 && npm test
     - nvm use 8 && npm test
     # Test for the minimum version we are supporting.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">=4"
   },
   "peerDependencies": {
-    "eslint": "^3.18.0 || ^4.0.0"
+    "eslint": "^3.18.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "vue-eslint-parser": "^2.0.3"
@@ -50,7 +50,7 @@
     "@types/node": "^4.2.16",
     "babel-eslint": "^8.2.2",
     "chai": "^4.1.0",
-    "eslint": "^4.14.0",
+    "eslint": "^5.0.0",
     "eslint-plugin-eslint-plugin": "^0.8.0",
     "eslint-plugin-html": "^4.0.1",
     "eslint-plugin-vue-libs": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^3.18.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "vue-eslint-parser": "^2.0.3"
+    "vue-eslint-parser": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",


### PR DESCRIPTION
https://eslint.org/blog/2018/06/eslint-v5.0.0-released
ESLint 5 drops support for Node 4, updated CI accordingly.