### PR TITLE
Add missing vue/ suffix to rule example

### DIFF
--- a/docs/rules/script-indent.md
+++ b/docs/rules/script-indent.md
@@ -10,7 +10,7 @@ This rule has some options.
 
 ```json
 {
-  "script-indent": ["error", TYPE, {
+  "vue/script-indent": ["error", TYPE, {
     "baseIndent": 0,
     "switchCase": 0,
     "ignores": []


### PR DESCRIPTION
Found at https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/script-indent.md