### PR TITLE
[New] Add `vue/singleline-html-element-content-newline` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 |:---|:--------|:------------|
 | :wrench: | [vue/component-name-in-template-casing](./docs/rules/component-name-in-template-casing.md) | enforce specific casing for the component naming style in template |
 | :wrench: | [vue/script-indent](./docs/rules/script-indent.md) | enforce consistent indentation in `<script>` |
+| :wrench: | [vue/singleline-html-element-content-newline](./docs/rules/singleline-html-element-content-newline.md) | require a line break before and after the contents of a singleline element |
 
 ### Deprecated
 

--- a/docs/rules/singleline-html-element-content-newline.md
+++ b/docs/rules/singleline-html-element-content-newline.md
@@ -1,0 +1,102 @@
+# require a line break before and after the contents of a singleline element (vue/singleline-html-element-content-newline)
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule enforces a line break before and after the contents of a singleline element.
+
+
+:-1: Examples of **incorrect** code:
+
+```html
+<div attr>content</div>
+
+<tr attr><td>{{ data1 }}</td><td>{{ data2 }}</td></tr>
+
+<div attr><!-- comment --></div>
+```
+
+:+1: Examples of **correct** code:
+
+```html
+<div attr>
+  content
+</div>
+
+<tr attr>
+  <td>
+    {{ data1 }}
+  </td>
+  <td>
+    {{ data2 }}
+  </td>
+</tr>
+
+<div attr>
+  <!-- comment -->
+</div>
+```
+
+## :wrench: Options
+
+```json
+{
+  "vue/singleline-html-element-content-newline": ["error", {
+    "strict": false,
+    "ignoreNames": ["pre", "textarea"]
+  }]
+}
+```
+
+- `strict` ... if false, if there are no attributes on the element, this rule allows having contents in one line.  
+    if true, even if there are no attributes on the element, this rule disallows having contents in one line.  
+    default `false`
+- `ignoreNames` ... the configuration for element names to ignore line breaks style.  
+    default `["pre", "textarea"]`
+
+:-1: Examples of **incorrect** code for `{strict: true}`:
+
+```html
+/* eslint vue/singleline-html-element-content-newline: ["error", { "strict": true}] */
+
+<div>content</div>
+
+<tr><td>{{ data1 }}</td><td>{{ data2 }}</td></tr>
+
+<div><!-- comment --></div>
+```
+
+:+1: Examples of **correct** code for `{strict: false}` (default):
+
+```html
+/* eslint vue/singleline-html-element-content-newline: ["error", { "strict": false}] */
+
+<div>content</div>
+
+<tr><td>{{ data1 }}</td><td>{{ data2 }}</td></tr>
+
+<div><!-- comment --></div>
+```
+
+:-1: Examples of **incorrect** code for `{strict: false}` (default):
+
+```html
+/* eslint vue/singleline-html-element-content-newline: ["error", { "strict": false}] */
+
+<div attr>content</div>
+
+<tr attr><td>{{ data1 }}</td><td>{{ data2 }}</td></tr>
+
+<div attr><!-- comment --></div>
+```
+
+:+1: Examples of **correct** code for `ignoreNames`:
+
+```html
+/* eslint vue/singleline-html-element-content-newline: ["error", { "ignoreNames": ["VueComponent", "pre", "textarea"]}] */
+
+<VueComponent>content</VueComponent>
+
+<VueComponent attr><span>content</span></VueComponent>
+```

--- a/docs/rules/singleline-html-element-content-newline.md
+++ b/docs/rules/singleline-html-element-content-newline.md
@@ -43,22 +43,21 @@ This rule enforces a line break before and after the contents of a singleline el
 ```json
 {
   "vue/singleline-html-element-content-newline": ["error", {
-    "strict": false,
-    "ignoreNames": ["pre", "textarea"]
+    "ignoreWhenNoAttributes": true,
+    "ignores": ["pre", "textarea"]
   }]
 }
 ```
 
