### PR TITLE
Fixed typo in v-html rule description

### DIFF
--- a/docs/rules/no-v-html.md
+++ b/docs/rules/no-v-html.md
@@ -2,7 +2,7 @@
 
 - :gear: This rule is included in `"plugin:vue/recommended"`.
 
-This rule reports use of `v-html` directive in order to reduce the risk of injecting potentially unsafe / unescaped html into the browser leading to Cross Side Scripting (XSS) attacks.
+This rule reports use of `v-html` directive in order to reduce the risk of injecting potentially unsafe / unescaped html into the browser leading to Cross-Site Scripting (XSS) attacks.
 
 ## :book: Rule Details
 


### PR DESCRIPTION
According to OWASP shorthand XSS stands for Cross-Site Scripting: https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)