### PR TITLE
Improve detection of components in no-unused-components rule

### DIFF
--- a/lib/rules/no-unused-components.js
+++ b/lib/rules/no-unused-components.js
@@ -71,13 +71,13 @@ module.exports = {
 
         registeredComponents
           .filter(({ name }) => {
-            // If the component name is PascalCase
+            // If the component name is PascalCase or camelCase
             // it can be used in various of ways inside template,
             // like "theComponent", "The-component" etc.
             // but except snake_case
-            if (casing.pascalCase(name) === name) {
+            if (casing.pascalCase(name) === name || casing.camelCase(name) === name) {
               return !usedComponents.some(n => {
-                return n.indexOf('_') === -1 && name === casing.pascalCase(n)
+                return n.indexOf('_') === -1 && (name === casing.pascalCase(n) || casing.camelCase(n) === name)
               })
             } else {
               // In any other case the used component name must exactly match

--- a/tests/lib/rules/no-unused-components.js
+++ b/tests/lib/rules/no-unused-components.js
@@ -131,6 +131,21 @@ tester.run('no-unused-components', rule, {
       filename: 'test.vue',
       code: `<template>
         <div>
+          <the-button />
+        </div>
+      </template>
+      <script>
+        export default {
+          components: {
+            theButton
+          }
+        }
+      </script>`
+    },
+    {
+      filename: 'test.vue',
+      code: `<template>
+        <div>
           <component is="the-button" />
         </div>
       </template>


### PR DESCRIPTION
The `no-unused-components` raises an error when the component is imported in camelCase. This PR fixes this behavior.

```vue
<template>
  <div>
    <the-button />
  </div>
</template>

<script>
  import theButton from './theButton.vue'
  export default {
    components: {
      theButton
    }
  }
</script>
```