-- `strict` ... if false, if there are no attributes on the element, this rule allows having contents in one line.  
-    if true, even if there are no attributes on the element, this rule disallows having contents in one line.  
-    default `false`
-- `ignoreNames` ... the configuration for element names to ignore line breaks style.  
+- `ignoreWhenNoAttributes` ... allows having contents in one line, when given element has no attributes.
+    default `true`
+- `ignores` ... the configuration for element names to ignore line breaks style.  
     default `["pre", "textarea"]`
 
-:-1: Examples of **incorrect** code for `{strict: true}`:
+:-1: Examples of **incorrect** code for `{ignoreWhenNoAttributes: false}`:
 
 ```html
-/* eslint vue/singleline-html-element-content-newline: ["error", { "strict": true}] */
+/* eslint vue/singleline-html-element-content-newline: ["error", { "ignoreWhenNoAttributes": false}] */
 
 <div>content</div>
 
@@ -67,10 +66,10 @@ This rule enforces a line break before and after the contents of a singleline el
 <div><!-- comment --></div>
 ```
 
-:+1: Examples of **correct** code for `{strict: false}` (default):
+:+1: Examples of **correct** code for `{ignoreWhenNoAttributes: true}` (default):
 
 ```html
-/* eslint vue/singleline-html-element-content-newline: ["error", { "strict": false}] */
+/* eslint vue/singleline-html-element-content-newline: ["error", { "ignoreWhenNoAttributes": true}] */
 
 <div>content</div>
 
@@ -79,10 +78,10 @@ This rule enforces a line break before and after the contents of a singleline el
 <div><!-- comment --></div>
 ```
 
-:-1: Examples of **incorrect** code for `{strict: false}` (default):
+:-1: Examples of **incorrect** code for `{ignoreWhenNoAttributes: true}` (default):
 
 ```html
-/* eslint vue/singleline-html-element-content-newline: ["error", { "strict": false}] */
+/* eslint vue/singleline-html-element-content-newline: ["error", { "ignoreWhenNoAttributes": true}] */
 
 <div attr>content</div>
 
@@ -91,10 +90,10 @@ This rule enforces a line break before and after the contents of a singleline el
 <div attr><!-- comment --></div>
 ```
 
