### PR TITLE
[New] Add `vue/html-tag-attrs-content-newline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :wrench: | [vue/component-name-in-template-casing](./docs/rules/component-name-in-template-casing.md) | enforce specific casing for the component naming style in template |
+| :wrench: | [vue/html-tag-attrs-content-newline](./docs/rules/html-tag-attrs-content-newline.md) | require a line break before and after contents whenever the HTML tag has any attribute |
 | :wrench: | [vue/script-indent](./docs/rules/script-indent.md) | enforce consistent indentation in `<script>` |
 
 ### Deprecated

--- a/docs/rules/html-tag-attrs-content-newline.md
+++ b/docs/rules/html-tag-attrs-content-newline.md
@@ -36,7 +36,7 @@ This rule enforces a line break before and after html contents whenever the HTML
 
 ```json
 {
-    "vue/html-content-newline": ["error", {
+    "vue/html-tag-attrs-content-newline": ["error", {
         "ignoreNames": ["pre", "textarea"]
     }]
 }
@@ -49,7 +49,7 @@ This rule enforces a line break before and after html contents whenever the HTML
 :+1: Examples of **correct** code:
 
 ```html
-/*eslint vue/html-content-newline: ["error", { "ignoreNames": ["VueComponent", "pre", "textarea"]}] */
+/*eslint vue/html-tag-attrs-content-newline: ["error", { "ignoreNames": ["VueComponent", "pre", "textarea"]}] */
 
 <VueComponent class="panel">content</VueComponent>
 

--- a/docs/rules/html-tag-attrs-content-newline.md
+++ b/docs/rules/html-tag-attrs-content-newline.md
@@ -49,7 +49,7 @@ This rule enforces a line break before and after html contents whenever the HTML
 :+1: Examples of **correct** code:
 
 ```html
-/*eslint vue/html-content-newline: ["error", { "ignoreNames": ["vue-component", "pre", "textarea"]}] */
+/*eslint vue/html-content-newline: ["error", { "ignoreNames": ["VueComponent", "pre", "textarea"]}] */
 
 <VueComponent class="panel">content</VueComponent>
 

--- a/docs/rules/html-tag-attrs-content-newline.md
+++ b/docs/rules/html-tag-attrs-content-newline.md
@@ -1,0 +1,62 @@
+# require a line break before and after contents whenever the HTML tag has any attribute (vue/html-tag-attrs-content-newline)
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule enforces a line break before and after html contents whenever the HTML tag has any attribute.
+
+
+:-1: Examples of **incorrect** code:
+
+```html
+<div
+  class="panel"
+>content</div>
+```
+
+:+1: Examples of **correct** code:
+
+```html
+<div>content</div>
+
+<div class="panel">
+  content
+</div>
+
+<div
+  class="panel"
+>
+  content
+</div>
+```
+
+
+## :wrench: Options
+
+```json
+{
+    "vue/html-content-newline": ["error", {
+        "ignoreNames": ["pre", "textarea"]
+    }]
+}
+```
+
+- `ignoreNames` ... the configuration for element names to ignore line breaks style.  
+    default `["pre", "textarea"]`
+
+
+:+1: Examples of **correct** code:
+
+```html
+/*eslint vue/html-content-newline: ["error", { "ignoreNames": ["vue-component", "pre", "textarea"]}] */
+
+<VueComponent class="panel">content</VueComponent>
+
+<VueComponent
+  class="panel"
+>
+  content
+</VueComponent>
+```
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'html-indent': require('./rules/html-indent'),
     'html-quotes': require('./rules/html-quotes'),
     'html-self-closing': require('./rules/html-self-closing'),
+    'html-tag-attrs-content-newline': require('./rules/html-tag-attrs-content-newline'),
     'jsx-uses-vars': require('./rules/jsx-uses-vars'),
     'max-attributes-per-line': require('./rules/max-attributes-per-line'),
     'mustache-interpolation-spacing': require('./rules/mustache-interpolation-spacing'),

--- a/lib/rules/html-tag-attrs-content-newline.js
+++ b/lib/rules/html-tag-attrs-content-newline.js
@@ -1,0 +1,149 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+function hasAttributes (node) {
+  return node.startTag.attributes.length > 0
+}
+
+function parseOptions (options) {
+  return Object.assign({
+    'ignoreNames': ['pre', 'textarea']
+  }, options)
+}
+
+function getPhrase (lineBreaks) {
+  switch (lineBreaks) {
+    case 0: return 'no'
+    default: return `${lineBreaks}`
+  }
+}
+
+/**
+ * Check whether the given element is empty or not.
+ * This ignores whitespaces, doesn't ignore comments.
+ * @param {VElement} node The element node to check.
+ * @param {SourceCode} sourceCode The source code object of the current context.
+ * @returns {boolean} `true` if the element is empty.
+ */
+function isEmpty (node, sourceCode) {
+  const start = node.startTag.range[1]
+  const end = node.endTag.range[0]
+
+  return sourceCode.text.slice(start, end).trim() === ''
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'require a line break before and after contents whenever the HTML tag has any attribute',
+      category: undefined,
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.2/docs/rules/html-tag-attrs-content-newline.md'
+    },
+    fixable: 'whitespace',
+    schema: [{
+      type: 'object',
+      properties: {
+        'ignoreNames': {
+          type: 'array',
+          items: { type: 'string' },
+          uniqueItems: true,
+          additionalItems: false
+        }
+      },
+      additionalProperties: false
+    }],
+    messages: {
+      unexpectedAfterClosingBracket: `Expected 1 line break after closing bracket of the "{{name}}" element, but {{actual}} line breaks found.`,
+      unexpectedBeforeOpeningBracket: `Expected 1 line break before opening bracket of the "{{name}}" element, but {{actual}} line breaks found.`
+    }
+  },
+
+  create (context) {
+    const ignoreNames = parseOptions(context.options[0]).ignoreNames
+    const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
+    const sourceCode = context.getSourceCode()
+
+    return utils.defineTemplateBodyVisitor(context, {
+      'VElement' (node) {
+        if (node.startTag.selfClosing || !node.endTag) {
+          // self closing
+          return
+        }
+        if (!hasAttributes(node)) {
+          return
+        }
+        let target = node
+        while (target.type === 'VElement') {
+          if (ignoreNames.indexOf(target.name) >= 0) {
+          // ignore element name
+            return
+          }
+          target = target.parent
+        }
+        const getTokenOption = { includeComments: true, filter: (token) => token.type !== 'HTMLWhitespace' }
+        const contentFirst = template.getTokenAfter(node.startTag, getTokenOption)
+        const contentLast = template.getTokenBefore(node.endTag, getTokenOption)
+        const beforeLineBreaks = contentFirst.loc.start.line - node.startTag.loc.end.line
+        const afterLineBreaks = node.endTag.loc.start.line - contentLast.loc.end.line
+        if (beforeLineBreaks !== 1) {
+          context.report({
+            node: template.getLastToken(node.startTag),
+            loc: {
+              start: node.startTag.loc.end,
+              end: contentFirst.loc.start
+            },
+            messageId: 'unexpectedAfterClosingBracket',
+            data: {
+              name: node.name,
+              actual: getPhrase(beforeLineBreaks)
+            },
+            fix (fixer) {
+              const range = [node.startTag.range[1], contentFirst.range[0]]
+              return fixer.replaceTextRange(range, '\n')
+            }
+          })
+        }
+
+        if (isEmpty(node, sourceCode)) {
+          return
+        }
+
+        if (afterLineBreaks !== 1) {
+          context.report({
+            node: template.getFirstToken(node.endTag),
+            loc: {
+              start: contentLast.loc.end,
+              end: node.endTag.loc.start
+            },
+            messageId: 'unexpectedBeforeOpeningBracket',
+            data: {
+              name: node.name,
+              actual: getPhrase(afterLineBreaks)
+            },
+            fix (fixer) {
+              const range = [contentLast.range[1], node.endTag.range[0]]
+              return fixer.replaceTextRange(range, '\n')
+            }
+          })
+        }
+      }
+    })
+  }
+}

