### PR TITLE
Add Vetur settings to "Why doesn't it work on .vue file?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ The `vue-eslint-parser` uses the parser which is set by `parserOptions.parser` t
   ```
 
 2. Make sure your tool is set to lint `.vue` files.
-  - CLI targets only `.js` files by default. You have to specify additional extensions by `--ext` option or glob patterns. E.g. `eslint "src/**/*.{js,vue}"` or `eslint src --ext .vue`.
+  - CLI targets only `.js` files by default. You have to specify additional extensions by `--ext` option or glob patterns. E.g. `eslint "src/**/*.{js,vue}"` or `eslint src --ext .vue`. If you use `@vue/cli-plugin-eslint` and the `vue-cli-service lint` command - you don't have to worry about it.
   - VSCode targets only JavaScript or HTML files by default. You have to add `"vue"` to the `"eslint.validate"` array in vscode settings. e.g. `"eslint.validate": [ "javascript", "javascriptreact", "vue" ]`
-  - Set VSCode Vetur settings: `"vetur.validation.template": false` to avoid Vetur template validation overriding plugin validation.
+  - If you use `Vetur` plugin in VSCode - set `"vetur.validation.template": false` to avoid default Vetur template validation. Check out [vetur documentation](https://github.com/vuejs/vetur/blob/master/docs/linting-error.md) for more info.
 
 ## :anchor: Semantic Versioning Policy
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ The `vue-eslint-parser` uses the parser which is set by `parserOptions.parser` t
 2. Make sure your tool is set to lint `.vue` files.
   - CLI targets only `.js` files by default. You have to specify additional extensions by `--ext` option or glob patterns. E.g. `eslint "src/**/*.{js,vue}"` or `eslint src --ext .vue`.
   - VSCode targets only JavaScript or HTML files by default. You have to add `"vue"` to the `"eslint.validate"` array in vscode settings. e.g. `"eslint.validate": [ "javascript", "javascriptreact", "vue" ]`
+  - Set VSCode Vetur settings: `"vetur.validation.template": false` to avoid Vetur template validation overriding plugin validation.
 
 ## :anchor: Semantic Versioning Policy
 


### PR DESCRIPTION
I had an issue where the plugin works, but red markings of errors remained. So I found out the instructions for this section are missing a note regarding Vetur. You need the following setting to complete the setup:
```
"vetur.validation.template": false
```

**Note**: While it solved my issue, there is something to consider with how it's applied. Eslint is mostly used in a per-project manner. This means, if you apply the rule above to `settings.json`, it's applied globally, thus Vue projects that do not use this plugin will not show template errors. To solve this, you need to apply the setting locally. In the context of VS Code, it's easy. You just save a "workspace" to your project root and that creates a file, where you can apply the settings, thus locally. See [here](https://github.com/Microsoft/vscode/issues/37519) for details.