-:+1: Examples of **correct** code for `ignoreNames`:
+:+1: Examples of **correct** code for `ignores`:
 
 ```html
-/* eslint vue/singleline-html-element-content-newline: ["error", { "ignoreNames": ["VueComponent", "pre", "textarea"]}] */
+/* eslint vue/singleline-html-element-content-newline: ["error", { "ignores": ["VueComponent", "pre", "textarea"]}] */
 
 <VueComponent>content</VueComponent>
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ module.exports = {
     'require-valid-default-prop': require('./rules/require-valid-default-prop'),
     'return-in-computed-property': require('./rules/return-in-computed-property'),
     'script-indent': require('./rules/script-indent'),
+    'singleline-html-element-content-newline': require('./rules/singleline-html-element-content-newline'),
     'this-in-template': require('./rules/this-in-template'),
     'v-bind-style': require('./rules/v-bind-style'),
     'v-on-style': require('./rules/v-on-style'),

--- a/lib/rules/singleline-html-element-content-newline.js
+++ b/lib/rules/singleline-html-element-content-newline.js
@@ -20,8 +20,8 @@ function isSinglelineElement (element) {
 
 function parseOptions (options) {
   return Object.assign({
-    'ignoreNames': ['pre', 'textarea'],
-    'strict': false
+    'ignores': ['pre', 'textarea'],
+    'ignoreWhenNoAttributes': true
   }, options)
 }
 
@@ -53,10 +53,10 @@ module.exports = {
     schema: [{
       type: 'object',
       properties: {
-        'strict': {
+        'ignoreWhenNoAttributes': {
           type: 'boolean'
         },
-        'ignoreNames': {
+        'ignores': {
           type: 'array',
           items: { type: 'string' },
           uniqueItems: true,
@@ -66,15 +66,15 @@ module.exports = {
       additionalProperties: false
     }],
     messages: {
-      unexpectedAfterClosingBracket: `Expected 1 line break after closing bracket of the "{{name}}" element, but no line breaks found.`,
-      unexpectedBeforeOpeningBracket: `Expected 1 line break before opening bracket of the "{{name}}" element, but no line breaks found.`
+      unexpectedAfterClosingBracket: 'Expected 1 line break after opening tag (`<{{name}}>`), but no line breaks found.',
+      unexpectedBeforeOpeningBracket: 'Expected 1 line break before closing tag (`</{{name}}>`), but no line breaks found.'
     }
   },
 
   create (context) {
     const options = parseOptions(context.options[0])
-    const ignoreNames = options.ignoreNames
-    const strict = options.strict
+    const ignores = options.ignores
+    const ignoreWhenNoAttributes = options.ignoreWhenNoAttributes
     const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
     const sourceCode = context.getSourceCode()
 
@@ -85,7 +85,7 @@ module.exports = {
         if (inIgnoreElement) {
           return
         }
-        if (ignoreNames.indexOf(node.name) >= 0) {
+        if (ignores.indexOf(node.name) >= 0) {
           // ignore element name
           inIgnoreElement = node
           return
@@ -98,7 +98,7 @@ module.exports = {
         if (!isSinglelineElement(node)) {
           return
         }
-        if (!strict && node.startTag.attributes.length === 0) {
+        if (ignoreWhenNoAttributes && node.startTag.attributes.length === 0) {
           return
         }
 

--- a/lib/rules/singleline-html-element-content-newline.js
+++ b/lib/rules/singleline-html-element-content-newline.js
@@ -1,0 +1,152 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+function isSinglelineElement (element) {
+  return element.loc.start.line === element.endTag.loc.start.line
+}
+
+function parseOptions (options) {
+  return Object.assign({
+    'ignoreNames': ['pre', 'textarea'],
+    'strict': false
+  }, options)
+}
+
+/**
+ * Check whether the given element is empty or not.
+ * This ignores whitespaces, doesn't ignore comments.
+ * @param {VElement} node The element node to check.
+ * @param {SourceCode} sourceCode The source code object of the current context.
+ * @returns {boolean} `true` if the element is empty.
+ */
+function isEmpty (node, sourceCode) {
+  const start = node.startTag.range[1]
+  const end = node.endTag.range[0]
+  return sourceCode.text.slice(start, end).trim() === ''
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'require a line break before and after the contents of a singleline element',
+      category: undefined,
+      url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.2/docs/rules/singleline-html-element-content-newline.md'
+    },
+    fixable: 'whitespace',
+    schema: [{
+      type: 'object',
+      properties: {
+        'strict': {
+          type: 'boolean'
+        },
+        'ignoreNames': {
+          type: 'array',
+          items: { type: 'string' },
+          uniqueItems: true,
+          additionalItems: false
+        }
+      },
+      additionalProperties: false
+    }],
+    messages: {
+      unexpectedAfterClosingBracket: `Expected 1 line break after closing bracket of the "{{name}}" element, but no line breaks found.`,
+      unexpectedBeforeOpeningBracket: `Expected 1 line break before opening bracket of the "{{name}}" element, but no line breaks found.`
+    }
+  },
+
+  create (context) {
+    const options = parseOptions(context.options[0])
+    const ignoreNames = options.ignoreNames
+    const strict = options.strict
+    const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
+    const sourceCode = context.getSourceCode()
+
+    let inIgnoreElement
+
+    return utils.defineTemplateBodyVisitor(context, {
+      'VElement' (node) {
+        if (inIgnoreElement) {
+          return
+        }
+        if (ignoreNames.indexOf(node.name) >= 0) {
+          // ignore element name
+          inIgnoreElement = node
+          return
+        }
+        if (node.startTag.selfClosing || !node.endTag) {
+          // self closing
+          return
+        }
+
+        if (!isSinglelineElement(node)) {
+          return
+        }
+        if (!strict && node.startTag.attributes.length === 0) {
+          return
+        }
+
+        const getTokenOption = { includeComments: true, filter: (token) => token.type !== 'HTMLWhitespace' }
+        const contentFirst = template.getTokenAfter(node.startTag, getTokenOption)
+        const contentLast = template.getTokenBefore(node.endTag, getTokenOption)
+
+        context.report({
+          node: template.getLastToken(node.startTag),
+          loc: {
+            start: node.startTag.loc.end,
+            end: contentFirst.loc.start
+          },
+          messageId: 'unexpectedAfterClosingBracket',
+          data: {
+            name: node.name
+          },
+          fix (fixer) {
+            const range = [node.startTag.range[1], contentFirst.range[0]]
+            return fixer.replaceTextRange(range, '\n')
+          }
+        })
+
+        if (isEmpty(node, sourceCode)) {
+          return
+        }
+
+        context.report({
+          node: template.getFirstToken(node.endTag),
+          loc: {
+            start: contentLast.loc.end,
+            end: node.endTag.loc.start
+          },
+          messageId: 'unexpectedBeforeOpeningBracket',
+          data: {
+            name: node.name
+          },
+          fix (fixer) {
+            const range = [contentLast.range[1], node.endTag.range[0]]
+            return fixer.replaceTextRange(range, '\n')
+          }
+        })
+      },
+      'VElement:exit' (node) {
+        if (inIgnoreElement === node) {
+          inIgnoreElement = null
+        }
+      }
+    })
+  }
+}

--- a/tests/lib/rules/singleline-html-element-content-newline.js
+++ b/tests/lib/rules/singleline-html-element-content-newline.js
@@ -1,0 +1,439 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/singleline-html-element-content-newline')
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2015
+  }
+})
+
+tester.run('singleline-html-element-content-newline', rule, {
+  valid: [
+    `
+      <template>
+        <div class="panel">
+          content
+        </div>
+      </template>`,
+    `
+      <template>
+        <div class="panel">
+          <div>
+          </div>
+        </div>
+      </template>`,
+    `
+      <template>
+        <div class="panel">
+          <!-- comment -->
+        </div>
+      </template>`,
+    `
+      <template>
+        <div>
+          content
+        </div>
+      </template>`,
+    `
+      <template>
+        <div>
+          <div>
+          </div>
+        </div>
+      </template>`,
+    `
+      <template>
+        <div>
+          <!-- comment -->
+        </div>
+      </template>`,
+    // strict: false
+    `
+      <template>
+        <div>singleline content</div>
+      </template>`,
+    `
+      <template>
+        <tr><td>singleline</td><td>children</td></tr>
+      </template>`,
+    `
+      <template>
+        <div><!-- singleline comment --></div>
+      </template>`,
+    `
+      <template>
+        <div     >singleline element</div     >
+      </template>`,
+    `
+      <template>
+        <div></div>
+      </template>`,
+    `
+      <template>
+        <div>    </div>
+      </template>`,
+    // strict: true
+    {
+      code: `
+      <template>
+        <div>
+          content
+        </div>
+      </template>`,
+      options: [{ strict: true }]
+    },
+    {
+      code: `
+      <template>
+        <div>
+          <div>
+          </div>
+        </div>
+      </template>`,
+      options: [{ strict: true }]
+    },
+    {
+      code: `
+      <template>
+        <div>
+          <!-- comment -->
+        </div>
+      </template>`,
+      options: [{ strict: true }]
+    },
+    // self closing
+    `
+      <template>
+        <self-closing />
+      </template>`,
+    // ignores
+    `
+      <template>
+        <pre>content</pre>
+        <pre attr>content</pre>
+        <pre><span attr>content</span></pre>
+        <textarea>content</textarea>
+        <textarea attr>content</textarea>
+        <textarea><span attr>content</span></textarea>
+      </template>`,
+    {
+      code: `
+        <template>
+          <ignore-tag>content</ignore-tag>
+          <ignore-tag attr>content</ignore-tag>
+          <ignore-tag><span attr>content</span></ignore-tag>
+        </template>`,
+      options: [{
+        ignoreNames: ['ignore-tag']
+      }]
+    },
+    // not target
+    `
+      <template>
+        <div>content
+        </div>
+      </template>`,
+    `
+      <template>
+        <div>
+          content</div>
+      </template>`,
+    // Ignore if no closing brackets
+    `
+      <template>
+        <div
+          id=
+          ""
+    `
+  ],
+  invalid: [
+    {
+      code: `
+        <template>
+          <div class="panel">content</div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div class="panel">
+content
+</div>
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 30,
+          nodeType: 'HTMLTagClose',
+          endLine: 3,
+          endColumn: 30
+        },
+        {
+          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          line: 3,
+          column: 37,
+          nodeType: 'HTMLEndTagOpen',
+          endLine: 3,
+          endColumn: 37
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <tr attr><td>singleline</td><td>children</td></tr>
+        </template>
+      `,
+      output: `
+        <template>
+          <tr attr>
+<td>singleline</td><td>children</td>
+</tr>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "tr" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "tr" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div attr><!-- singleline comment --></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+<!-- singleline comment -->
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div attr><!-- singleline --><!-- comments --></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+<!-- singleline --><!-- comments -->
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div attr     >content</div    >
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr     >
+content
+</div    >
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div attr     >content</div
+          >
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr     >
+content
+</div
+          >
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div attr></div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div attr>    </div>
+        </template>
+      `,
+      output: `
+        <template>
+          <div attr>
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div>singleline content</div>
+        </template>
+      `,
+      options: [{ strict: true }],
+      output: `
+        <template>
+          <div>
+singleline content
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <tr><td>singleline</td><td>children</td></tr>
+        </template>
+      `,
+      options: [{ strict: true }],
+      output: `
+        <template>
+          <tr>
+<td>
+singleline
+</td><td>
+children
+</td>
+</tr>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "tr" element, but no line breaks found.',
+        'Expected 1 line break after closing bracket of the "td" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "td" element, but no line breaks found.',
+        'Expected 1 line break after closing bracket of the "td" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "td" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "tr" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div><!-- singleline comment --></div>
+        </template>
+      `,
+      options: [{ strict: true }],
+      output: `
+        <template>
+          <div>
+<!-- singleline comment -->
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div   >   singleline element   </div   >
+        </template>
+      `,
+      options: [{ strict: true }],
+      output: `
+        <template>
+          <div   >
+singleline element
+</div   >
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div></div>
+        </template>
+      `,
+      options: [{ strict: true }],
+      output: `
+        <template>
+          <div>
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div>    </div>
+        </template>
+      `,
+      options: [{ strict: true }],
+      output: `
+        <template>
+          <div>
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/singleline-html-element-content-newline.js
+++ b/tests/lib/rules/singleline-html-element-content-newline.js
@@ -61,7 +61,7 @@ tester.run('singleline-html-element-content-newline', rule, {
           <!-- comment -->
         </div>
       </template>`,
-    // strict: false
+    // ignoreWhenNoAttributes: true
     `
       <template>
         <div>singleline content</div>
@@ -86,7 +86,7 @@ tester.run('singleline-html-element-content-newline', rule, {
       <template>
         <div>    </div>
       </template>`,
-    // strict: true
+    // ignoreWhenNoAttributes: false
     {
       code: `
       <template>
@@ -94,7 +94,7 @@ tester.run('singleline-html-element-content-newline', rule, {
           content
         </div>
       </template>`,
-      options: [{ strict: true }]
+      options: [{ ignoreWhenNoAttributes: false }]
     },
     {
       code: `
@@ -104,7 +104,7 @@ tester.run('singleline-html-element-content-newline', rule, {
           </div>
         </div>
       </template>`,
-      options: [{ strict: true }]
+      options: [{ ignoreWhenNoAttributes: false }]
     },
     {
       code: `
@@ -113,7 +113,7 @@ tester.run('singleline-html-element-content-newline', rule, {
           <!-- comment -->
         </div>
       </template>`,
-      options: [{ strict: true }]
+      options: [{ ignoreWhenNoAttributes: false }]
     },
     // self closing
     `
@@ -138,7 +138,7 @@ tester.run('singleline-html-element-content-newline', rule, {
           <ignore-tag><span attr>content</span></ignore-tag>
         </template>`,
       options: [{
-        ignoreNames: ['ignore-tag']
+        ignores: ['ignore-tag']
       }]
     },
     // not target
@@ -176,7 +176,7 @@ content
       `,
       errors: [
         {
-          message: 'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
+          message: 'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
           line: 3,
           column: 30,
           nodeType: 'HTMLTagClose',
@@ -184,7 +184,7 @@ content
           endColumn: 30
         },
         {
-          message: 'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.',
+          message: 'Expected 1 line break before closing tag (`</div>`), but no line breaks found.',
           line: 3,
           column: 37,
           nodeType: 'HTMLEndTagOpen',
@@ -207,8 +207,8 @@ content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "tr" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "tr" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<tr>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</tr>`), but no line breaks found.'
       ]
     },
     {
@@ -225,8 +225,8 @@ content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     {
@@ -243,8 +243,8 @@ content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     {
@@ -261,8 +261,8 @@ content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     {
@@ -281,8 +281,8 @@ content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     {
@@ -298,7 +298,7 @@ content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
       ]
     },
     {
@@ -314,7 +314,7 @@ content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
       ]
     },
     {
@@ -323,7 +323,7 @@ content
           <div>singleline content</div>
         </template>
       `,
-      options: [{ strict: true }],
+      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
@@ -332,8 +332,8 @@ singleline content
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     {
@@ -342,7 +342,7 @@ singleline content
           <tr><td>singleline</td><td>children</td></tr>
         </template>
       `,
-      options: [{ strict: true }],
+      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <tr>
@@ -355,12 +355,12 @@ children
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "tr" element, but no line breaks found.',
-        'Expected 1 line break after closing bracket of the "td" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "td" element, but no line breaks found.',
-        'Expected 1 line break after closing bracket of the "td" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "td" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "tr" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<tr>`), but no line breaks found.',
+        'Expected 1 line break after opening tag (`<td>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</td>`), but no line breaks found.',
+        'Expected 1 line break after opening tag (`<td>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</td>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</tr>`), but no line breaks found.'
       ]
     },
     {
@@ -369,7 +369,7 @@ children
           <div><!-- singleline comment --></div>
         </template>
       `,
-      options: [{ strict: true }],
+      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
@@ -378,8 +378,8 @@ children
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     {
@@ -388,7 +388,7 @@ children
           <div   >   singleline element   </div   >
         </template>
       `,
-      options: [{ strict: true }],
+      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div   >
@@ -397,8 +397,8 @@ singleline element
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.',
-        'Expected 1 line break before opening bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     {
@@ -407,7 +407,7 @@ singleline element
           <div></div>
         </template>
       `,
-      options: [{ strict: true }],
+      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
@@ -415,7 +415,7 @@ singleline element
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
       ]
     },
     {
@@ -424,7 +424,7 @@ singleline element
           <div>    </div>
         </template>
       `,
-      options: [{ strict: true }],
+      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
@@ -432,7 +432,7 @@ singleline element
         </template>
       `,
       errors: [
-        'Expected 1 line break after closing bracket of the "div" element, but no line breaks found.'
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
       ]
     }
   ]


### PR DESCRIPTION
This PR adds `vue/singleline-html-element-content-newline` rule.
This implements rule proposed in https://github.com/vuejs/eslint-plugin-vue/pull/547#issuecomment-410517455

It is related to #415.