### PR TITLE
Fix attribute-hyphenation ignore lists

### DIFF
--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -49,10 +49,10 @@ module.exports = {
     const option = context.options[0]
     const optionsPayload = context.options[1]
     const useHyphenated = option !== 'never'
-    const ignoredAttributes = ['data-', 'aria-', 'slot-scope']
+    let ignoredAttributes = ['data-', 'aria-', 'slot-scope']
 
     if (optionsPayload && optionsPayload.ignore) {
-      ignoredAttributes.push(optionsPayload.ignore)
+      ignoredAttributes = ignoredAttributes.concat(optionsPayload.ignore)
     }
 
     const caseConverter = casing.getConverter(useHyphenated ? 'kebab-case' : 'camelCase')

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -63,7 +63,7 @@ module.exports = {
       context.report({
         node: node.key,
         loc: node.loc,
-        message: useHyphenated ? "Attribute '{{text}}' must be hyphenated." : "Attribute '{{text}}' cann't be hyphenated.",
+        message: useHyphenated ? "Attribute '{{text}}' must be hyphenated." : "Attribute '{{text}}' can't be hyphenated.",
         data: {
           text
         },

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -130,27 +130,74 @@ ruleTester.run('attribute-hyphenation', rule, {
     },
     {
       filename: 'test.vue',
-      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" third-custom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
-      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" thirdCustom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
-      options: ['never', { 'ignore': ['custom-hyphen', 'second-custom'] }],
+      code: '<template><div><custom v-bind:my-prop="prop" :second-prop="test"></custom></div></template>',
+      output: '<template><div><custom v-bind:my-prop="prop" :secondProp="test"></custom></div></template>',
+      options: ['never', { ignore: ['my-prop'] }],
       errors: [{
-        message: "Attribute 'third-custom' can't be hyphenated.",
+        message: "Attribute ':second-prop' can't be hyphenated.",
         type: 'VDirectiveKey',
         line: 1
       }]
     },
     {
-      // This is the same code as the `'ignore': ['custom-hyphen']`
-      // valid test; to verify that setting ignore actually makes the
-      // difference.
       filename: 'test.vue',
-      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
-      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" customHyphen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
+      code: '<template><div><custom v-bind:myProp="prop" :secondProp="test"></custom></div></template>',
+      output: '<template><div><custom v-bind:my-prop="prop" :secondProp="test"></custom></div></template>',
+      options: ['always', { ignore: ['secondProp'] }],
+      errors: [{
+        message: "Attribute 'v-bind:myProp' must be hyphenated.",
+        type: 'VDirectiveKey',
+        line: 1
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" second-custom="baz" third-custom="bar">
+            <a onClick="" my-prop="prop"></a>
+          </custom>
+        </template>
+      `,
+      output: `
+        <template>
+          <custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" second-custom="baz" thirdCustom="bar">
+            <a onClick="" my-prop="prop"></a>
+          </custom>
+        </template>
+      `,
+      options: ['never', { 'ignore': ['custom-hyphen', 'second-custom'] }],
+      errors: [{
+        message: "Attribute 'third-custom' can't be hyphenated.",
+        type: 'VIdentifier',
+        line: 3
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" second-custom="baz" thirdCustom="bar">
+            <a onClick="" my-prop="prop"></a>
+          </custom>
+        </template>
+      `,
+      output: `
+        <template>
+          <custom data-id="foo" aria-test="bar" slot-scope="{ data }" customHyphen="foo" secondCustom="baz" thirdCustom="bar">
+            <a onClick="" my-prop="prop"></a>
+          </custom>
+        </template>
+      `,
       options: ['never'],
       errors: [{
         message: "Attribute 'custom-hyphen' can't be hyphenated.",
         type: 'VIdentifier',
-        line: 1
+        line: 3
+      }, {
+        message: "Attribute 'second-custom' can't be hyphenated.",
+        type: 'VIdentifier',
+        line: 3
       }]
     }
   ]

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -45,7 +45,7 @@ ruleTester.run('attribute-hyphenation', rule, {
     },
     {
       filename: 'test.vue',
-      code: '<template><div data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo"><a onClick="" my-prop="prop"></a></div></template>',
+      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
       options: ['never', { 'ignore': ['custom-hypen'] }]
     }
   ],
@@ -114,6 +114,20 @@ ruleTester.run('attribute-hyphenation', rule, {
       errors: [{
         message: "Attribute 'v-bind:MyProp' must be hyphenated.",
         type: 'VDirectiveKey',
+        line: 1
+      }]
+    },
+    {
+      // This is the same code as the `'ignore': ['custom-hypen']`
+      // valid test; to verify that setting ignore actually makes the
+      // difference.
+      filename: 'test.vue',
+      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
+      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" customHypen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
+      options: ['never'],
+      errors: [{
+        message: "Attribute 'custom-hypen' cann't be hyphenated.",
+        type: 'VIdentifier',
         line: 1
       }]
     }

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -45,8 +45,8 @@ ruleTester.run('attribute-hyphenation', rule, {
     },
     {
       filename: 'test.vue',
-      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo" second-custom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
-      options: ['never', { 'ignore': ['custom-hypen', 'second-custom'] }]
+      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" second-custom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
+      options: ['never', { 'ignore': ['custom-hyphen', 'second-custom'] }]
     }
   ],
 
@@ -57,7 +57,7 @@ ruleTester.run('attribute-hyphenation', rule, {
       output: '<template><div><custom myProp="foo"></custom></div></template>',
       options: ['never'],
       errors: [{
-        message: "Attribute 'my-prop' cann't be hyphenated.",
+        message: "Attribute 'my-prop' can't be hyphenated.",
         type: 'VIdentifier',
         line: 1
       }]
@@ -79,7 +79,7 @@ ruleTester.run('attribute-hyphenation', rule, {
       output: '<template><div><custom :myProp="prop"></custom></div></template>',
       options: ['never'],
       errors: [{
-        message: "Attribute ':my-prop' cann't be hyphenated.",
+        message: "Attribute ':my-prop' can't be hyphenated.",
         type: 'VDirectiveKey',
         line: 1
       }]
@@ -101,7 +101,7 @@ ruleTester.run('attribute-hyphenation', rule, {
       output: '<template><div><custom v-bind:myProp="prop"></custom></div></template>',
       options: ['never'],
       errors: [{
-        message: "Attribute 'v-bind:my-prop' cann't be hyphenated.",
+        message: "Attribute 'v-bind:my-prop' can't be hyphenated.",
         type: 'VDirectiveKey',
         line: 1
       }]
@@ -130,25 +130,25 @@ ruleTester.run('attribute-hyphenation', rule, {
     },
     {
       filename: 'test.vue',
-      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo" third-custom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
-      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo" thirdCustom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
-      options: ['never', { 'ignore': ['custom-hypen', 'second-custom'] }],
+      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" third-custom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
+      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" thirdCustom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
+      options: ['never', { 'ignore': ['custom-hyphen', 'second-custom'] }],
       errors: [{
-        message: "Attribute 'third-custom' cann't be hyphenated.",
+        message: "Attribute 'third-custom' can't be hyphenated.",
         type: 'VDirectiveKey',
         line: 1
       }]
     },
     {
-      // This is the same code as the `'ignore': ['custom-hypen']`
+      // This is the same code as the `'ignore': ['custom-hyphen']`
       // valid test; to verify that setting ignore actually makes the
       // difference.
       filename: 'test.vue',
-      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
-      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" customHypen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
+      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
+      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" customHyphen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
       options: ['never'],
       errors: [{
-        message: "Attribute 'custom-hypen' cann't be hyphenated.",
+        message: "Attribute 'custom-hyphen' can't be hyphenated.",
         type: 'VIdentifier',
         line: 1
       }]

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -45,8 +45,8 @@ ruleTester.run('attribute-hyphenation', rule, {
     },
     {
       filename: 'test.vue',
-      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo"><a onClick="" my-prop="prop"></a></custom></template>',
-      options: ['never', { 'ignore': ['custom-hypen'] }]
+      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo" second-custom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
+      options: ['never', { 'ignore': ['custom-hypen', 'second-custom'] }]
     }
   ],
 
@@ -113,6 +113,28 @@ ruleTester.run('attribute-hyphenation', rule, {
       options: ['always'],
       errors: [{
         message: "Attribute 'v-bind:MyProp' must be hyphenated.",
+        type: 'VDirectiveKey',
+        line: 1
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><custom v-bind:MyProp="prop"></custom></div></template>',
+      output: '<template><div><custom v-bind:my-prop="prop"></custom></div></template>',
+      options: ['always', { 'ignore': [] }],
+      errors: [{
+        message: "Attribute 'v-bind:MyProp' must be hyphenated.",
+        type: 'VDirectiveKey',
+        line: 1
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo" third-custom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
+      output: '<template><custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hypen="foo" thirdCustom="bar"><a onClick="" my-prop="prop"></a></custom></template>',
+      options: ['never', { 'ignore': ['custom-hypen', 'second-custom'] }],
+      errors: [{
+        message: "Attribute 'third-custom' cann't be hyphenated.",
         type: 'VDirectiveKey',
         line: 1
       }]


### PR DESCRIPTION
Commit f9e1eee3fe711b9dfedc037fe25aa5570370296e introduced the "ignore" config option for the attribute-hyphenation rule.  However, that commit has a few problems:

 - The added testcase doesn't actually test the functionality at all
 - The code only works correctly if the ignore list has exactly 1 item in it
 - There are spelling mistakes in the test

See each individual commit message for more details.