### PR TITLE
[New] Add `vue/multiline-html-element-content-newline` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 |    | Rule ID | Description |
 |:---|:--------|:------------|
 | :wrench: | [vue/component-name-in-template-casing](./docs/rules/component-name-in-template-casing.md) | enforce specific casing for the component naming style in template |
+| :wrench: | [vue/multiline-html-element-content-newline](./docs/rules/multiline-html-element-content-newline.md) | require a line break before and after the contents of a multiline element |
 | :wrench: | [vue/script-indent](./docs/rules/script-indent.md) | enforce consistent indentation in `<script>` |
 
 ### Deprecated

--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -1,0 +1,87 @@
+# require a line break before and after the contents of a multiline element (vue/multiline-html-element-content-newline)
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule enforces a line break before and after the contents of a multiline element.
+
+
+:-1: Examples of **incorrect** code:
+
+```html
+<div>multiline
+  content</div>
+
+<div
+  attr
+>multiline start tag</div>
+
+<tr><td>multiline</td>
+  <td>children</td></tr>
+
+<div><!-- multiline
+  comment --></div>
+
+<div
+></div>
+```
+
+:+1: Examples of **correct** code:
+
+```html
+<div>
+  multiline
+  content
+</div>
+
+<div
+  attr
+>
+  multiline start tag
+</div>
+
+<tr>
+  <td>multiline</td>
+  <td>children</td>
+</tr>
+
+<div>
+  <!-- multiline
+       comment -->
+</div>
+
+<div
+>
+</div>
+
+<div attr>singleline element</div>
+```
+
+
+## :wrench: Options
+
+```json
+{
+    "vue/multiline-html-element-content-newline": ["error", {
+        "ignoreNames": ["pre", "textarea"]
+    }]
+}
+```
+
+- `ignoreNames` ... the configuration for element names to ignore line breaks style.  
+    default `["pre", "textarea"]`
+
+
+:+1: Examples of **correct** code:
+
+```html
+/* eslint vue/multiline-html-element-content-newline: ["error", { "ignoreNames": ["VueComponent", "pre", "textarea"]}] */
+
+<VueComponent>multiline
+content</VueComponent>
+
+<VueComponent><span
+  class="bold">For example,</span>
+Defines the Vue component that accepts preformatted text.</VueComponent>
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ module.exports = {
     'html-self-closing': require('./rules/html-self-closing'),
     'jsx-uses-vars': require('./rules/jsx-uses-vars'),
     'max-attributes-per-line': require('./rules/max-attributes-per-line'),
+    'multiline-html-element-content-newline': require('./rules/multiline-html-element-content-newline'),
     'mustache-interpolation-spacing': require('./rules/mustache-interpolation-spacing'),
     'name-property-casing': require('./rules/name-property-casing'),
     'no-async-in-computed-properties': require('./rules/no-async-in-computed-properties'),

--- a/lib/rules/multiline-html-element-content-newline.js
+++ b/lib/rules/multiline-html-element-content-newline.js
@@ -1,0 +1,157 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+function isMultilineElement (element) {
+  return element.loc.start.line < element.endTag.loc.start.line
+}
+
+function parseOptions (options) {
+  return Object.assign({
+    'ignoreNames': ['pre', 'textarea']
+  }, options)
+}
+
+function getPhrase (lineBreaks) {
+  switch (lineBreaks) {
+    case 0: return 'no'
+    default: return `${lineBreaks}`
+  }
+}
+/**
+ * Check whether the given element is empty or not.
+ * This ignores whitespaces, doesn't ignore comments.
+ * @param {VElement} node The element node to check.
+ * @param {SourceCode} sourceCode The source code object of the current context.
+ * @returns {boolean} `true` if the element is empty.
+ */
+function isEmpty (node, sourceCode) {
+  const start = node.startTag.range[1]
+  const end = node.endTag.range[0]
+  return sourceCode.text.slice(start, end).trim() === ''
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'require a line break before and after the contents of a multiline element',
+      category: undefined,
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.2/docs/rules/multiline-html-element-content-newline.md'
+    },
+    fixable: 'whitespace',
+    schema: [{
+      type: 'object',
+      properties: {
+        'ignoreNames': {
+          type: 'array',
+          items: { type: 'string' },
+          uniqueItems: true,
+          additionalItems: false
+        }
+      },
+      additionalProperties: false
+    }],
+    messages: {
+      unexpectedAfterClosingBracket: `Expected 1 line break after closing bracket of the "{{name}}" element, but {{actual}} line breaks found.`,
+      unexpectedBeforeOpeningBracket: `Expected 1 line break before opening bracket of the "{{name}}" element, but {{actual}} line breaks found.`
+    }
+  },
+
+  create (context) {
+    const ignoreNames = parseOptions(context.options[0]).ignoreNames
+    const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
+    const sourceCode = context.getSourceCode()
+
+    let inIgnoreElement
+
+    return utils.defineTemplateBodyVisitor(context, {
+      'VElement' (node) {
+        if (inIgnoreElement) {
+          return
+        }
+        if (ignoreNames.indexOf(node.name) >= 0) {
+          // ignore element name
+          inIgnoreElement = node
+          return
+        }
+        if (node.startTag.selfClosing || !node.endTag) {
+          // self closing
+          return
+        }
+
+        if (!isMultilineElement(node)) {
+          return
+        }
+
+        const getTokenOption = { includeComments: true, filter: (token) => token.type !== 'HTMLWhitespace' }
+        const contentFirst = template.getTokenAfter(node.startTag, getTokenOption)
+        const contentLast = template.getTokenBefore(node.endTag, getTokenOption)
+
+        const beforeLineBreaks = contentFirst.loc.start.line - node.startTag.loc.end.line
+        const afterLineBreaks = node.endTag.loc.start.line - contentLast.loc.end.line
+        if (beforeLineBreaks !== 1) {
+          context.report({
+            node: template.getLastToken(node.startTag),
+            loc: {
+              start: node.startTag.loc.end,
+              end: contentFirst.loc.start
+            },
+            messageId: 'unexpectedAfterClosingBracket',
+            data: {
+              name: node.name,
+              actual: getPhrase(beforeLineBreaks)
+            },
+            fix (fixer) {
+              const range = [node.startTag.range[1], contentFirst.range[0]]
+              return fixer.replaceTextRange(range, '\n')
+            }
+          })
+        }
+
+        if (isEmpty(node, sourceCode)) {
+          return
+        }
+
+        if (afterLineBreaks !== 1) {
+          context.report({
+            node: template.getFirstToken(node.endTag),
+            loc: {
+              start: contentLast.loc.end,
+              end: node.endTag.loc.start
+            },
+            messageId: 'unexpectedBeforeOpeningBracket',
+            data: {
+              name: node.name,
+              actual: getPhrase(afterLineBreaks)
+            },
+            fix (fixer) {
+              const range = [contentLast.range[1], node.endTag.range[0]]
+              return fixer.replaceTextRange(range, '\n')
+            }
+          })
+        }
+      },
+      'VElement:exit' (node) {
+        if (inIgnoreElement === node) {
+          inIgnoreElement = null
+        }
+      }
+    })
+  }
+}

--- a/tests/lib/rules/multiline-html-element-content-newline.js
+++ b/tests/lib/rules/multiline-html-element-content-newline.js
@@ -1,0 +1,499 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/multiline-html-element-content-newline')
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2015
+  }
+})
+
+tester.run('multiline-html-element-content-newline', rule, {
+  valid: [
+    `<template><div class="panel">content</div></template>`,
+    `<template><div class="panel"><div></div></div></template>`,
+    `<template><div class="panel"><!-- comment --></div></template>`,
+    `
+      <template>
+        <div class="panel">
+          content
+        </div>
+      </template>`,
+    `
+      <template>
+        <div
+          class="panel"
+        >
+          content
+        </div>
+      </template>`,
+    `
+      <template>
+        <div>
+          <div>
+            content
+            content
+          </div>
+        </div>
+      </template>`,
+    `<div>multiline end tag</div
+      >`,
+    // empty
+    `<template><div class="panel"></div></template>`,
+    `
+      <template>
+        <div
+          class="panel">
+        </div>
+      </template>`,
+    // self closing
+    `
+      <template>
+        <self-closing />
+      </template>`,
+    // ignores
+    `
+      <template>
+        <pre>content</pre>
+        <pre
+          id="test-pre"
+        >content</pre>
+        <pre><div
+          >content</div></pre>
+        <pre>content
+          content</pre>
+        <textarea>content</textarea>
+        <textarea
+          id="test-textarea"
+        >content</textarea>
+        <textarea>content
+          content</textarea>
+      </template>`,
+    {
+      code: `
+        <template>
+          <ignore-tag>content</ignore-tag>
+          <ignore-tag
+            id="test-pre"
+          >content</ignore-tag>
+          <ignore-tag><div
+            >content</div></ignore-tag>
+          <ignore-tag>>content
+            content</ignore-tag>
+        </template>`,
+      options: [{
+        ignoreNames: ['ignore-tag']
+      }]
+    },
+    // Ignore if no closing brackets
+    `
+      <template>
+        <div
+          id=
+          ""
+    `
+  ],
+  invalid: [
+    {
+      code: `
+        <template>
+          <div
+            class="panel"
+          >content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div
+            class="panel"
+          >
+content
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 5,
+          column: 12,
+          nodeType: 'HTMLTagClose',
+          endLine: 5,
+          endColumn: 12
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 5,
+          column: 19,
+          nodeType: 'HTMLEndTagOpen',
+          endLine: 5,
+          endColumn: 19
+        }
+      ]
+    },
+    // spaces
+    {
+      code: `
+        <template>
+          <div
+            class="panel"
+          >   content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div
+            class="panel"
+          >
+content
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 5,
+          column: 12,
+          endLine: 5,
+          endColumn: 15
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 5,
+          column: 22,
+          endLine: 5,
+          endColumn: 22
+        }
+      ]
+    },
+    // elements
+    {
+      code: `
+        <template>
+          <div><div></div>
+          <div></div></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+<div></div>
+          <div></div>
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 16,
+          endLine: 3,
+          endColumn: 16
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 4,
+          column: 22,
+          endLine: 4,
+          endColumn: 22
+        }
+      ]
+    },
+    // contents
+    {
+      code: `
+        <template>
+          <div>multiline
+            content</div>
+        </template>`,
+      output: `
+        <template>
+          <div>
+multiline
+            content
+</div>
+        </template>`,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div>multiline content
+          </div>
+        </template>`,
+      output: `
+        <template>
+          <div>
+multiline content
+          </div>
+        </template>`,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div>
+            multiline content</div>
+        </template>`,
+      output: `
+        <template>
+          <div>
+            multiline content
+</div>
+        </template>`,
+      errors: [
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    // comments
+    {
+      code: `
+        <template>
+          <div><!--comment-->
+          <!--comment--></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+<!--comment-->
+          <!--comment-->
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div><!--comment
+            comment--></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+<!--comment
+            comment-->
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    // one error
+    {
+      code: `
+        <template>
+          <div>content
+            content
+          </div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+content
+            content
+          </div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div>
+          content
+          content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+          content
+          content
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    // multi
+    {
+      code: `
+        <template><div>content<div>content
+        content</div>content</div></template>
+      `,
+      output: `
+        <template>
+<div>
+content<div>
+content
+        content
+</div>content
+</div>
+</template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "template" element, but no line breaks found.',
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "template" element, but no line breaks found.'
+      ]
+    },
+    // multi line breaks
+    {
+      code: `
+        <template>
+          <div>
+
+            content
+            content
+
+          </div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+content
+            content
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but 2 line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but 2 line breaks found.'
+      ]
+    },
+    // mustache
+    {
+      code: `
+        <template>
+          <div>{{content}}
+          {{content2}}</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+{{content}}
+          {{content2}}
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    // mix
+    {
+      code: `
+        <template>
+          <div>content
+          <child></child>
+          <!-- comment --></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div>
+content
+          <child></child>
+          <!-- comment -->
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    // start tag
+    {
+      code: `
+        <template>
+          <div
+            >content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div
+            >
+content
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            attr>content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div
+            attr>
+content
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            ></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div
+            >
+</div>
+        </template>
+      `,
+      errors: ['Expected 1 line break after closing bracket of the "div" element, but no line breaks found.']
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds `vue/multiline-html-element-content-newline` rule.
This implements rule proposed in https://github.com/vuejs/eslint-plugin-vue/pull/547#issuecomment-410517455

It is related to #415.