--- a/tests/lib/rules/html-tag-attrs-content-newline.js
+++ b/tests/lib/rules/html-tag-attrs-content-newline.js
@@ -1,0 +1,379 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/html-tag-attrs-content-newline')
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2015
+  }
+})
+
+tester.run('html-tag-attrs-content-newline', rule, {
+  valid: [
+    `<template><div>content</div></template>`,
+    `<template><div>
+      content</div></template>`,
+    `
+      <template><div>
+        content
+      </div></template>`,
+    `
+      <template>
+        <div class="panel">
+          content
+        </div>
+      </template>`,
+    `
+      <template>
+        <div
+          class="panel"
+        >
+          content
+        </div>
+      </template>`,
+    `
+      <template><div class="panel">
+        content
+      </div></template>
+    `,
+    `
+      <template><div
+          class="panel"
+        >
+        content
+      </div></template>
+    `,
+    // empty
+    `<template><div class="panel">
+      </div></template>`,
+    `<template><div
+      class="panel">
+      </div></template>`,
+    // self closing
+    `
+      <template>
+        <self-closing />
+      </template>`,
+    // ignores
+    `
+      <template>
+        <pre>content</pre>
+        <pre
+          id="test-pre"
+        >content</pre>
+        <pre><div>content</div></pre>
+        <textarea>content</textarea>
+        <textarea
+          id="test-textarea"
+        >content</textarea>
+      </template>`,
+    {
+      code: `
+        <template>
+          <ignore-tag>content</ignore-tag>
+          <ignore-tag
+            id="test-pre"
+          >content</ignore-tag>
+          <ignore-tag><div>content</div></ignore-tag>
+        </template>`,
+      options: [{
+        ignoreNames: ['ignore-tag']
+      }]
+    },
+    `
+      <template>
+        <div>
+          <div>
+            content
+            content
+          </div>
+        </div>
+      </template>
+    `,
+    `
+      <template>
+        <div attr>
+        <!--comment-->
+        </div>
+      </template>
+    `,
+    // Ignore if no closing brackets
+    `
+      <template>
+        <div
+          id=
+          ""
+    `
+  ],
+  invalid: [
+    {
+      code: `
+        <template>
+          <div
+            class="panel"
+          >content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div
+            class="panel"
+          >
+content
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 5,
+          column: 12,
+          nodeType: 'HTMLTagClose',
+          endLine: 5,
+          endColumn: 12
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 5,
+          column: 19,
+          nodeType: 'HTMLEndTagOpen',
+          endLine: 5,
+          endColumn: 19
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div class="panel">content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div class="panel">
+content
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 30,
+          nodeType: 'HTMLTagClose',
+          endLine: 3,
+          endColumn: 30
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 37,
+          nodeType: 'HTMLEndTagOpen',
+          endLine: 3,
+          endColumn: 37
+        }
+      ]
+    },
+    // comments
+    {
+      code: `
+        <template>
+          <div attr><!--comment--></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+<!--comment-->
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 21
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 35
+        }
+      ]
+    },
+    // one error
+    {
+      code: `
+        <template>
+          <div attr>content
+          </div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+content
+          </div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 21
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div attr>
+          content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+          content
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 4,
+          column: 18
+        }
+      ]
+    },
+    // multiline content
+    {
+      code: `
+        <template><div attr>content<div attr>content
+        content</div>content</div></template>
+      `,
+      output: `
+        <template><div attr>
+content<div attr>
+content
+        content
+</div>content
+</div></template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 2,
+          column: 29
+        },
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 2,
+          column: 46
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 16
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 29
+        }
+      ]
+    },
+    // empty
+    {
+      code: `
+        <template>
+          <div attr></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 21
+        }
+      ]
+    },
+    // multi line breaks
+    {
+      code: `
+        <template>
+          <div attr>
+
+            content
+
+          </div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+content
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but 2 line breaks found.',
+          line: 3,
+          column: 21
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but 2 line breaks found.',
+          line: 5,
+          column: 20
+        }
+      ]
+    },
+    // mustache
+    {
+      code: `
+        <template>
+          <div attr>{{content}}</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+{{content}}
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 21
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 32
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds `vue/html-tag-attrs-content-newline` rule.
This implements rule proposed in https://github.com/vuejs/eslint-plugin-vue/pull/445#issuecomment-408873646

It is related to #415.