### PR TITLE
fixed: Corrected doc name use-v-on-exact

### DIFF
--- a/docs/rules/use-v-on-exact.md
+++ b/docs/rules/use-v-on-exact.md
@@ -1,6 +1,4 @@
-# Enforce usage of `exact` modifier on `v-on`
-
-- :gear: This rule is included in `"plugin:vue/essential"`.
+# enforce usage of `exact` modifier on `v-on` (vue/use-v-on-exact)
 
 This rule enforce usage of `exact` modifier on `v-on` when there is another `v-on` with modifier.
 

--- a/docs/rules/use-v-on-exact.md
+++ b/docs/rules/use-v-on-exact.md
@@ -1,4 +1,6 @@
-# enforce usage of `exact` modifier on `v-on` (vue/use-v-on-exact)
+# Enforce usage of `exact` modifier on `v-on`
+
+- :gear: This rule is included in `"plugin:vue/essential"`.
 
 This rule enforce usage of `exact` modifier on `v-on` when there is another `v-on` with modifier.
 


### PR DESCRIPTION
The doc name for `use-v-on-exact` was misspelt: https://github.com/vuejs/eslint-plugin-vue/pull/602/files