### PR TITLE
Fix logic behind kabab case and snake case for propID

### DIFF
--- a/lib/utils/casing.js
+++ b/lib/utils/casing.js
@@ -9,7 +9,9 @@ const invalidChars = /[^a-zA-Z0-9:]+/g
  */
 function kebabCase (str) {
   return str
-    .replace(/([a-z])([A-Z])/g, match => match[0] + '-' + match[1])
+    .replace(/[A-Z]/g, match => '-' + match)
+    .replace(/([^a-zA-Z])-([A-Z])/g, match => match[0] + match[2])
+    .replace(/^-/, '')
     .replace(invalidChars, '-')
     .toLowerCase()
 }
@@ -21,7 +23,9 @@ function kebabCase (str) {
  */
 function snakeCase (str) {
   return str
-    .replace(/([a-z])([A-Z])/g, match => match[0] + '_' + match[1])
+    .replace(/[A-Z]/g, match => '_' + match)
+    .replace(/([^a-zA-Z])_([A-Z])/g, match => match[0] + match[2])
+    .replace(/^_/, '')
     .replace(invalidChars, '_')
     .toLowerCase()
 }

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -152,6 +152,17 @@ ruleTester.run('attribute-hyphenation', rule, {
     },
     {
       filename: 'test.vue',
+      code: '<template><div><custom v-bind:propID="prop" :secondPropID="test"></custom></div></template>',
+      output: '<template><div><custom v-bind:prop-i-d="prop" :secondPropID="test"></custom></div></template>',
+      options: ['always', { ignore: ['secondPropID'] }],
+      errors: [{
+        message: "Attribute 'v-bind:propID' must be hyphenated.",
+        type: 'VDirectiveKey',
+        line: 1
+      }]
+    },
+    {
+      filename: 'test.vue',
       code: `
         <template>
           <custom data-id="foo" aria-test="bar" slot-scope="{ data }" custom-hyphen="foo" second-custom="baz" third-custom="bar">

--- a/tests/lib/utils/casing.js
+++ b/tests/lib/utils/casing.js
@@ -6,39 +6,54 @@ const chai = require('chai')
 const assert = chai.assert
 
 describe('getConverter()', () => {
-  it('should conver string to camelCase', () => {
+  it('should convert string to camelCase', () => {
     const converter = casing.getConverter('camelCase')
 
-    assert.ok(converter('fooBar') === 'fooBar')
-    assert.ok(converter('foo-bar') === 'fooBar')
-    assert.ok(converter('FooBar') === 'fooBar')
-    assert.ok(converter('Foo1Bar') === 'foo1Bar')
+    assert.equal(converter('fooBar'), 'fooBar')
+    assert.equal(converter('foo-bar'), 'fooBar')
+    assert.equal(converter('foo_bar'), 'fooBar')
+    assert.equal(converter('FooBar'), 'fooBar')
+    assert.equal(converter('Foo1Bar'), 'foo1Bar')
+    assert.equal(converter('FooBAR'), 'fooBAR')
+    assert.equal(converter('Foo1BAZ'), 'foo1BAZ')
+    assert.equal(converter('foo1b_a_z'), 'foo1bAZ')
   })
 
-  it('should conver string to PascalCase', () => {
+  it('should convert string to PascalCase', () => {
     const converter = casing.getConverter('PascalCase')
 
-    assert.ok(converter('fooBar') === 'FooBar')
-    assert.ok(converter('foo-bar') === 'FooBar')
-    assert.ok(converter('FooBar') === 'FooBar')
-    assert.ok(converter('Foo1Bar') === 'Foo1Bar')
+    assert.equal(converter('fooBar'), 'FooBar')
+    assert.equal(converter('foo-bar'), 'FooBar')
+    assert.equal(converter('foo_bar'), 'FooBar')
+    assert.equal(converter('FooBar'), 'FooBar')
+    assert.equal(converter('Foo1Bar'), 'Foo1Bar')
+    assert.equal(converter('FooBAR'), 'FooBAR')
+    assert.equal(converter('Foo1BAZ'), 'Foo1BAZ')
+    assert.equal(converter('foo1b_a_z'), 'Foo1bAZ')
   })
 
-  it('should conver string to kebab-case', () => {
+  it('should convert string to kebab-case', () => {
     const converter = casing.getConverter('kebab-case')
 
-    assert.ok(converter('fooBar') === 'foo-bar')
-    assert.ok(converter('foo-bar') === 'foo-bar')
-    assert.ok(converter('FooBar') === 'foo-bar')
-    assert.ok(converter('Foo1Bar') === 'foo1bar')
+    assert.equal(converter('fooBar'), 'foo-bar')
+    assert.equal(converter('foo-bar'), 'foo-bar')
+    assert.equal(converter('foo_bar'), 'foo-bar')
+    assert.equal(converter('FooBar'), 'foo-bar')
+    assert.equal(converter('Foo1Bar'), 'foo1bar')
+    assert.equal(converter('FooBAR'), 'foo-b-a-r')
+    assert.equal(converter('Foo1BAZ'), 'foo1b-a-z')
+    assert.equal(converter('foo1b_a_z'), 'foo1b-a-z')
   })
 
-  it('should conver string to snake_case', () => {
+  it('should convert string to snake_case', () => {
     const converter = casing.getConverter('snake_case')
 
-    assert.ok(converter('fooBar') === 'foo_bar')
-    assert.ok(converter('foo-bar') === 'foo_bar')
-    assert.ok(converter('FooBar') === 'foo_bar')
-    assert.ok(converter('Foo1Bar') === 'foo1bar')
+    assert.equal(converter('fooBar'), 'foo_bar')
+    assert.equal(converter('foo-bar'), 'foo_bar')
+    assert.equal(converter('FooBar'), 'foo_bar')
+    assert.equal(converter('Foo1Bar'), 'foo1bar')
+    assert.equal(converter('FooBAR'), 'foo_b_a_r')
+    assert.equal(converter('Foo1BAZ'), 'foo1b_a_z')
+    assert.equal(converter('foo1b_a_z'), 'foo1b_a_z')
   })
 })


### PR DESCRIPTION
fix issue #550 

`assert.equal` throws more detailer errors than `assert.ok`
```
AssertionError: expected 'XXXXX' to equal 'YYYYY'
```
instead of 
```
AssertionError: expected false to be truthy
```