### PR TITLE
Fix: if no trailing comma, not to leave trailing comma after fixed of `order-in-components`

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -193,21 +193,24 @@ module.exports = {
               if (hasSideEffectsPossibility) {
                 return undefined
               }
-              const comma = sourceCode.getTokenAfter(propertyNode)
-              const hasAfterComma = isComma(comma)
+              const afterComma = sourceCode.getTokenAfter(propertyNode)
+              const hasAfterComma = isComma(afterComma)
 
-              const codeStart = sourceCode.getTokenBefore(propertyNode).range[1] // to include comments
-              const codeEnd = hasAfterComma ? comma.range[1] : propertyNode.range[1]
+              const beforeComma = sourceCode.getTokenBefore(propertyNode)
+              const codeStart = beforeComma.range[1] // to include comments
+              const codeEnd = hasAfterComma ? afterComma.range[1] : propertyNode.range[1]
 
               const propertyCode = sourceCode.text.slice(codeStart, codeEnd) + (hasAfterComma ? '' : ',')
               const insertTarget = sourceCode.getTokenBefore(firstUnorderedPropertyNode)
+
+              const removeStart = hasAfterComma ? codeStart : beforeComma.range[0]
               // If we can upgrade requirements to `eslint@>4.1.0`, this code can be replaced by:
               // return [
-              //   fixer.removeRange([codeStart, codeEnd]),
+              //   fixer.removeRange([removeStart, codeEnd]),
               //   fixer.insertTextAfter(insertTarget, propertyCode)
               // ]
               const insertStart = insertTarget.range[1]
-              const newCode = propertyCode + sourceCode.text.slice(insertStart, codeStart)
+              const newCode = propertyCode + sourceCode.text.slice(insertStart, removeStart)
               return fixer.replaceTextRange([insertStart, codeEnd], newCode)
             }
           })

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -204,14 +204,11 @@ module.exports = {
               const insertTarget = sourceCode.getTokenBefore(firstUnorderedPropertyNode)
 
               const removeStart = hasAfterComma ? codeStart : beforeComma.range[0]
-              // If we can upgrade requirements to `eslint@>4.1.0`, this code can be replaced by:
-              // return [
-              //   fixer.removeRange([removeStart, codeEnd]),
-              //   fixer.insertTextAfter(insertTarget, propertyCode)
-              // ]
-              const insertStart = insertTarget.range[1]
-              const newCode = propertyCode + sourceCode.text.slice(insertStart, removeStart)
-              return fixer.replaceTextRange([insertStart, codeEnd], newCode)
+
+              return [
+                fixer.removeRange([removeStart, codeEnd]),
+                fixer.insertTextAfter(insertTarget, propertyCode)
+              ]
             }
           })
         }

--- a/tests/lib/autofix.js
+++ b/tests/lib/autofix.js
@@ -1,0 +1,87 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const Linter = require('eslint').Linter
+const chai = require('chai')
+
+const rules = require('../..').rules
+
+const assert = chai.assert
+
+const baseConfig = {
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+}
+
+describe('Complex autofix test cases', () => {
+  const linter = new Linter()
+  for (const key of Object.keys(rules)) {
+    const ruleId = `vue/${key}`
+    linter.defineRule(ruleId, rules[key])
+  }
+
+  // https://github.com/vuejs/eslint-plugin-vue/issues/566
+  describe('Autofix of `vue/order-in-components` and `comma-dangle` should not conflict.', () => {
+    const config = Object.assign({}, baseConfig, { 'rules': {
+      'vue/order-in-components': ['error'],
+      'comma-dangle': ['error', 'always']
+    }})
+    it('Even if set comma-dangle:always, the output should be as expected.', () => {
+      const code = `
+      <script>
+        export default {
+          data() {
+          },
+          name: 'burger'
+        };
+      </script>`
+      const output = `
+      <script>
+        export default {
+          name: 'burger',
+          data() {
+          },
+        };
+      </script>`
+      assert.equal(
+        linter.verifyAndFix(code, config, 'test.vue').output,
+        output
+      )
+    })
+    it('Even if include comments, the output should be as expected.', () => {
+      const code = `
+      <script>
+        export default {
+          /**data*/
+          data() {
+          }/*after data*/,
+          /**name*/
+          name: 'burger'/*after name*/
+        };
+      </script>`
+      const output = `
+      <script>
+        export default {
+          /**name*/
+          name: 'burger',
+          /**data*/
+          data() {
+          },/*after data*//*after name*/
+        };
+      </script>`
+      assert.equal(
+        linter.verifyAndFix(code, config, 'test.vue').output,
+        output
+      )
+    })
+  })
+})

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -374,7 +374,7 @@ ruleTester.run('order-in-components', rule, {
           data() {
           },
           test: 'ok',
-          name: 'burger',
+          name: 'burger'
         };
       `,
       options: [{ order: ['data', 'test', 'name'] }],
@@ -401,7 +401,33 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
           /** data provider */
           data() {
-          },
+          }
+        };
+      `,
+      errors: [{
+        message: 'The "name" property should be above the "data" property on line 4.',
+        line: 7
+      }]
+    },
+    {
+      filename: 'example.vue',
+      code: `
+        export default {
+          /** data provider */
+          data() {
+          }/*test*/,
+          /** name of vue component */
+          name: 'burger'
+        };
+      `,
+      parserOptions,
+      output: `
+        export default {
+          /** name of vue component */
+          name: 'burger',
+          /** data provider */
+          data() {
+          }/*test*/
         };
       `,
       errors: [{
@@ -413,7 +439,7 @@ ruleTester.run('order-in-components', rule, {
       filename: 'example.vue',
       code: `export default {data(){},name:'burger'};`,
       parserOptions,
-      output: `export default {name:'burger',data(){},};`,
+      output: `export default {name:'burger',data(){}};`,
       errors: [{
         message: 'The "name" property should be above the "data" property on line 1.',
         line: 1


### PR DESCRIPTION
Fixed #566 

This pull request, if there is no trailing comma, make sure `vue/order-in-components` does not leave trailing comma after autofix.

Until now, after moving the target property up, we did not delete the last comma of the previous property. because of this, if the target property is the last property, the trailing comma will always remain.

With this fix, autofix will no conflict with `"comma-dangle": ["error", "always"]`.
