### PR TITLE
Update default settings in html-closing-bracket-newline

### DIFF
--- a/docs/rules/html-closing-bracket-newline.md
+++ b/docs/rules/html-closing-bracket-newline.md
@@ -25,7 +25,7 @@ This rule enforces a line break (or no line break) before tag's closing brackets
 {
     "vue/html-closing-bracket-newline": ["error", {
         "singleline": "never",
-        "multiline": "never"
+        "multiline": "always"
     }]
 }
 ```
@@ -34,63 +34,53 @@ This rule enforces a line break (or no line break) before tag's closing brackets
     - `"never"` ... disallow line breaks before the closing bracket. This is the default.
     - `"always"` ... require one line break before the closing bracket.
 - `multiline` ... the configuration for multiline elements. It's a multiline element if the last attribute is not on the same line of the opening bracket.
-    - `"never"` ... disallow line breaks before the closing bracket. This is the default.
-    - `"always"` ... require one line break before the closing bracket.
+    - `"never"` ... disallow line breaks before the closing bracket.
+    - `"always"` ... require one line break before the closing bracket. This is the default.
 
 Plus, you can use [`vue/html-indent`](./html-indent.md) rule to enforce indent-level of the closing brackets.
 
 :-1: Examples of **incorrect** code for this rule:
 
 ```html
-/*eslint html-closing-bracket-newline: "error"*/
+<!-- eslint html-closing-bracket-newline: "error" -->
 
 <div id="foo" class="bar"
 >
+
 <div
     id="foo"
-    class="bar"
->
-<div
-    id="foo"
-    class="bar"
-    >
+    class="bar">
 ```
 
 :+1: Examples of **correct** code for this rule:
 
 ```html
-/*eslint html-closing-bracket-newline: "error"*/
-
-<div id="foo" class="bar">
-<div
-    id="foo"
-    class="bar">
-```
-
-:-1: Examples of **incorrect** code for `{ "multiline": "always" }`:
-
-```html
-/*eslint html-closing-bracket-newline: ["error", { multiline: always }]*/
-
-<div id="foo" class="bar"
->
-<div
-    id="foo"
-    class="bar">
-```
-
-:+1: Examples of **correct** code for `{ "multiline": "always" }`:
-
-```html
-/*eslint html-closing-bracket-newline: ["error", { multiline: always }]*/
+<!-- eslint html-closing-bracket-newline: "error" -->
 
 <div id="foo" class="bar">
 <div
     id="foo"
     class="bar"
 >
+```
+
+:-1: Examples of **incorrect** code for `{ "multiline": "never" }`:
+
+```html
+<!-- eslint html-closing-bracket-newline: ["error", { multiline: never }] -->
+
 <div
     id="foo"
     class="bar"
-    >
+>
+```
+
+:+1: Examples of **correct** code for `{ "multiline": "never" }`:
+
+```html
+<!-- html-closing-bracket-newline: ["error", { multiline: never }] -->
+
+<div
+    id="foo"
+    class="bar">
 ```

--- a/lib/rules/html-closing-bracket-newline.js
+++ b/lib/rules/html-closing-bracket-newline.js
@@ -46,7 +46,10 @@ module.exports = {
   },
 
   create (context) {
-    const options = context.options[0] || {}
+    const options = Object.assign({}, {
+      singleline: 'never',
+      multiline: 'always'
+    }, context.options[0] || {})
     const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
 
     return utils.defineTemplateBodyVisitor(context, {

--- a/tests/lib/rules/html-closing-bracket-newline.js
+++ b/tests/lib/rules/html-closing-bracket-newline.js
@@ -29,7 +29,8 @@ tester.run('html-closing-bracket-newline', rule, {
     `
       <template>
         <div
-          id="">
+          id=""
+        >
         </div>
       </template>
     `,
@@ -144,20 +145,20 @@ tester.run('html-closing-bracket-newline', rule, {
       code: `
         <template>
           <div
-            id=""
-            >
+            id="">
           </div>
         </template>
       `,
       output: `
         <template>
           <div
-            id="">
+            id=""
+>
           </div>
         </template>
       `,
       errors: [
-        'Expected no line breaks before closing bracket, but 1 line break found.'
+        'Expected 1 line break before closing bracket, but no line breaks found.'
       ]
     },
     {


### PR DESCRIPTION
This PR introduces update to default setting for `html-closing-bracket-newline`, to force new line in case of multiline elements.
```
{
  "singleline": "never",
  "multiline": "always"
}
```

The reason behind this update, is that in case of multiline elements, having closing tag on a separate line makes the code more readable. Especially when there are many elements in the template. We could compare it to JS objects. We don't write:
```js
const a = {
  key: 'value' };
```
but rather:
```js
const a = {
  key: 'value'
};
```

Incorrect code regarding new setting:
```html
<SomeComponent
  class="lorem"
  :lorem="ipsum" />
```

Correct code:
```html
<SomeComponent
  class="lorem"
  :lorem="ipsum"
/>
```

`singleline` setting stays as is, forcing devs to keep closing tag at the same line.