### PR TITLE
chore: Update uncategorized rules' categories

### DIFF
--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -22,7 +22,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce specific casing for the component naming style in template',
-      category: undefined, // strongly-recommended
+      category: 'strongly-recommended',
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.4/docs/rules/component-name-in-template-casing.md'
     },
     fixable: 'code',

--- a/lib/rules/multiline-html-element-content-newline.js
+++ b/lib/rules/multiline-html-element-content-newline.js
@@ -51,7 +51,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'require a line break before and after the contents of a multiline element',
-      category: undefined,
+      category: 'strongly-recommended',
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.4/docs/rules/multiline-html-element-content-newline.md'
     },
     fixable: 'whitespace',

--- a/lib/rules/no-spaces-around-equal-signs-in-attribute.js
+++ b/lib/rules/no-spaces-around-equal-signs-in-attribute.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'disallow spaces around equal signs in attribute',
-      category: undefined,
+      category: 'strongly-recommended',
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.4/docs/rules/no-spaces-around-equal-signs-in-attribute.md'
     },
     fixable: 'whitespace',

--- a/lib/rules/singleline-html-element-content-newline.js
+++ b/lib/rules/singleline-html-element-content-newline.js
@@ -46,7 +46,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'require a line break before and after the contents of a singleline element',
-      category: undefined,
+      category: 'strongly-recommended',
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.4/docs/rules/singleline-html-element-content-newline.md'
     },
     fixable: 'whitespace',

--- a/lib/rules/use-v-on-exact.js
+++ b/lib/rules/use-v-on-exact.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'enforce usage of `exact` modifier on `v-on`',
-      category: undefined, // essential
+      category: 'essential',
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0-beta.4/docs/rules/use-v-on-exact.md'
     },
     fixable: null,


### PR DESCRIPTION
Let's enable remaining rules in the v5, except `script-indent` which will remain an `opt-in` rule, for those that want an extra indentation, otherwise original ESLint indent rule is perfectly fine.