### PR TITLE
chore: Report errors only for base and essential rules

### DIFF
--- a/tools/update-lib-configs.js
+++ b/tools/update-lib-configs.js
@@ -14,9 +14,11 @@ const path = require('path')
 const eslint = require('eslint')
 const categories = require('./lib/categories')
 
+const errorCategories = ['base', 'essential']
+
 function formatRules (rules) {
   const obj = rules.reduce((setting, rule) => {
-    setting[rule.ruleId] = 'error'
+    setting[rule.ruleId] = errorCategories.includes(rule.meta.docs.category) ? 'error' : 'warn'
     return setting
   }, {})
   return JSON.stringify(obj, null, 2)


### PR DESCRIPTION
Currently we report errors for all rules, but it's not a very semantic way of telling user something's not exactly ok. We should rather report errors only for things that are crucial - that is `base` and `essential` rules, and for recommendations throw warnings instead. It will also give users the ability to set treshold value. cc @chrisvfritz 