### PR TITLE
Fix issues with `require-render-return` and `return-in-computed-property`

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -654,8 +654,12 @@ module.exports = {
       node: null
     }
 
+    function isReachable (segment) {
+      return segment.reachable
+    }
+
     function isValidReturn () {
-      if (!funcInfo.hasReturn) {
+      if (funcInfo.codePath.currentSegments.some(isReachable)) {
         return false
       }
       return !treatUndefinedAsUnspecified || funcInfo.hasReturnValue

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -73,6 +73,36 @@ ruleTester.run('require-render-return', rule, {
     {
       filename: 'test.vue',
       code: `export default {
+        render() {
+          const foo = function () {}
+          return foo
+        }
+      }`,
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `export default {
+        render() {
+          if (a) {
+            if (b) {
+              
+            }
+            if (c) {
+              return true
+            } else {
+              return foo
+            }
+          } else {
+            return foo
+          }
+        }
+      }`,
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `export default {
         render: () => null
       }`,
       parserOptions
@@ -120,10 +150,58 @@ ruleTester.run('require-render-return', rule, {
       }]
     },
     {
+      filename: 'test.vue',
+      code: `export default {
+        render: function () {
+          if (foo) {
+            return h('div', 'hello')
+          }
+        }
+      }`,
+      parserOptions,
+      errors: [{
+        message: 'Expected to return a value in render function.',
+        type: 'Identifier',
+        line: 2
+      }]
+    },
+    {
       code: `Vue.component('test', {
         render: function () {
           if (a) {
             return
+          }
+        }
+      })`,
+      parserOptions,
+      errors: [{
+        message: 'Expected to return a value in render function.',
+        type: 'Identifier',
+        line: 2
+      }]
+    },
+    {
+      code: `Vue.component('test2', {
+        render: function () {
+          if (a) {
+            return h('div', 'hello')
+          }
+        }
+      })`,
+      parserOptions,
+      errors: [{
+        message: 'Expected to return a value in render function.',
+        type: 'Identifier',
+        line: 2
+      }]
+    },
+    {
+      code: `Vue.component('test2', {
+        render: function () {
+          if (a) {
+            
+          } else {
+            return h('div', 'hello')
           }
         }
       })`,


### PR DESCRIPTION
i found this issue while doing: 
https://armano2.github.io/eslint-plugin-vue/rules/require-render-return.html#rule-details
and
http://armano2.github.io/eslint-plugin-vue/rules/return-in-computed-property.html#rule-details