### PR TITLE
chore: vuepress: update documentation

### DIFF
--- a/docs/.vuepress/components/eslint-code-block.vue
+++ b/docs/.vuepress/components/eslint-code-block.vue
@@ -10,7 +10,7 @@
         :preprocess="preprocess"
         :postprocess="postprocess"
         dark
-        fix
+        :fix="fix"
     />
 </template>
 
@@ -24,6 +24,10 @@ export default {
   components: { EslintEditor },
 
   props: {
+    fix: {
+      type: Boolean,
+      default: false
+    },
     rules: {
       type: Object,
       default () {

--- a/docs/.vuepress/components/eslint-code-block.vue
+++ b/docs/.vuepress/components/eslint-code-block.vue
@@ -7,6 +7,8 @@
         class="eslint-code-block"
         filename="example.vue"
         language="html"
+        :preprocess="preprocess"
+        :postprocess="postprocess"
         dark
         fix
     />
@@ -15,7 +17,7 @@
 <script>
 // https://github.com/vuejs/vuepress/issues/451
 import EslintEditor from '../../../node_modules/vue-eslint-editor'
-import { rules } from '../../../'
+import { rules, processors } from '../../../'
 
 export default {
   name: 'ESLintCodeBlock',
@@ -32,7 +34,9 @@ export default {
 
   data () {
     return {
-      linter: null
+      linter: null,
+      preprocess: processors['.vue'].preprocess,
+      postprocess: processors['.vue'].postprocess
     }
   },
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -5,21 +5,21 @@
 'use strict'
 
 const rules = require('../../tools/lib/rules')
+const categories = require('../../tools/lib/categories')
 
 const uncategorizedRules = rules.filter(rule => !rule.meta.docs.category && !rule.meta.deprecated)
 const deprecatedRules = rules.filter(rule => rule.meta.deprecated)
-const categories = require('../../tools/lib/categories')
 
-const extraRules = []
+const extraCategories = []
 if (uncategorizedRules.length > 0) {
-  extraRules.push({
+  extraCategories.push({
     title: 'Uncategorized',
     collapsable: false,
     children: uncategorizedRules.map(({ ruleId, name }) => [`/rules/${name}`, ruleId])
   })
 }
 if (deprecatedRules.length > 0) {
-  extraRules.push({
+  extraCategories.push({
     title: 'Deprecated',
     collapsable: false,
     children: deprecatedRules.map(({ ruleId, name }) => [`/rules/${name}`, ruleId])
@@ -62,7 +62,7 @@ module.exports = {
         })),
 
         // Rules in no category.
-        ...extraRules
+        ...extraCategories
       ],
 
       '/': ['/', '/user-guide/', '/developer-guide/', '/rules/']

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -4,8 +4,27 @@
  */
 'use strict'
 
-const uncategorizedRules = require('../../tools/lib/rules').filter(rule => !rule.meta.docs.category)
+const rules = require('../../tools/lib/rules')
+
+const uncategorizedRules = rules.filter(rule => !rule.meta.docs.category && !rule.meta.deprecated)
+const deprecatedRules = rules.filter(rule => rule.meta.deprecated)
 const categories = require('../../tools/lib/categories')
+
+const extraRules = []
+if (uncategorizedRules.length > 0) {
+  extraRules.push({
+    title: 'Uncategorized',
+    collapsable: false,
+    children: uncategorizedRules.map(({ ruleId, name }) => [`/rules/${name}`, ruleId])
+  })
+}
+if (deprecatedRules.length > 0) {
+  extraRules.push({
+    title: 'Deprecated',
+    collapsable: false,
+    children: deprecatedRules.map(({ ruleId, name }) => [`/rules/${name}`, ruleId])
+  })
+}
 
 module.exports = {
   base: '/eslint-plugin-vue/',
@@ -43,11 +62,7 @@ module.exports = {
         })),
 
         // Rules in no category.
-        {
-          title: 'Uncategorized',
-          collapsable: false,
-          children: uncategorizedRules.map(({ ruleId, name }) => [`/rules/${name}`, ruleId])
-        }
+        ...extraRules
       ],
 
       '/': ['/', '/user-guide/', '/developer-guide/', '/rules/']

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -4,7 +4,7 @@ Contributing is welcome.
 
 ## 🐛 Bug reporting
 
-If you think you’ve found a bug in ESLint, please [create a new issue](https://github.com/vuejs/eslint-plugin-vue/issues/new) or a pull request on GitHub.
+If you think you’ve found a bug in ESLint, please [create a new issue](https://github.com/vuejs/eslint-plugin-vue/issues/new?labels=&template=bug_report.md) or a pull request on GitHub.
 
 Please include as much detail as possible to help us properly address your issue. If we need to triage issues and constantly ask people for more detail, that’s time taken away from actually fixing issues. Help us be as efficient as possible by including a lot of detail in your issues.
 

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -2,13 +2,13 @@
 
 Contributing is welcome.
 
-## 🐛 Bug reporting
+## :bug: Bug reporting
 
 If you think you’ve found a bug in ESLint, please [create a new issue](https://github.com/vuejs/eslint-plugin-vue/issues/new?labels=&template=bug_report.md) or a pull request on GitHub.
 
 Please include as much detail as possible to help us properly address your issue. If we need to triage issues and constantly ask people for more detail, that’s time taken away from actually fixing issues. Help us be as efficient as possible by including a lot of detail in your issues.
 
-## ✨ Proposing a new rule or a rule change
+## :sparkles: Proposing a new rule or a rule change
 
 In order to add a new rule or a rule change, you should:
 
@@ -23,7 +23,7 @@ In order to add a new rule or a rule change, you should:
 
 We're more than happy to see potential contributions, so don't hesitate. If you have any suggestions, ideas or problems feel free to add new [issue](https://github.com/vuejs/eslint-plugin-vue/issues), but first please make sure your question does not repeat previous ones.
 
-## 🔥 Working with rules
+## :fire: Working with rules
 
 Before you start writing new rule, please read the [official ESLint guide](https://eslint.org/docs/developer-guide/working-with-rules).
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -40,9 +40,11 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 | [vue/no-side-effects-in-computed-properties](./no-side-effects-in-computed-properties.md) | disallow side effects in computed properties |  |
 | [vue/no-template-key](./no-template-key.md) | disallow `key` attribute on `<template>` |  |
 | [vue/no-textarea-mustache](./no-textarea-mustache.md) | disallow mustaches in `<textarea>` |  |
+| [vue/no-unused-components](./no-unused-components.md) | disallow registering components that are not used inside templates |  |
 | [vue/no-unused-vars](./no-unused-vars.md) | disallow unused variable definitions of v-for directives or scope attributes |  |
 | [vue/no-use-v-if-with-v-for](./no-use-v-if-with-v-for.md) | disallow use v-if on the same element as v-for |  |
 | [vue/require-component-is](./require-component-is.md) | require `v-bind:is` of `<component>` elements |  |
+| [vue/require-prop-type-constructor](./require-prop-type-constructor.md) | require prop type to be a constructor | :wrench: |
 | [vue/require-render-return](./require-render-return.md) | enforce render function to always return value |  |
 | [vue/require-v-for-key](./require-v-for-key.md) | require `v-bind:key` with `v-for` directives |  |
 | [vue/require-valid-default-prop](./require-valid-default-prop.md) | enforce props default values to be valid |  |
@@ -127,7 +129,11 @@ For example:
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [vue/component-name-in-template-casing](./component-name-in-template-casing.md) | enforce specific casing for the component naming style in template | :wrench: |
+| [vue/multiline-html-element-content-newline](./multiline-html-element-content-newline.md) | require a line break before and after the contents of a multiline element | :wrench: |
+| [vue/no-spaces-around-equal-signs-in-attribute](./no-spaces-around-equal-signs-in-attribute.md) | disallow spaces around equal signs in attribute | :wrench: |
 | [vue/script-indent](./script-indent.md) | enforce consistent indentation in `<script>` | :wrench: |
+| [vue/singleline-html-element-content-newline](./singleline-html-element-content-newline.md) | require a line break before and after the contents of a singleline element | :wrench: |
+| [vue/use-v-on-exact](./use-v-on-exact.md) | enforce usage of `exact` modifier on `v-on` |  |
 
 ## Deprecated
 

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -7,11 +7,16 @@
 
 Default casing is set to `always` with `['data-', 'aria-', 'slot-scope']` set to be ignored
 
-```
-'vue/attribute-hyphenation': [2, 'always'|'never', { 'ignore': ['custom-prop'] }]
+```json
+{
+  "vue/attribute-hyphenation": [2, "always" | "never", {
+    "ignore": ["custom-prop"]
+  }}]
+}
 ```
 
-### `["error", "always"]` - Use hyphenated name. (It errors on upper case letters.)
+### `["error", "always"]` - Use hyphenated name. 
+It errors on upper case letters.
 
 <eslint-code-block :rules="{'vue/attribute-hyphenation': ['error', 'always']}">
 ```
@@ -25,7 +30,8 @@ Default casing is set to `always` with `['data-', 'aria-', 'slot-scope']` set to
 ```
 </eslint-code-block>
 
-### `["error", "never"]` - Don't use hyphenated name. (It errors on hyphens except `data-`, `aria-` and `slot-scope`.)
+### `["error", "never"]` - Don't use hyphenated name. 
+It errors on hyphens except `data-`, `aria-` and `slot-scope`.
 
 <eslint-code-block :rules="{'vue/attribute-hyphenation': ['error', 'never']}">
 ```

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -3,19 +3,37 @@
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-## :wrench: Options
+## :book: Rule Details
 
-Default casing is set to `always` with `['data-', 'aria-', 'slot-scope']` set to be ignored
+<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'always']}">
+```
+<template>
+  <!-- ✔ GOOD -->
+  <MyComponent my-prop="prop" />
+
+  <!-- ✘ BAD -->
+  <MyComponent myProp="prop" />
+</template>
+```
+</eslint-code-block>
+
+## :wrench: Options
 
 ```json
 {
   "vue/attribute-hyphenation": [2, "always" | "never", {
-    "ignore": ["custom-prop"]
+    "ignore": []
   }]
 }
 ```
 
-### `["error", "always"]` - Use hyphenated name. 
+Default casing is set to `always` with `['data-', 'aria-', 'slot-scope']` set to be ignored
+
+- `"always"` (default) ... Use hyphenated name.
+- `"never"` ... Don't use hyphenated name except `data-`, `aria-` and `slot-scope`.
+- `"ignore"` ... Array of ignored names
+
+### `"always"`
 It errors on upper case letters.
 
 <eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'always']}">
@@ -30,7 +48,7 @@ It errors on upper case letters.
 ```
 </eslint-code-block>
 
-### `["error", "never"]` - Don't use hyphenated name. 
+### `"never"`
 It errors on hyphens except `data-`, `aria-` and `slot-scope`.
 
 <eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never']}">
@@ -48,9 +66,10 @@ It errors on hyphens except `data-`, `aria-` and `slot-scope`.
 ```
 </eslint-code-block>
 
-### `["error", "never", { "ignore": ["custom-prop"] }]` - Don't use hyphenated name but allow custom attributes
+### `"never", { "ignore": ["custom-prop"] }` 
+Don't use hyphenated name but allow custom attributes
 
-<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never', {'ignore': ['custom-prop']}]}">
+<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never', { ignore: ['custom-prop']}]}">
 ```
 <template>
   <!-- ✔ GOOD -->

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -18,7 +18,7 @@ Default casing is set to `always` with `['data-', 'aria-', 'slot-scope']` set to
 ### `["error", "always"]` - Use hyphenated name. 
 It errors on upper case letters.
 
-<eslint-code-block :rules="{'vue/attribute-hyphenation': ['error', 'always']}">
+<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'always']}">
 ```
 <template>
   <!-- ✔ GOOD -->
@@ -33,7 +33,7 @@ It errors on upper case letters.
 ### `["error", "never"]` - Don't use hyphenated name. 
 It errors on hyphens except `data-`, `aria-` and `slot-scope`.
 
-<eslint-code-block :rules="{'vue/attribute-hyphenation': ['error', 'never']}">
+<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never']}">
 ```
 <template>
   <!-- ✔ GOOD -->
@@ -50,7 +50,7 @@ It errors on hyphens except `data-`, `aria-` and `slot-scope`.
 
 ### `["error", "never", { "ignore": ["custom-prop"] }]` - Don't use hyphenated name but allow custom attributes
 
-<eslint-code-block :rules="{'vue/attribute-hyphenation': ['error', 'never', {'ignore': ['custom-prop']}]}">
+<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never', {'ignore': ['custom-prop']}]}">
 ```
 <template>
   <!-- ✔ GOOD -->

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -11,7 +11,7 @@ Default casing is set to `always` with `['data-', 'aria-', 'slot-scope']` set to
 {
   "vue/attribute-hyphenation": [2, "always" | "never", {
     "ignore": ["custom-prop"]
-  }}]
+  }]
 }
 ```
 

--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -80,7 +80,28 @@ This rule aims to enforce ordering of component attributes. The default order is
 ```
 </eslint-code-block>
 
-### custom orders
+## :wrench: Options
+```json
+{
+  "vue/attributes-order": [2, {
+    "order": [
+      "DEFINITION",
+      "LIST_RENDERING",
+      "CONDITIONALS", 
+      "RENDER_MODIFIERS",
+      "GLOBAL", 
+      "UNIQUE", 
+      "TWO_WAY_BINDING", 
+      "OTHER_DIRECTIVES", 
+      "OTHER_ATTR", 
+      "EVENTS", 
+      "CONTENT"
+    ]
+  }]
+}
+```
+
+### Custom orders
 
 #### `['LIST_RENDERING', 'CONDITIONALS', 'RENDER_MODIFIERS', 'GLOBAL', 'UNIQUE', 'TWO_WAY_BINDING', 'DEFINITION', 'OTHER_DIRECTIVES', 'OTHER_ATTR', 'EVENTS', 'CONTENT']`
 

--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -32,7 +32,7 @@ This rule aims to enforce ordering of component attributes. The default order is
 
 ### the default order
 
-<eslint-code-block :rules="{'vue/attributes-order': ['error']}">
+<eslint-code-block fix :rules="{'vue/attributes-order': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -105,7 +105,7 @@ This rule aims to enforce ordering of component attributes. The default order is
 
 #### `['LIST_RENDERING', 'CONDITIONALS', 'RENDER_MODIFIERS', 'GLOBAL', 'UNIQUE', 'TWO_WAY_BINDING', 'DEFINITION', 'OTHER_DIRECTIVES', 'OTHER_ATTR', 'EVENTS', 'CONTENT']`
 
-<eslint-code-block :rules="{'vue/attributes-order': ['error', {order: ['LIST_RENDERING', 'CONDITIONALS', 'RENDER_MODIFIERS', 'GLOBAL', 'UNIQUE', 'TWO_WAY_BINDING', 'DEFINITION', 'OTHER_DIRECTIVES', 'OTHER_ATTR', 'EVENTS', 'CONTENT']}]}">
+<eslint-code-block fix :rules="{'vue/attributes-order': ['error', {order: ['LIST_RENDERING', 'CONDITIONALS', 'RENDER_MODIFIERS', 'GLOBAL', 'UNIQUE', 'TWO_WAY_BINDING', 'DEFINITION', 'OTHER_DIRECTIVES', 'OTHER_ATTR', 'EVENTS', 'CONTENT']}]}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -128,7 +128,7 @@ This rule aims to enforce ordering of component attributes. The default order is
 
 #### `[['LIST_RENDERING', 'CONDITIONALS', 'RENDER_MODIFIERS'], ['DEFINITION', 'GLOBAL', 'UNIQUE'], 'TWO_WAY_BINDING', 'OTHER_DIRECTIVES', 'OTHER_ATTR', 'EVENTS', 'CONTENT']`
 
-<eslint-code-block :rules="{'vue/attributes-order': ['error', {order: [['LIST_RENDERING', 'CONDITIONALS', 'RENDER_MODIFIERS'], ['DEFINITION', 'GLOBAL', 'UNIQUE'], 'TWO_WAY_BINDING', 'OTHER_DIRECTIVES', 'OTHER_ATTR', 'EVENTS', 'CONTENT']}]}">
+<eslint-code-block fix :rules="{'vue/attributes-order': ['error', {order: [['LIST_RENDERING', 'CONDITIONALS', 'RENDER_MODIFIERS'], ['DEFINITION', 'GLOBAL', 'UNIQUE'], 'TWO_WAY_BINDING', 'OTHER_DIRECTIVES', 'OTHER_ATTR', 'EVENTS', 'CONTENT']}]}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/comment-directive.md
+++ b/docs/rules/comment-directive.md
@@ -22,7 +22,7 @@ ESLint doesn't provide any API to enhance `eslint-disable` functionality and ESL
 
 This rule sends all `eslint-disable`-like comments as errors to the post-process of the `.vue` file processor, then the post-process removes all `vue/comment-directive` errors and the reported errors in disabled areas.
 
-<eslint-code-block :rules="{'vue/comment-directive': ['error']}">
+<eslint-code-block :rules="{'vue/comment-directive': ['error'], 'vue/max-attributes-per-line': ['error']}">
 ```vue
 <template>
   <!-- eslint-disable-next-line vue/max-attributes-per-line -->

--- a/docs/rules/component-name-in-template-casing.md
+++ b/docs/rules/component-name-in-template-casing.md
@@ -12,11 +12,9 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
 
 ```json
 {
-  "vue/component-name-in-template-casing": [
-    "error",
-    "PascalCase" | "kebab-case",
-    { "ignores": [] }
-  ]
+  "vue/component-name-in-template-casing": ["error", "PascalCase" | "kebab-case", { 
+    "ignores": []
+  }]
 }
 ```
 

--- a/docs/rules/component-name-in-template-casing.md
+++ b/docs/rules/component-name-in-template-casing.md
@@ -24,7 +24,7 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
 
 ### `"PascalCase"`
 
-<eslint-code-block :rules="{'vue/component-name-in-template-casing': ['error']}">
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -40,7 +40,7 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
 
 ### `"kebab-case"`
 
-<eslint-code-block :rules="{'vue/component-name-in-template-casing': ['error', 'kebab-case']}">
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'kebab-case']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -58,7 +58,7 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
 
 ### `"PascalCase", { ignores: ["custom-element"] }`
 
-<eslint-code-block :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', {ignores: ['custom-element']}]}">
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', {ignores: ['custom-element']}]}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/html-closing-bracket-newline.md
+++ b/docs/rules/html-closing-bracket-newline.md
@@ -63,7 +63,7 @@ This rule aims to warn the right angle brackets which are at the location other 
 
 Plus, you can use [`vue/html-indent`](./html-indent.md) rule to enforce indent-level of the closing brackets.
 
-### `{ "multiline": "never" }`
+### `"multiline": "never"`
 
 <eslint-code-block :rules="{'vue/html-closing-bracket-newline': ['error', { 'multiline': 'never' }]}">
 ```

--- a/docs/rules/html-closing-bracket-newline.md
+++ b/docs/rules/html-closing-bracket-newline.md
@@ -55,11 +55,11 @@ This rule aims to warn the right angle brackets which are at the location other 
 ```
 
 - `singleline` ... the configuration for single-line elements. It's a single-line element if the element does not have attributes or the last attribute is on the same line as the opening bracket.
-    - `"never"` ... disallow line breaks before the closing bracket. This is the default.
+    - `"never"` (default) ... disallow line breaks before the closing bracket.
     - `"always"` ... require one line break before the closing bracket.
 - `multiline` ... the configuration for multiline elements. It's a multiline element if the last attribute is not on the same line of the opening bracket.
     - `"never"` ... disallow line breaks before the closing bracket.
-    - `"always"` ... require one line break before the closing bracket. This is the default.
+    - `"always"` (default) ... require one line break before the closing bracket.
 
 Plus, you can use [`vue/html-indent`](./html-indent.md) rule to enforce indent-level of the closing brackets.
 

--- a/docs/rules/html-closing-bracket-newline.md
+++ b/docs/rules/html-closing-bracket-newline.md
@@ -23,7 +23,7 @@ This rule enforces a line break (or no line break) before tag's closing brackets
 
 This rule aims to warn the right angle brackets which are at the location other than the configured location.
 
-<eslint-code-block :rules="{'vue/html-closing-bracket-newline': ['error']}">
+<eslint-code-block fix :rules="{'vue/html-closing-bracket-newline': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -65,7 +65,7 @@ Plus, you can use [`vue/html-indent`](./html-indent.md) rule to enforce indent-l
 
 ### `"multiline": "never"`
 
-<eslint-code-block :rules="{'vue/html-closing-bracket-newline': ['error', { 'multiline': 'never' }]}">
+<eslint-code-block fix :rules="{'vue/html-closing-bracket-newline': ['error', { 'multiline': 'never' }]}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/html-closing-bracket-spacing.md
+++ b/docs/rules/html-closing-bracket-spacing.md
@@ -7,7 +7,7 @@
 
 This rule aims to enforce consistent spacing style before closing brackets `>` of tags.
 
-<eslint-code-block :rules="{'vue/html-closing-bracket-spacing': ['error']}">
+<eslint-code-block fix :rules="{'vue/html-closing-bracket-spacing': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -55,7 +55,7 @@ This rule aims to enforce consistent spacing style before closing brackets `>` o
 
 ### `"startTag": "always", "endTag": "always", "selfClosingTag": "always"`
 
-<eslint-code-block :rules="{'vue/html-closing-bracket-spacing': ['error', {startTag: 'always', endTag: 'always', selfClosingTag: 'always' }]}">
+<eslint-code-block fix :rules="{'vue/html-closing-bracket-spacing': ['error', {startTag: 'always', endTag: 'always', selfClosingTag: 'always' }]}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/html-closing-bracket-spacing.md
+++ b/docs/rules/html-closing-bracket-spacing.md
@@ -53,7 +53,7 @@ This rule aims to enforce consistent spacing style before closing brackets `>` o
     - `"always"` ... requires one or more spaces.
     - `"never"` ... disallows spaces.
 
-### `{ "startTag": "always", "endTag": "always", "selfClosingTag": "always" }`
+### `"startTag": "always", "endTag": "always", "selfClosingTag": "always"`
 
 <eslint-code-block :rules="{'vue/html-closing-bracket-spacing': ['error', {startTag: 'always', endTag: 'always', selfClosingTag: 'always' }]}">
 ```

--- a/docs/rules/html-closing-bracket-spacing.md
+++ b/docs/rules/html-closing-bracket-spacing.md
@@ -70,7 +70,7 @@ This rule aims to enforce consistent spacing style before closing brackets `>` o
 ```
 </eslint-code-block>
 
-## :bookmark: Related rules
+## :couple: Related rules
 
 - [vue/no-multi-spaces](./no-multi-spaces.md)
 - [vue/html-closing-bracket-newline](./html-closing-bracket-newline.md)

--- a/docs/rules/html-end-tags.md
+++ b/docs/rules/html-end-tags.md
@@ -7,7 +7,7 @@
 
 This rule aims to disallow lacking end tags.
 
-<eslint-code-block :rules="{'vue/html-end-tags': ['error']}">
+<eslint-code-block fix :rules="{'vue/html-end-tags': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/html-indent.md
+++ b/docs/rules/html-indent.md
@@ -10,7 +10,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 - This rule checks all tags, also all expressions in directives and mustaches.
 - In the expressions, this rule supports ECMAScript 2017 syntaxes. It ignores unknown AST nodes, but it might be confused by non-standard syntaxes.
 
-<eslint-code-block :rules="{'vue/html-indent': ['error']}">
+<eslint-code-block fix :rules="{'vue/html-indent': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -71,7 +71,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ### `2, {"attribute": 1, "closeBracket": 1}`
 
-<eslint-code-block :rules="{'vue/html-indent': ['error', 2, {attribute: 1, closeBracket: 1}]}">
+<eslint-code-block fix :rules="{'vue/html-indent': ['error', 2, {attribute: 1, closeBracket: 1}]}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -91,7 +91,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ### `2, {"attribute": 2, "closeBracket": 1}`
 
-<eslint-code-block :rules="{'vue/html-indent': ['error', 2, {attribute: 2, closeBracket: 1}]}">
+<eslint-code-block fix :rules="{'vue/html-indent': ['error', 2, {attribute: 2, closeBracket: 1}]}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -111,7 +111,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ### `2, {"ignores": ["VAttribute"]}`
 
-<eslint-code-block :rules="{'vue/html-indent': ['error', 2, {ignores: ['VAttribute']}]}">
+<eslint-code-block fix :rules="{'vue/html-indent': ['error', 2, {ignores: ['VAttribute']}]}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -125,7 +125,7 @@ This rule enforces a consistent indentation style in `<template>`. The default s
 
 ### `2, {"alignAttributesVertically": false}`
 
-<eslint-code-block :rules="{'vue/html-indent': ['error', 2, {alignAttributesVertically: false}]}">
+<eslint-code-block fix :rules="{'vue/html-indent': ['error', 2, {alignAttributesVertically: false}]}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/html-quotes.md
+++ b/docs/rules/html-quotes.md
@@ -30,6 +30,14 @@ This rule reports the quotes of attributes if it is different to configured quot
 
 ## :wrench: Options
 
+Default is set to `double`.
+
+```json
+{
+  "vue/html-quotes": [2, "double" | "single"]
+}
+```
+
 - `"double"` (default) ... requires double quotes.
 - `"single"` ... requires single quotes.
 

--- a/docs/rules/html-quotes.md
+++ b/docs/rules/html-quotes.md
@@ -15,7 +15,7 @@ This rule enforces the quotes style of HTML attributes.
 
 This rule reports the quotes of attributes if it is different to configured quotes.
 
-<eslint-code-block :rules="{'vue/html-quotes': ['error']}">
+<eslint-code-block fix :rules="{'vue/html-quotes': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -43,7 +43,7 @@ Default is set to `double`.
 
 ### `"single"`
 
-<eslint-code-block :rules="{'vue/html-quotes': ['error', 'single']}">
+<eslint-code-block fix :rules="{'vue/html-quotes': ['error', 'single']}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/html-self-closing.md
+++ b/docs/rules/html-self-closing.md
@@ -61,7 +61,7 @@ Every option can be set to one of the following values:
 - `"never"` ... Disallow self-closing.
 - `"any"` ... Don't enforce self-closing style.
 
-### `{html: {normal: "never", void: "always"}}`
+### `html: {normal: "never", void: "always"}`
 
 <eslint-code-block :rules="{'vue/html-self-closing': ['error', {html: {normal: 'never', void: 'always'}}]}">
 ```

--- a/docs/rules/html-self-closing.md
+++ b/docs/rules/html-self-closing.md
@@ -15,7 +15,7 @@ This rule helps you to make consistent on the self-closing style.
 
 This rule aims to enforce the self-closing sign as the configured style.
 
-<eslint-code-block :rules="{'vue/html-self-closing': ['error']}">
+<eslint-code-block fix :rules="{'vue/html-self-closing': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -63,7 +63,7 @@ Every option can be set to one of the following values:
 
 ### `html: {normal: "never", void: "always"}`
 
-<eslint-code-block :rules="{'vue/html-self-closing': ['error', {html: {normal: 'never', void: 'always'}}]}">
+<eslint-code-block fix :rules="{'vue/html-self-closing': ['error', {html: {normal: 'never', void: 'always'}}]}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/html-self-closing.md
+++ b/docs/rules/html-self-closing.md
@@ -3,17 +3,16 @@
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
+## :book: Rule Details
+
+This rule aims to enforce the self-closing sign as the configured style.
+
 In Vue.js template, we can use either two styles for elements which don't have their content.
 
 1. `<YourComponent></YourComponent>`
 2. `<YourComponent/>` (self-closing)
 
 Self-closing is simple and shorter, but it's not supported in the HTML spec.
-This rule helps you to make consistent on the self-closing style.
-
-## :book: Rule Details
-
-This rule aims to enforce the self-closing sign as the configured style.
 
 <eslint-code-block fix :rules="{'vue/html-self-closing': ['error']}">
 ```

--- a/docs/rules/jsx-uses-vars.md
+++ b/docs/rules/jsx-uses-vars.md
@@ -7,7 +7,7 @@ This rule will find variables used in JSX and mark them as used.
 
 This rule only has an effect when the `no-unused-vars` rule is enabled.
 
-## Rule Details
+## :book: Rule Details
 
 Without this rule this code triggers warning:
 
@@ -25,7 +25,7 @@ export default {
 
 After turning on, `Hello` is being marked as used and `no-unused-vars` rule doesn't report an issue.
 
-## When Not To Use It
+## :mute: When Not To Use It
 
 If you are not using JSX or if you do not use the `no-unused-vars` rule then you can disable this rule.
 

--- a/docs/rules/jsx-uses-vars.md
+++ b/docs/rules/jsx-uses-vars.md
@@ -11,7 +11,7 @@ This rule only has an effect when the `no-unused-vars` rule is enabled.
 
 Without this rule this code triggers warning:
 
-```js
+```jsx
 import HelloWorld from './HelloWorld';
 
 export default {

--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -59,7 +59,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 - `multiline.max` (`number`) ... The max number of attributes per line when the opening tag is in multiple lines. Default is `1`. This can be `{ multiline: 1 }` instead of `{ multiline: { max: 1 }}` if you don't configure `allowFirstLine` property.
 - `multiline.allowFirstLine` (`boolean`) ... If `true`, it allows attributes on the same line as that tag name. Default is `false`.
 
-### `{ "singleline": 3 }`
+### `"singleline": 3`
 
 <eslint-code-block :rules="{'vue/max-attributes-per-line': ['error', {singleline: 3}]}">
 ```
@@ -73,7 +73,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 ```
 </eslint-code-block>
 
-### `{ multiline: 2 }`
+### `multiline: 2`
 
 <eslint-code-block :rules="{'vue/max-attributes-per-line': ['error', {multiline: 2}]}">
 ```
@@ -93,7 +93,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 ```
 </eslint-code-block>
 
-### `{ multiline: 1, allowFirstLine: true }`
+### `multiline: 1, allowFirstLine: true`
 
 <eslint-code-block :rules="{'vue/max-attributes-per-line': ['error', {multiline: { allowFirstLine: true }}]}">
 ```

--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -73,7 +73,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 ```
 </eslint-code-block>
 
-### `multiline: 2`
+### `"multiline": 2`
 
 <eslint-code-block fix :rules="{'vue/max-attributes-per-line': ['error', {multiline: 2}]}">
 ```
@@ -93,7 +93,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 ```
 </eslint-code-block>
 
-### `multiline: 1, allowFirstLine: true`
+### `"multiline": 1, "allowFirstLine": true`
 
 <eslint-code-block fix :rules="{'vue/max-attributes-per-line': ['error', {multiline: { allowFirstLine: true }}]}">
 ```

--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -13,7 +13,7 @@ An attribute is considered to be in a new line when there is a line break betwee
 
 There is a configurable number of attributes that are acceptable in one-line case (default 1), as well as how many attributes are acceptable per line in multi-line case (default 1).
 
-<eslint-code-block :rules="{'vue/max-attributes-per-line': ['error']}">
+<eslint-code-block fix :rules="{'vue/max-attributes-per-line': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -61,7 +61,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 
 ### `"singleline": 3`
 
-<eslint-code-block :rules="{'vue/max-attributes-per-line': ['error', {singleline: 3}]}">
+<eslint-code-block fix :rules="{'vue/max-attributes-per-line': ['error', {singleline: 3}]}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -75,7 +75,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 
 ### `multiline: 2`
 
-<eslint-code-block :rules="{'vue/max-attributes-per-line': ['error', {multiline: 2}]}">
+<eslint-code-block fix :rules="{'vue/max-attributes-per-line': ['error', {multiline: 2}]}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -95,7 +95,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 
 ### `multiline: 1, allowFirstLine: true`
 
-<eslint-code-block :rules="{'vue/max-attributes-per-line': ['error', {multiline: { allowFirstLine: true }}]}">
+<eslint-code-block fix :rules="{'vue/max-attributes-per-line': ['error', {multiline: { allowFirstLine: true }}]}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -6,7 +6,7 @@
 
 This rule enforces a line break before and after the contents of a multiline element.
 
-<eslint-code-block :rules="{'vue/multiline-html-element-content-newline': ['error']}">
+<eslint-code-block fix :rules="{'vue/multiline-html-element-content-newline': ['error']}">
 ```vue
 <template>
   <!-- ✓ GOOD -->
@@ -77,7 +77,7 @@ This rule enforces a line break before and after the contents of a multiline ele
 
 ### `"ignores": ["VueComponent", "pre", "textarea"]`
 
-<eslint-code-block :rules="{'vue/multiline-html-element-content-newline': ['error', { ignores: ['VueComponent', 'pre', 'textarea'] }]}">
+<eslint-code-block fix :rules="{'vue/multiline-html-element-content-newline': ['error', { ignores: ['VueComponent', 'pre', 'textarea'] }]}">
 ```vue
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -6,58 +6,61 @@
 
 This rule enforces a line break before and after the contents of a multiline element.
 
+<eslint-code-block :rules="{'vue/multiline-html-element-content-newline': ['error']}">
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <div>
+    multiline
+    content
+  </div>
 
-:-1: Examples of **incorrect** code:
+  <pre>some
+  content</pre>
 
-```html
-<div>multiline
-  content</div>
+  <div
+    attr
+  >
+    multiline start tag
+  </div>
 
-<div
-  attr
->multiline start tag</div>
+  <table>
+    <tr>
+      <td>multiline</td>
+      <td>children</td>
+    </tr>
+  </table>
 
-<tr><td>multiline</td>
-  <td>children</td></tr>
+  <div>
+    <!-- multiline
+         comment -->
+  </div>
 
-<div><!-- multiline
-  comment --></div>
+  <div
+  >
+  </div>
 
-<div
-></div>
+  <div attr>singleline element</div>
+
+  <!-- ✗ BAD -->
+  <div>multiline
+    content</div>
+
+  <div
+    attr
+  >multiline start tag</div>
+  
+  <table><tr><td>multiline</td>
+    <td>children</td></tr></table>
+  
+  <div><!-- multiline
+    comment --></div>
+
+  <div
+  ></div>
+</template>
 ```
-
-:+1: Examples of **correct** code:
-
-```html
-<div>
-  multiline
-  content
-</div>
-
-<div
-  attr
->
-  multiline start tag
-</div>
-
-<tr>
-  <td>multiline</td>
-  <td>children</td>
-</tr>
-
-<div>
-  <!-- multiline
-       comment -->
-</div>
-
-<div
->
-</div>
-
-<div attr>singleline element</div>
-```
-
+</eslint-code-block>
 
 ## :wrench: Options
 
@@ -72,19 +75,24 @@ This rule enforces a line break before and after the contents of a multiline ele
 - `ignores` ... the configuration for element names to ignore line breaks style.  
     default `["pre", "textarea"]`
 
+### `"ignores": ["VueComponent", "pre", "textarea"]`
 
-:+1: Examples of **correct** code:
+<eslint-code-block :rules="{'vue/multiline-html-element-content-newline': ['error', { ignores: ['VueComponent', 'pre', 'textarea'] }]}">
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <VueComponent>multiline
+  content</VueComponent>
 
-```html
-/* eslint vue/multiline-html-element-content-newline: ["error", { "ignores": ["VueComponent", "pre", "textarea"]}] */
+  <pre>some
+  content</pre>
 
-<VueComponent>multiline
-content</VueComponent>
-
-<VueComponent><span
-  class="bold">For example,</span>
-Defines the Vue component that accepts preformatted text.</VueComponent>
+  <VueComponent><span
+    class="bold">For example,</span>
+  Defines the Vue component that accepts preformatted text.</VueComponent>
+</template>
 ```
+</eslint-code-block>
 
 ## :mag: Implementation
 

--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -63,9 +63,9 @@ This rule enforces a line break before and after the contents of a multiline ele
 
 ```json
 {
-    "vue/multiline-html-element-content-newline": ["error", {
-        "ignores": ["pre", "textarea"]
-    }]
+  "vue/multiline-html-element-content-newline": ["error", {
+    "ignores": ["pre", "textarea"]
+  }]
 }
 ```
 

--- a/docs/rules/mustache-interpolation-spacing.md
+++ b/docs/rules/mustache-interpolation-spacing.md
@@ -7,19 +7,6 @@
 
 This rule aims at enforcing unified spacing in mustache interpolations.
 
-## :wrench: Options
-
-```json
-{
-  "vue/mustache-interpolation-spacing": ["error", "always" | "never"]
-}
-```
-
-- `"always"` (default) ... Expect one space between expression and curly brackets.
-- `"never"` ... Expect no spaces between expression and curly brackets.
-
-### `"always"`
-
 <eslint-code-block fix :rules="{'vue/mustache-interpolation-spacing': ['error']}">
 ```
 <template>
@@ -32,6 +19,17 @@ This rule aims at enforcing unified spacing in mustache interpolations.
 </template>
 ```
 </eslint-code-block>
+
+## :wrench: Options
+
+```json
+{
+  "vue/mustache-interpolation-spacing": ["error", "always" | "never"]
+}
+```
+
+- `"always"` (default) ... Expect one space between expression and curly brackets.
+- `"never"` ... Expect no spaces between expression and curly brackets.
 
 ### `"never"`
 

--- a/docs/rules/mustache-interpolation-spacing.md
+++ b/docs/rules/mustache-interpolation-spacing.md
@@ -20,7 +20,7 @@ This rule aims at enforcing unified spacing in mustache interpolations.
 
 ### `"always"`
 
-<eslint-code-block :rules="{'vue/mustache-interpolation-spacing': ['error']}">
+<eslint-code-block fix :rules="{'vue/mustache-interpolation-spacing': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -35,7 +35,7 @@ This rule aims at enforcing unified spacing in mustache interpolations.
 
 ### `"never"`
 
-<eslint-code-block :rules="{'vue/mustache-interpolation-spacing': ['error', 'never']}">
+<eslint-code-block fix :rules="{'vue/mustache-interpolation-spacing': ['error', 'never']}">
 ```
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/name-property-casing.md
+++ b/docs/rules/name-property-casing.md
@@ -20,7 +20,7 @@ This rule aims at enforcing the style for the `name` property casing for consist
 
 ### `"PascalCase"`
 
-<eslint-code-block :rules="{'vue/name-property-casing': ['error']}">
+<eslint-code-block fix :rules="{'vue/name-property-casing': ['error']}">
 ```
 <script>
   /* ✓ GOOD */
@@ -31,7 +31,7 @@ This rule aims at enforcing the style for the `name` property casing for consist
 ```
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/name-property-casing': ['error']}">
+<eslint-code-block fix :rules="{'vue/name-property-casing': ['error']}">
 ```
 <script>
   /* ✗ BAD */
@@ -44,7 +44,7 @@ This rule aims at enforcing the style for the `name` property casing for consist
 
 ### `"kebab-case"`
 
-<eslint-code-block :rules="{'vue/name-property-casing': ['error', 'kebab-case']}">
+<eslint-code-block fix :rules="{'vue/name-property-casing': ['error', 'kebab-case']}">
 ```
 <script>
   /* ✓ GOOD */
@@ -55,7 +55,7 @@ This rule aims at enforcing the style for the `name` property casing for consist
 ```
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/name-property-casing': ['error', 'kebab-case']}">
+<eslint-code-block fix :rules="{'vue/name-property-casing': ['error', 'kebab-case']}">
 ```
 <script>
   /* ✗ BAD */

--- a/docs/rules/name-property-casing.md
+++ b/docs/rules/name-property-casing.md
@@ -7,19 +7,6 @@
 
 This rule aims at enforcing the style for the `name` property casing for consistency purposes.
 
-## :wrench: Options
-
-```json
-{
-  "vue/name-property-casing": ["error", "PascalCase" | "kebab-case"]
-}
-```
-
-- `"PascalCase"` (default) ... Enforce the `name` property to Pascal case.
-- `"kebab-case"` ... Enforce the `name` property to kebab case.
-
-### `"PascalCase"`
-
 <eslint-code-block fix :rules="{'vue/name-property-casing': ['error']}">
 ```
 <script>
@@ -41,6 +28,17 @@ This rule aims at enforcing the style for the `name` property casing for consist
 </script>
 ```
 </eslint-code-block>
+
+## :wrench: Options
+
+```json
+{
+  "vue/name-property-casing": ["error", "PascalCase" | "kebab-case"]
+}
+```
+
+- `"PascalCase"` (default) ... Enforce the `name` property to Pascal case.
+- `"kebab-case"` ... Enforce the `name` property to kebab case.
 
 ### `"kebab-case"`
 

--- a/docs/rules/no-confusing-v-for-v-if.md
+++ b/docs/rules/no-confusing-v-for-v-if.md
@@ -2,12 +2,6 @@
 
 - :warning: This rule was **deprecated** and replaced by [vue/no-use-v-if-with-v-for](no-use-v-if-with-v-for.md) rule.
 
-> When they exist on the same node, `v-for` has a higher priority than `v-if`. That means the `v-if` will be run on each iteration of the loop separately.
->
-> https://vuejs.org/v2/guide/list.html#v-for-with-v-if
-
-So when they exist on the same node, `v-if` directive should use the reference which is to the variables which are defined by the `v-for` directives.
-
 ## :book: Rule Details
 
 This rule reports the elements which have both `v-for` and `v-if` directives in the following cases:
@@ -41,6 +35,12 @@ In that case, the `v-if` should be written on the wrapper element.
 </template>
 ```
 </eslint-code-block>
+
+::: warning Note
+When they exist on the same node, `v-for` has a higher priority than `v-if`. That means the `v-if` will be run on each iteration of the loop separately.
+
+[https://vuejs.org/v2/guide/list.html#v-for-with-v-if](https://vuejs.org/v2/guide/list.html#v-for-with-v-if)
+:::
 
 ## :wrench: Options
 

--- a/docs/rules/no-confusing-v-for-v-if.md
+++ b/docs/rules/no-confusing-v-for-v-if.md
@@ -1,6 +1,5 @@
 # disallow confusing `v-for` and `v-if` on the same element (vue/no-confusing-v-for-v-if)
 
-- :gear: This rule is included in `"plugin:vue/recommended"`.
 - :warning: This rule was **deprecated** and replaced by [vue/no-use-v-if-with-v-for](no-use-v-if-with-v-for.md) rule.
 
 > When they exist on the same node, `v-for` has a higher priority than `v-if`. That means the `v-if` will be run on each iteration of the loop separately.

--- a/docs/rules/no-dupe-keys.md
+++ b/docs/rules/no-dupe-keys.md
@@ -34,15 +34,17 @@ export default {
 
 ## :wrench: Options
 
-``` json
+```json
 {
-  "vue/no-dupe-keys": ["error", { "groups": [] }]
+  "vue/no-dupe-keys": ["error", {
+    "groups": []
+  }]
 }
 ```
 
 - `"groups"` (`string[]`) Array of additional groups to search for duplicates. Defailt is empty.
 
-### `{ "groups": ["firebase"] }`
+### `"groups": ["firebase"]`
 
 <eslint-code-block :rules="{'vue/no-dupe-keys': ['error', {groups: ['firebase']}]}">
 ```

--- a/docs/rules/no-duplicate-attributes.md
+++ b/docs/rules/no-duplicate-attributes.md
@@ -45,7 +45,7 @@ This rule reports duplicate attributes.
 [`v-bind:class`]: https://vuejs.org/v2/guide/class-and-style.html
 [`v-bind:style`]: https://vuejs.org/v2/guide/class-and-style.html
 
-### `{ "allowCoexistClass": false, "allowCoexistStyle": false }`
+### `"allowCoexistClass": false, "allowCoexistStyle": false`
 
 <eslint-code-block :rules="{'vue/no-duplicate-attributes': ['error', {allowCoexistClass: false, allowCoexistStyle: false}]}">
 ```

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -7,7 +7,7 @@
 
 This rule aims at removing multiple spaces in tags, which are not used for indentation.
 
-<eslint-code-block :rules="{'vue/no-multi-spaces': ['error']}">
+<eslint-code-block fix :rules="{'vue/no-multi-spaces': ['error']}">
 ```
 <template>
   <!-- ✓ GOOD -->
@@ -36,7 +36,7 @@ This rule aims at removing multiple spaces in tags, which are not used for inden
 
 ### `"ignoreProperties": true`
 
-<eslint-code-block :rules="{'vue/no-multi-spaces': ['error', { 'ignoreProperties': true }]}">
+<eslint-code-block fix :rules="{'vue/no-multi-spaces': ['error', { 'ignoreProperties': true }]}">
 ```vue
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -24,28 +24,31 @@ This rule aims at removing multiple spaces in tags, which are not used for inden
 
 ## :wrench: Options
 
-This rule has an object option:
-
-`"ignoreProperties": false` (default) whether or not objects' properties should be ignored
-
-### Example:
-
 ```json
-"vue/no-multi-spaces": [2, {
-  "ignoreProperties": true
-}]
+{
+  "vue/no-multi-spaces": [2, {
+    "ignoreProperties": false
+  }]
+}
 ```
 
-:+1: Examples of **correct** code for this rule:
+- `ignoreProperties` ... whether or not objects' properties should be ignored. default `false`
 
-```html
-<i
-  :class="{
-    'fa-angle-up'   : isExpanded,
-    'fa-angle-down' : !isExpanded,
-  }"
-/>
+### `"ignoreProperties": true`
+
+<eslint-code-block :rules="{'vue/no-multi-spaces': ['error', { 'ignoreProperties': true }]}">
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <i
+    :class="{
+      'fa-angle-up'   : isExpanded,
+      'fa-angle-down' : !isExpanded,
+    }"
+  />
+</template>
 ```
+</eslint-code-block>
 
 ## :mag: Implementation
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -14,10 +14,22 @@ This rule aims at removing multiple spaces in tags, which are not used for inden
   <div
     class="foo"
     :style="bar" />
+  <i
+    :class="{
+      'fa-angle-up' : isExpanded,
+      'fa-angle-down' : !isExpanded,
+    }"
+  />
 
   <!-- ✗ BAD -->
   <div     class="foo"
     :style =  "bar"         />
+  <i
+    :class="{
+      'fa-angle-up'   : isExpanded,
+      'fa-angle-down' : !isExpanded,
+    }"
+  />
 </template>
 ```
 </eslint-code-block>

--- a/docs/rules/no-parsing-error.md
+++ b/docs/rules/no-parsing-error.md
@@ -10,7 +10,7 @@ This rule reports syntax errors in `<template>`. For example:
     - Invalid end tags.
     - Attributes in end tags.
     - ...
-    - See also: https://html.spec.whatwg.org/multipage/parsing.html#parse-errors
+    - See also: [WHATWG HTML spec](https://html.spec.whatwg.org/multipage/parsing.html#parse-errors)
 
 ## :book: Rule Details
 
@@ -86,6 +86,10 @@ The error codes which have `x-` prefix are original of this rule because errors 
 
 - `x-invalid-end-tag` enables the errors about the end tags of elements which have not opened.
 - `x-invalid-namespace` enables the errors about invalid `xmlns` attributes. See also [step 10. of "create an element for a token"](https://html.spec.whatwg.org/multipage/parsing.html#create-an-element-for-the-token).
+
+## :books: Further reading
+
+- [WHATWG HTML spec](https://html.spec.whatwg.org/multipage/parsing.html#parse-errors)
 
 ## :mag: Implementation
 

--- a/docs/rules/no-reserved-keys.md
+++ b/docs/rules/no-reserved-keys.md
@@ -32,7 +32,7 @@ export default {
 
 ## :wrench: Options
 
-``` json
+```json
 {
   "vue/no-reserved-keys": ["error", {
     "reserved": [],
@@ -44,7 +44,7 @@ export default {
 - `reserved` (`string[]`) ... Array of additional restricted attributes inside `groups`. Default is empty.
 - `groups` (`string[]`) ... Array of additional group names to search for duplicates in. Default is empty.
 
-### `{ "reserved": ["foo", "foo2"], "groups": ["firebase"] }`
+### `"reserved": ["foo", "foo2"], "groups": ["firebase"]`
 
 <eslint-code-block :rules="{'vue/no-reserved-keys': ['error', {reserved: ['foo', 'foo2'], groups: ['firebase']}]}">
 ```

--- a/docs/rules/no-shared-component-data.md
+++ b/docs/rules/no-shared-component-data.md
@@ -9,7 +9,7 @@ When using the data property on a component (i.e. anywhere except on `new Vue`),
 
 When the value of `data` is an object, it’s shared across all instances of a component.
 
-<eslint-code-block :rules="{'vue/no-shared-component-data': ['error']}">
+<eslint-code-block fix :rules="{'vue/no-shared-component-data': ['error']}">
 ```
 <script>
 /* ✓ GOOD */
@@ -32,7 +32,7 @@ export default {
 ```
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/no-shared-component-data': ['error']}">
+<eslint-code-block fix :rules="{'vue/no-shared-component-data': ['error']}">
 ```
 <script>
 /* ✗ BAD */

--- a/docs/rules/no-side-effects-in-computed-properties.md
+++ b/docs/rules/no-side-effects-in-computed-properties.md
@@ -49,6 +49,10 @@ export default {
 
 Nothing.
 
+## :books: Further reading
+
+- [Guide - Computed Caching vs Methods](https://vuejs.org/v2/guide/computed.html#Computed-Caching-vs-Methods)
+
 ## :mag: Implementation
 
 - [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-side-effects-in-computed-properties.js)

--- a/docs/rules/no-side-effects-in-computed-properties.md
+++ b/docs/rules/no-side-effects-in-computed-properties.md
@@ -2,11 +2,11 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-It is considered a very bad practice to introduce side effects inside computed properties. It makes the code not predictable and hard to understand.
-
 ## :book: Rule Details
 
 This rule is aimed at preventing the code which makes side effects in computed properties.
+
+It is considered a very bad practice to introduce side effects inside computed properties. It makes the code not predictable and hard to understand.
 
 <eslint-code-block :rules="{'vue/no-side-effects-in-computed-properties': ['error']}">
 ```

--- a/docs/rules/no-spaces-around-equal-signs-in-attribute.md
+++ b/docs/rules/no-spaces-around-equal-signs-in-attribute.md
@@ -29,7 +29,7 @@ HTML5 allows spaces around equal signs. But space-less is easier to read, and gr
 }
 ```
 
-## Further Reading
+## :books: Further reading
 
 * [HTML5 Style Guide - W3Schools *Spaces and Equal Signs*](https://www.w3schools.com/html/html5_syntax.asp)
 

--- a/docs/rules/no-spaces-around-equal-signs-in-attribute.md
+++ b/docs/rules/no-spaces-around-equal-signs-in-attribute.md
@@ -6,7 +6,7 @@
 
 This rule disallow spaces around equal signs in attribute.
 
-<eslint-code-block :rules="{'vue/no-spaces-around-equal-signs-in-attribute': ['error']}">
+<eslint-code-block fix :rules="{'vue/no-spaces-around-equal-signs-in-attribute': ['error']}">
 ```
 <template>
   <!-- ✗ BAD -->

--- a/docs/rules/no-template-key.md
+++ b/docs/rules/no-template-key.md
@@ -27,6 +27,10 @@ This rule reports the `<template>` elements which have `key` attribute.
 
 Nothing.
 
+## :books: Further reading
+
+- [API - Special Attributes - key](https://vuejs.org/v2/api/#key)
+
 ## :mag: Implementation
 
 - [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-template-key.js)

--- a/docs/rules/no-template-shadow.md
+++ b/docs/rules/no-template-shadow.md
@@ -9,7 +9,7 @@
 This rule aims to eliminate shadowed variable declarations of v-for directives or scope attributes.
 
 <eslint-code-block :rules="{'vue/no-template-shadow': ['error']}">
-```
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-for="i in 5"></div>

--- a/docs/rules/no-textarea-mustache.md
+++ b/docs/rules/no-textarea-mustache.md
@@ -2,11 +2,6 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-::: warning Note
-Interpolation on textareas (`<textarea>{{text}}</textarea>`) won't work. Use `v-model` instead.
-[https://vuejs.org/v2/guide/forms.html#Multiline-text](https://vuejs.org/v2/guide/forms.html#Multiline-text)
-:::
-
 ## :book: Rule Details
 
 This rule reports mustaches in `<textarea>`.
@@ -22,6 +17,11 @@ This rule reports mustaches in `<textarea>`.
 </template>
 ```
 </eslint-code-block>
+
+::: warning Note
+Interpolation on textareas (`<textarea>{{text}}</textarea>`) won't work. Use `v-model` instead.
+[https://vuejs.org/v2/guide/forms.html#Multiline-text](https://vuejs.org/v2/guide/forms.html#Multiline-text)
+:::
 
 ## :wrench: Options
 

--- a/docs/rules/no-unused-components.md
+++ b/docs/rules/no-unused-components.md
@@ -66,9 +66,9 @@ Note that components registered under other than `PascalCase` name have to be ca
 
 ```json
 {
-    "vue/no-unused-components": ["error", {
-        "ignoreWhenBindingPresent": true
-    }]
+  "vue/no-unused-components": ["error", {
+    "ignoreWhenBindingPresent": true
+  }]
 }
 ```
 
@@ -80,9 +80,9 @@ Note that components registered under other than `PascalCase` name have to be ca
 
 ```json
 {
-    "vue/no-unused-components": ["error", {
-        "ignoreWhenBindingPresent": false
-    }]
+  "vue/no-unused-components": ["error", {
+    "ignoreWhenBindingPresent": false
+  }]
 }
 ```
 
@@ -116,9 +116,9 @@ Note that components registered under other than `PascalCase` name have to be ca
 
 ```json
 {
-    "vue/no-unused-components": ["error", {
-        "ignoreWhenBindingPresent": false
-    }]
+  "vue/no-unused-components": ["error", {
+    "ignoreWhenBindingPresent": false
+  }]
 }
 ```
 

--- a/docs/rules/no-unused-components.md
+++ b/docs/rules/no-unused-components.md
@@ -6,34 +6,9 @@
 
 This rule reports components that haven't been used in the template.
 
-:-1: Examples of **incorrect** code for this rule:
-
-```html
-<template>
-  <div>
-    <h2>Lorem ipsum</h2>
-    <TheModal />
-  </div>
-</template>
-
-<script>
-  import TheButton from 'components/TheButton.vue'
-  import TheModal from 'components/TheModal.vue'
-
-  export default {
-    components: {
-      TheButton // Unused component
-      'the-modal': TheModal // Unused component
-    }
-  }
-</script>
-```
-
-Note that components registered under other than `PascalCase` name have to be called directly under the specified name, whereas if you register it using `PascalCase` you can call it however you like, except using `snake_case`.
-
-:+1: Examples of **correct** code for this rule:
-
-```html
+<eslint-code-block :rules="{'vue/no-unused-components': ['error']}">
+```vue
+<!-- ✓ GOOD -->
 <template>
   <div>
     <h2>Lorem ipsum</h2>
@@ -61,6 +36,35 @@ Note that components registered under other than `PascalCase` name have to be ca
   }
 </script>
 ```
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-unused-components': ['error']}">
+```vue
+<!-- ✗ BAD -->
+<template>
+  <div>
+    <h2>Lorem ipsum</h2>
+    <TheModal />
+  </div>
+</template>
+
+<script>
+  import TheButton from 'components/TheButton.vue'
+  import TheModal from 'components/TheModal.vue'
+
+  export default {
+    components: {
+      TheButton, // Unused component
+      'the-modal': TheModal // Unused component
+    }
+  }
+</script>
+```
+</eslint-code-block>
+
+::: warning Note
+Components registered under other than `PascalCase` name have to be called directly under the specified name, whereas if you register it using `PascalCase` you can call it however you like, except using `snake_case`.
+:::
 
 ## :wrench: Options
 
@@ -75,54 +79,11 @@ Note that components registered under other than `PascalCase` name have to be ca
 - `ignoreWhenBindingPresent` ... suppresses all errors if binding has been detected in the template
     default `true`
 
+### `ignoreWhenBindingPresent: false`
 
-:+1: Examples of **incorrect** code:
-
-```json
-{
-  "vue/no-unused-components": ["error", {
-    "ignoreWhenBindingPresent": false
-  }]
-}
-```
-
-```html
-<template>
-  <div>
-    <h2>Lorem ipsum</h2>
-    <component :is="computedComponent" />
-  </div>
-</template>
-
-<script>
-  import TheButton from 'components/TheButton.vue'
-  import TheSelect from 'components/TheSelect.vue'
-  import TheInput from 'components/TheInput.vue'
-
-  export default {
-    components: {
-      TheButton, // <- not used
-      TheSelect, // <- not used
-      TheInput, // <- not used
-    },
-    computed: {
-      computedComponent() { ... }
-    }
-  }
-</script>
-```
-
-:+1: Examples of **correct** code:
-
-```json
-{
-  "vue/no-unused-components": ["error", {
-    "ignoreWhenBindingPresent": false
-  }]
-}
-```
-
-```html
+<eslint-code-block :rules="{'vue/no-unused-components': ['error', { 'ignoreWhenBindingPresent': false }]}">
+```vue
+<!-- ✓ GOOD -->
 <template>
   <div>
     <h2>Lorem ipsum</h2>
@@ -146,6 +107,37 @@ Note that components registered under other than `PascalCase` name have to be ca
   }
 </script>
 ```
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-unused-components': ['error', { 'ignoreWhenBindingPresent': false }]}">
+```vue
+<!-- ✗ BAD -->
+<template>
+  <div>
+    <h2>Lorem ipsum</h2>
+    <component :is="computedComponent" />
+  </div>
+</template>
+
+<script>
+  import TheButton from 'components/TheButton.vue'
+  import TheSelect from 'components/TheSelect.vue'
+  import TheInput from 'components/TheInput.vue'
+
+  export default {
+    components: {
+      TheButton, // <- not used
+      TheSelect, // <- not used
+      TheInput, // <- not used
+    },
+    computed: {
+      computedComponent() {
+      }
+    }
+  }
+</script>
+```
+</eslint-code-block>
 
 ## :mag: Implementation
 

--- a/docs/rules/no-unused-components.md
+++ b/docs/rules/no-unused-components.md
@@ -2,9 +2,9 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-This rule reports components that haven't been used in the template.
-
 ## :book: Rule Details
+
+This rule reports components that haven't been used in the template.
 
 :-1: Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-use-v-if-with-v-for.md
+++ b/docs/rules/no-use-v-if-with-v-for.md
@@ -45,7 +45,7 @@ There are two common cases where this can be tempting:
 ```json
 {
   "vue/no-use-v-if-with-v-for": ["error", {
-    allowUsingIterationVar: false
+    "allowUsingIterationVar": false
   }]
 }
 ```

--- a/docs/rules/no-use-v-if-with-v-for.md
+++ b/docs/rules/no-use-v-if-with-v-for.md
@@ -2,19 +2,13 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-> Never use `v-if` on the same element as `v-for`.
->
-> There are two common cases where this can be tempting:
->
-> * To filter items in a list (e.g. `v-for="user in users" v-if="user.isActive"`). In these cases, replace `users` with a new computed property that returns your filtered list (e.g. `activeUsers`).
->
-> * To avoid rendering a list if it should be hidden (e.g. `v-for="user in users" v-if="shouldShowUsers"`). In these cases, move the `v-if` to a container element (e.g. `ul`, `ol`).
->
-> https://vuejs.org/v2/style-guide/#Avoid-v-if-with-v-for-essential
-
 ## :book: Rule Details
 
 This rule is aimed at preventing the use of `v-for` directives together with `v-if` directives on the same element.
+
+There are two common cases where this can be tempting:
+ * To filter items in a list (e.g. `v-for="user in users" v-if="user.isActive"`). In these cases, replace `users` with a new computed property that returns your filtered list (e.g. `activeUsers`).
+ * To avoid rendering a list if it should be hidden (e.g. `v-for="user in users" v-if="shouldShowUsers"`). In these cases, move the `v-if` to a container element (e.g. `ul`, `ol`).
 
 <eslint-code-block :rules="{'vue/no-use-v-if-with-v-for': ['error']}">
 ```
@@ -58,7 +52,7 @@ This rule is aimed at preventing the use of `v-for` directives together with `v-
 
 - `allowUsingIterationVar` (`boolean`) ... Enables The `v-if` directive use the reference which is to the variables which are defined by the `v-for` directives. Default is `false`.
 
-### { "allowUsingIterationVar": true }
+### `"allowUsingIterationVar": true`
 
 <eslint-code-block :rules="{'vue/no-use-v-if-with-v-for': ['error', {allowUsingIterationVar: true}]}">
 ```

--- a/docs/rules/no-v-html.md
+++ b/docs/rules/no-v-html.md
@@ -2,11 +2,9 @@
 
 - :gear: This rule is included in `"plugin:vue/recommended"`.
 
-This rule reports use of `v-html` directive in order to reduce the risk of injecting potentially unsafe / unescaped html into the browser leading to Cross-Site Scripting (XSS) attacks.
-
 ## :book: Rule Details
 
-This rule reports all uses of `v-html` to help prevent XSS attacks.
+This rule reports all uses of `v-html` directive in order to reduce the risk of injecting potentially unsafe / unescaped html into the browser leading to Cross-Site Scripting (XSS) attacks.
 
 <eslint-code-block :rules="{'vue/no-v-html': ['error']}">
 ```
@@ -20,7 +18,7 @@ This rule reports all uses of `v-html` to help prevent XSS attacks.
 ```
 </eslint-code-block>
 
-This rule does not check syntax errors in directives because it's checked by no-parsing-error rule.
+This rule does not check syntax errors in directives because it's checked by [vue/no-parsing-error](./no-parsing-error.md) rule.
 
 ## :wrench: Options
 
@@ -28,7 +26,7 @@ Nothing.
 
 ## :mute: When Not To Use It
 
-If you are certain the content passed `to v-html` is sanitized HTML you can disable this rule.
+If you are certain the content passed to `v-html` is sanitized HTML you can disable this rule.
 
 ## :books: Further reading
 

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -8,7 +8,7 @@
 This rule makes sure you keep declared order of properties in components.
 Recommended order of properties can be [found here](https://vuejs.org/v2/style-guide/#Component-instance-options-order-recommended).
 
-<eslint-code-block :rules="{'vue/order-in-components': ['error']}">
+<eslint-code-block fix :rules="{'vue/order-in-components': ['error']}">
 ```
 <script>
 /* ✓ GOOD */
@@ -27,7 +27,7 @@ export default {
 ```
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/order-in-components': ['error']}">
+<eslint-code-block fix :rules="{'vue/order-in-components': ['error']}">
 ```
 <script>
 /* ✗ BAD */

--- a/docs/rules/prop-name-casing.md
+++ b/docs/rules/prop-name-casing.md
@@ -3,11 +3,9 @@
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-This rule would enforce proper casing of props in vue components(camelCase).
-
 ## :book: Rule Details
 
-(https://vuejs.org/v2/style-guide/#Prop-name-casing-strongly-recommended).
+This rule enforce proper casing of props in vue components(camelCase).
 
 <eslint-code-block fix :rules="{'vue/prop-name-casing': ['error']}">
 ```

--- a/docs/rules/prop-name-casing.md
+++ b/docs/rules/prop-name-casing.md
@@ -9,7 +9,7 @@ This rule would enforce proper casing of props in vue components(camelCase).
 
 (https://vuejs.org/v2/style-guide/#Prop-name-casing-strongly-recommended).
 
-<eslint-code-block :rules="{'vue/prop-name-casing': ['error']}">
+<eslint-code-block fix :rules="{'vue/prop-name-casing': ['error']}">
 ```
 <script>
 export default {
@@ -39,7 +39,7 @@ export default {
 
 ### `"snake_case"`
 
-<eslint-code-block :rules="{'vue/prop-name-casing': ['error', 'snake_case']}">
+<eslint-code-block fix :rules="{'vue/prop-name-casing': ['error', 'snake_case']}">
 ```
 <script>
 export default {

--- a/docs/rules/prop-name-casing.md
+++ b/docs/rules/prop-name-casing.md
@@ -28,7 +28,7 @@ export default {
 
 ## :wrench: Options
 
-```
+```json
 {
   "vue/prop-name-casing": ["error", "camelCase" | "snake_case"]
 }

--- a/docs/rules/require-component-is.md
+++ b/docs/rules/require-component-is.md
@@ -30,7 +30,7 @@ You can use the same mount point and dynamically switch between multiple compone
 
 Nothing.
 
-## Related links
+## :books: Further reading
 
 - [Guide - Dynamic Components](https://vuejs.org/v2/guide/components.html#Dynamic-Components)
 

--- a/docs/rules/require-component-is.md
+++ b/docs/rules/require-component-is.md
@@ -2,27 +2,29 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-> You can use the same mount point and dynamically switch between multiple components using the reserved `<component>` element and dynamically bind to its `is` attribute:
->
-> https://vuejs.org/v2/guide/components.html#Dynamic-Components
-
 ## :book: Rule Details
 
 This rule reports the `<component>` elements which do not have `v-bind:is` attributes.
 
-:-1: Examples of **incorrect** code for this rule:
 
-```html
-<component/>
-<component is="type"/>
+<eslint-code-block :rules="{'vue/require-component-is': ['error']}">
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <component :is="type"/>
+  <component v-bind:is="type"/>
+
+  <!-- ✗ BAD -->
+  <component/>
+  <component is="type"/>
+</template>
 ```
+</eslint-code-block>
 
-:+1: Examples of **correct** code for this rule:
+::: warning Note
+You can use the same mount point and dynamically switch between multiple components using the reserved `<component>` element and dynamically bind to its `is` attribute.
+:::
 
-```html
-<component :is="type"/>
-<component v-bind:is="type"/>
-```
 
 ## :wrench: Options
 

--- a/docs/rules/require-default-prop.md
+++ b/docs/rules/require-default-prop.md
@@ -2,7 +2,7 @@
 
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-## Rule Details
+## :book: Rule Details
 
 This rule requires default value to be set for each props that are not marked as `required` (except `Boolean` props).
 

--- a/docs/rules/require-default-prop.md
+++ b/docs/rules/require-default-prop.md
@@ -2,51 +2,55 @@
 
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-This rule requires default value to be set for each props that are not marked as `required` (except `Boolean` props).
-
 ## Rule Details
 
-Examples of **incorrect** code for this rule:
+This rule requires default value to be set for each props that are not marked as `required` (except `Boolean` props).
 
-```js
-props: {
-  a: Number,
-  b: [Number, String],
-  c: [Boolean, Number],
-  d: {
-    type: Number
-  },
-  e: {
-    type: Number,
-    required: false
+<eslint-code-block :rules="{'vue/require-default-prop': ['error']}">
+```
+<script>
+export default {
+  props: {
+    /* ✓ GOOD */
+    a: {
+      type: Number,
+      required: true
+    },
+    b: {
+      type: Number,
+      default: 0
+    },
+    c: {
+      type: Number,
+      default: 0,
+      required: false
+    },
+    d: {
+      type: Boolean, // Boolean is the only type that doesn't require default
+    },
+
+    /* ✗ BAD */
+    e: Number,
+    f: [Number, String],
+    g: [Boolean, Number],
+    j: {
+      type: Number
+    },
+    i: {
+      type: Number,
+      required: false
+    }
   }
 }
+</script>
 ```
+</eslint-code-block>
 
-Examples of **correct** code for this rule:
+## :wrench: Options
 
-```js
-props: {
-  a: {
-    type: Number,
-    required: true
-  },
-  b: {
-    type: Number,
-    default: 0
-  },
-  c: {
-    type: Number,
-    default: 0,
-    required: false
-  },
-  d: {
-    type: Boolean, // Boolean is the only type that doesn't require default
-  }
-}
-```
+Nothing.
 
-## Related links
+## :books: Further reading
 
 - [Style guide - Prop definitions](https://vuejs.org/v2/style-guide/#Prop-definitions-essential)
 

--- a/docs/rules/require-prop-type-constructor.md
+++ b/docs/rules/require-prop-type-constructor.md
@@ -3,7 +3,7 @@
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-## Rule Details
+## :book: Rule Details
 
 This rule reports prop types that can't be presumed as constructors.
 

--- a/docs/rules/require-prop-type-constructor.md
+++ b/docs/rules/require-prop-type-constructor.md
@@ -18,7 +18,7 @@ The following types are forbidden and will be reported:
 
 It will catch most commonly made mistakes which are using strings instead of constructors.
 
-<eslint-code-block :rules="{'vue/require-prop-type-constructor': ['error']}">
+<eslint-code-block fix :rules="{'vue/require-prop-type-constructor': ['error']}">
 ```vue
 <script>
 export default {

--- a/docs/rules/require-prop-type-constructor.md
+++ b/docs/rules/require-prop-type-constructor.md
@@ -3,6 +3,8 @@
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
+## Rule Details
+
 This rule reports prop types that can't be presumed as constructors.
 
 It's impossible to catch every possible case and know whether the prop type is a constructor or not, hence this rule black list few types of nodes, instead of white-listing correct ones.
@@ -15,8 +17,6 @@ The following types are forbidden and will be reported:
 - UpdateExpression
 
 It will catch most commonly made mistakes which are using strings instead of constructors.
-
-## Rule Details
 
 <eslint-code-block :rules="{'vue/require-prop-type-constructor': ['error']}">
 ```vue

--- a/docs/rules/require-prop-type-constructor.md
+++ b/docs/rules/require-prop-type-constructor.md
@@ -59,6 +59,10 @@ export default {
 
 Nothing.
 
+## :books: Further reading
+
+- [Guide - Prop Validation](https://vuejs.org/v2/guide/components-props.html#Prop-Validation)
+
 ## :mag: Implementation
 
 - [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/require-prop-type-constructor.js)

--- a/docs/rules/require-prop-types.md
+++ b/docs/rules/require-prop-types.md
@@ -52,7 +52,7 @@ props: {
 
 Nothing.
 
-## Related links
+## :books: Further reading
 
 - [Style guide - Prop definitions](https://vuejs.org/v2/style-guide/#Prop-definitions-essential)
 

--- a/docs/rules/require-prop-types.md
+++ b/docs/rules/require-prop-types.md
@@ -2,51 +2,51 @@
 
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-In committed code, prop definitions should always be as detailed as possible, specifying at least type(s).
-
 ## :book: Rule Details
 
 This rule enforces that a `props` statement contains type definition.
 
-:-1: Examples of **incorrect** code for this rule:
+In committed code, prop definitions should always be as detailed as possible, specifying at least type(s).
 
-```js
-props: ['status']
-```
-
-:+1: Examples of **correct** code for this rule:
-
-```js
-// Without options, just type reference
-props: {
-  status: String
-}
-```
-
-```js
-// With options with type field
-props: {
-  status: {
-    type: String,
-    required: true,
-  }
-}
-```
-
-```js
-// With options without type field but with validator field
-props: {
-  status: {
-    required: true,
-    validator: function (value) {
-      return (
-        value === null ||
-        Array.isArray(value) && value.length > 0
-      )
+<eslint-code-block :rules="{'vue/require-prop-types': ['error']}">
+```vue
+<script>
+/* ✓ GOOD */
+Vue.component('foo', {
+  props: {
+    // Without options, just type reference
+    foo: String,
+    // With options with type field
+    bar: {
+      type: String,
+      required: true,
+    },
+    // With options without type field but with validator field
+    baz: {
+      required: true,
+      validator: function (value) {
+        return (
+          value === null ||
+          Array.isArray(value) && value.length > 0
+        )
+      }
     }
   }
-}
+})
+
+/* ✗ BAD */
+Vue.component('bar', {
+  props: ['foo']
+})
+
+Vue.component('baz', {
+  props: {
+    foo: {},
+  }
+})
+</script>
 ```
+</eslint-code-block>
 
 ## :wrench: Options
 

--- a/docs/rules/require-render-return.md
+++ b/docs/rules/require-render-return.md
@@ -2,19 +2,15 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-This rule aims to enforce render function to always return value
-
 ## :book: Rule Details
+
+This rule aims to enforce render function to always return value
 
 :-1: Examples of **incorrect** code for this rule:
 
-```js
-export default {
-  render () {}
-}
-```
-
-```js
+<eslint-code-block :rules="{'vue/require-render-return': ['error']}">
+```vue
+<script>
 export default {
   render (h) {
     if (foo) {
@@ -22,17 +18,23 @@ export default {
     }
   }
 }
+</script>
 ```
+</eslint-code-block>
 
 :+1: Examples of **correct** code for this rule:
 
-```js
+<eslint-code-block :rules="{'vue/require-render-return': ['error']}">
+```vue
+<script>
 export default {
   render (h) {
     return h('div', 'hello')
   }
 }
+</script>
 ```
+</eslint-code-block>
 
 ## :wrench: Options
 

--- a/docs/rules/require-render-return.md
+++ b/docs/rules/require-render-return.md
@@ -40,6 +40,10 @@ export default {
 
 Nothing.
 
+## :books: Further reading
+
+- [Guide - Render Functions & JSX](https://vuejs.org/v2/guide/render-function.html)
+
 ## :mag: Implementation
 
 - [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/require-render-return.js)

--- a/docs/rules/require-render-return.md
+++ b/docs/rules/require-render-return.md
@@ -6,30 +6,28 @@
 
 This rule aims to enforce render function to always return value
 
-:-1: Examples of **incorrect** code for this rule:
-
 <eslint-code-block :rules="{'vue/require-render-return': ['error']}">
 ```vue
 <script>
 export default {
+  /* ✓ GOOD */
   render (h) {
-    if (foo) {
-      return h('div', 'hello')
-    }
+    return h('div', 'hello')
   }
 }
 </script>
 ```
 </eslint-code-block>
 
-:+1: Examples of **correct** code for this rule:
-
 <eslint-code-block :rules="{'vue/require-render-return': ['error']}">
 ```vue
 <script>
 export default {
+  /* ✗ BAD */
   render (h) {
-    return h('div', 'hello')
+    if (foo) {
+      return h('div', 'hello')
+    }
   }
 }
 </script>

--- a/docs/rules/require-v-for-key.md
+++ b/docs/rules/require-v-for-key.md
@@ -12,20 +12,19 @@ This rule reports the elements which have `v-for` and do not have `v-bind:key`.
 This rule does not report custom components.
 It will be reported by [valid-v-for] rule.
 
-:-1: Examples of **incorrect** code for this rule:
-
-```html
-<div v-for="todo in todos"/>
+<eslint-code-block :rules="{'vue/require-v-for-key': ['error']}">
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <div
+    v-for="todo in todos"
+    :key="todo.id"
+  />
+  <!-- ✗ BAD -->
+  <div v-for="todo in todos"/>
+</template>
 ```
-
-:+1: Examples of **correct** code for this rule:
-
-```html
-<div
-  v-for="todo in todos"
-  :key="todo.id"
-/>
-```
+</eslint-code-block>
 
 ## :wrench: Options
 

--- a/docs/rules/require-v-for-key.md
+++ b/docs/rules/require-v-for-key.md
@@ -2,15 +2,9 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-When `v-for` is written on custom components, it requires `v-bind:key` at the same time.
-On other elements, it's better that `v-bind:key` is written as well.
-
 ## :book: Rule Details
 
-This rule reports the elements which have `v-for` and do not have `v-bind:key`.
-
-This rule does not report custom components.
-It will be reported by [valid-v-for] rule.
+This rule reports the elements which have `v-for` and do not have `v-bind:key` with exception to custom components.
 
 <eslint-code-block :rules="{'vue/require-v-for-key': ['error']}">
 ```vue
@@ -25,6 +19,11 @@ It will be reported by [valid-v-for] rule.
 </template>
 ```
 </eslint-code-block>
+
+::: warning Note
+This rule does not report missing `v-bind:key` on custom components.
+It will be reported by [valid-v-for](./valid-v-for.md) rule.
+:::
 
 ## :wrench: Options
 

--- a/docs/rules/require-v-for-key.md
+++ b/docs/rules/require-v-for-key.md
@@ -34,7 +34,7 @@ Nothing.
 
 - [valid-v-for](./valid-v-for.md)
 
-## Related links
+## :books: Further reading
 
 - [Style guide - Keyed v-for](https://vuejs.org/v2/style-guide/#Keyed-v-for-essential)
 - [Guide - v-for with a Component](https://vuejs.org/v2/guide/list.html#v-for-with-a-Component)

--- a/docs/rules/require-valid-default-prop.md
+++ b/docs/rules/require-valid-default-prop.md
@@ -65,7 +65,7 @@ export default {
 
 Nothing.
 
-## Related links
+## :books: Further reading
 
 - [Guide - Prop Validation](https://vuejs.org/v2/guide/components-props.html#Prop-Validation)
 

--- a/docs/rules/require-valid-default-prop.md
+++ b/docs/rules/require-valid-default-prop.md
@@ -2,65 +2,64 @@
 
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 
-This rule checks whether the default value of each prop is valid for the given type. It should report an error when default value for type `Array` or `Object` is not returned using function.
-
 ## :book: Rule Details
 
-:-1: Examples of **incorrect** code for this rule:
+This rule checks whether the default value of each prop is valid for the given type. It should report an error when default value for type `Array` or `Object` is not returned using function.
 
-```js
-props: {
-  propA: {
-    type: String,
-    default: {}
-  },
-  propB: {
-    type: String,
-    default: []
-  },
-  propC: {
-    type: Object,
-    default: []
-  },
-  propD: {
-    type: Array,
-    default: []
-  },
-  propE: {
-    type: Object,
-    default: { message: 'hello' }
+<eslint-code-block :rules="{'vue/require-valid-default-prop': ['error']}">
+```vue
+<script>
+export default {
+  props: {
+    /* ✓ GOOD */
+    // basic type check (`null` means accept any type)
+    propA: Number,
+    // multiple possible types
+    propB: [String, Number],
+    // a number with default value
+    propD: {
+      type: Number,
+      default: 100
+    },
+    // object/array defaults should be returned from a factory function
+    propE: {
+      type: Object,
+      default() {
+        return { message: 'hello' }
+      }
+    },
+    propF: {
+      type: Array,
+      default() {
+        return []
+      }
+    },
+    /* ✗ BAD */
+    propA: {
+      type: String,
+      default: {}
+    },
+    propB: {
+      type: String,
+      default: []
+    },
+    propC: {
+      type: Object,
+      default: []
+    },
+    propD: {
+      type: Array,
+      default: []
+    },
+    propE: {
+      type: Object,
+      default: { message: 'hello' }
+    }
   }
 }
+</script>
 ```
-
-:+1: Examples of **correct** code for this rule:
-
-```js
-props: {
-  // basic type check (`null` means accept any type)
-  propA: Number,
-  // multiple possible types
-  propB: [String, Number],
-  // a number with default value
-  propD: {
-    type: Number,
-    default: 100
-  },
-  // object/array defaults should be returned from a factory function
-  propE: {
-    type: Object,
-    default() {
-      return { message: 'hello' }
-    }
-  },
-  propF: {
-    type: Array,
-    default() {
-      return []
-    }
-  }  
-}
-```
+</eslint-code-block>
 
 ## :wrench: Options
 

--- a/docs/rules/return-in-computed-property.md
+++ b/docs/rules/return-in-computed-property.md
@@ -8,29 +8,34 @@ This rule enforces that a `return` statement is present in `computed` properties
 
 :-1: Examples of **incorrect** code for this rule:
 
-```js
+<eslint-code-block :rules="{'vue/return-in-computed-property': ['error']}">
+```vue
+<script>
 export default {
   computed: {
-    foo () {},
-    bar: function () {}
-  }
-}
-```
-
-:+1: Examples of **correct** code for this rule:
-
-```js
-export default {
-  computed: {
+    /* ✓ GOOD */
     foo () {
-      return true
+      if (this.bar) {
+        return this.baz
+      } else {
+        return this.baf
+      }
     },
     bar: function () {
       return false
-    }
+    },
+    /* ✗ BAD */
+    baz () {
+      if (this.baf) {
+        return this.baf
+      }
+    },
+    baf: function () {}
   }
 }
+</script>
 ```
+</eslint-code-block>
 
 ## :wrench: Options
 

--- a/docs/rules/return-in-computed-property.md
+++ b/docs/rules/return-in-computed-property.md
@@ -6,8 +6,6 @@
 
 This rule enforces that a `return` statement is present in `computed` properties.
 
-:-1: Examples of **incorrect** code for this rule:
-
 <eslint-code-block :rules="{'vue/return-in-computed-property': ['error']}">
 ```vue
 <script>

--- a/docs/rules/return-in-computed-property.md
+++ b/docs/rules/return-in-computed-property.md
@@ -37,9 +37,6 @@ export default {
 
 ## :wrench: Options
 
-This rule has an object option:
-- `"treatUndefinedAsUnspecified"`: `true` (default) disallows implicitly returning undefined with a `return;` statement.
-
 ```json
 {
   "vue/return-in-computed-property": [2, {
@@ -47,6 +44,40 @@ This rule has an object option:
   }]
 }
 ```
+
+This rule has an object option:
+- `"treatUndefinedAsUnspecified"`: `true` (default) disallows implicitly returning undefined with a `return` statement.
+
+### `treatUndefinedAsUnspecified: false`
+
+<eslint-code-block :rules="{'vue/return-in-computed-property': ['error', { treatUndefinedAsUnspecified: false }]}">
+```vue
+<script>
+export default {
+  computed: {
+    /* ✓ GOOD */
+    foo () {
+      if (this.bar) {
+        return undefined
+      } else {
+        return
+      }
+    },
+    bar: function () {
+      return
+    },
+    /* ✗ BAD */
+    baz () {
+      if (this.baf) {
+        return this.baf
+      }
+    },
+    baf: function () {}
+  }
+}
+</script>
+```
+</eslint-code-block>
 
 ## :mag: Implementation
 

--- a/docs/rules/script-indent.md
+++ b/docs/rules/script-indent.md
@@ -2,7 +2,7 @@
 
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-## Rule Details
+## :book: Rule Details
 
 This rule is similar to core [indent](https://eslint.org/docs/rules/indent) rule, but it has an option for inside of `<script>` tag.
 
@@ -100,7 +100,7 @@ This rule only checks `.vue` files and does not interfere with other `.js` files
 ```
 </eslint-code-block>
 
-## Related rules
+## :couple: Related rules
 
 - [indent](https://eslint.org/docs/rules/indent)
 - [vue/html-indent](./html-indent.md)

--- a/docs/rules/script-indent.md
+++ b/docs/rules/script-indent.md
@@ -6,7 +6,7 @@
 
 This rule is similar to core [indent](https://eslint.org/docs/rules/indent) rule, but it has an option for inside of `<script>` tag.
 
-<eslint-code-block :rules="{'vue/script-indent': ['error']}">
+<eslint-code-block fix :rules="{'vue/script-indent': ['error']}">
 ```vue
 <script>
 let a = {
@@ -73,7 +73,7 @@ This rule only checks `.vue` files and does not interfere with other `.js` files
 ```
 
 ### `2, "baseIndent": 1`
-<eslint-code-block :rules="{'vue/script-indent': ['error', 2, { 'baseIndent': 1 }]}">
+<eslint-code-block fix :rules="{'vue/script-indent': ['error', 2, { 'baseIndent': 1 }]}">
 ```vue
 <script>
   let a = {

--- a/docs/rules/singleline-html-element-content-newline.md
+++ b/docs/rules/singleline-html-element-content-newline.md
@@ -8,7 +8,7 @@ This rule enforces a line break before and after the contents of a singleline el
 
 
 <eslint-code-block :rules="{'vue/singleline-html-element-content-newline': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div attr>
@@ -58,7 +58,7 @@ This rule enforces a line break before and after the contents of a singleline el
 ### `"ignoreWhenNoAttributes": true`
 
 <eslint-code-block :rules="{'vue/singleline-html-element-content-newline': ['error', {'ignoreWhenNoAttributes': true}]}">
-```html
+```vue
 <template>
   <!-- ✗ BAD -->
   <div attr>content</div>
@@ -73,7 +73,7 @@ This rule enforces a line break before and after the contents of a singleline el
 ### `"ignoreWhenNoAttributes": false`
 
 <eslint-code-block :rules="{'vue/singleline-html-element-content-newline': ['error', {'ignoreWhenNoAttributes': false}]}">
-```html
+```vue
 <template>
   <!-- ✗ BAD -->
   <div>content</div>

--- a/docs/rules/singleline-html-element-content-newline.md
+++ b/docs/rules/singleline-html-element-content-newline.md
@@ -7,7 +7,7 @@
 This rule enforces a line break before and after the contents of a singleline element.
 
 
-<eslint-code-block :rules="{'vue/singleline-html-element-content-newline': ['error']}">
+<eslint-code-block fix :rules="{'vue/singleline-html-element-content-newline': ['error']}">
 ```vue
 <template>
   <!-- ✓ GOOD -->
@@ -57,7 +57,7 @@ This rule enforces a line break before and after the contents of a singleline el
 
 ### `"ignoreWhenNoAttributes": true`
 
-<eslint-code-block :rules="{'vue/singleline-html-element-content-newline': ['error', {'ignoreWhenNoAttributes': true}]}">
+<eslint-code-block fix :rules="{'vue/singleline-html-element-content-newline': ['error', {'ignoreWhenNoAttributes': true}]}">
 ```vue
 <template>
   <!-- ✗ BAD -->
@@ -72,7 +72,7 @@ This rule enforces a line break before and after the contents of a singleline el
 
 ### `"ignoreWhenNoAttributes": false`
 
-<eslint-code-block :rules="{'vue/singleline-html-element-content-newline': ['error', {'ignoreWhenNoAttributes': false}]}">
+<eslint-code-block fix :rules="{'vue/singleline-html-element-content-newline': ['error', {'ignoreWhenNoAttributes': false}]}">
 ```vue
 <template>
   <!-- ✗ BAD -->

--- a/docs/rules/this-in-template.md
+++ b/docs/rules/this-in-template.md
@@ -4,67 +4,49 @@
 
 ## :book: Rule Details
 
-:-1: Examples of **incorrect** code for this rule:
-
-```html
-<a :href="this.url">
-  {{ this.text }}
-</a>
+<eslint-code-block :rules="{'vue/this-in-template': ['error']}">
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <a :href="url">
+    {{ text }}
+  </a>
+  
+  <!-- ✗ BAD -->
+  <a :href="this.url">
+    {{ this.text }}
+  </a>
+</template>
 ```
-
-:+1: Examples of **correct** code for this rule:
-
-```html
-<a :href="url">
-  {{ text }}
-</a>
-```
+</eslint-code-block>
 
 ## :wrench: Options
-
-Default is set to `never`.
 
 ```json
 {
   "vue/this-in-template": [2, "always" | "never"]
 }
 ```
+- `"always"` ... Always use `this` while accessing properties from Vue.
+- `"never"` (default) ... Never use `this` keyword in expressions.
 
-### `"always"` - Always use `this` while accessing properties from Vue
+### `"always"`
 
-:-1: Examples of **incorrect** code:
-
-```html
-<a :href="url">
-  {{ text }}
-</a>
+<eslint-code-block :rules="{'vue/this-in-template': ['error', 'always']}">
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <a :href="this.url">
+    {{ this.text }}
+  </a>
+  
+  <!-- ✗ BAD -->
+  <a :href="url">
+    {{ text }}
+  </a>
+</template>
 ```
-
-:+1: Examples of **correct** code`:
-
-```html
-<a :href="this.url">
-  {{ this.text }}
-</a>
-```
-
-### `"never"` - Never use `this` keyword in expressions
-
-:-1: Examples of **incorrect** code:
-
-```html
-<a :href="this.url">
-  {{ this.text }}
-</a>
-```
-
-:+1: Examples of **correct** code:
-
-```html
-<a :href="url">
-  {{ text }}
-</a>
-```
+</eslint-code-block>
 
 ## :mag: Implementation
 

--- a/docs/rules/this-in-template.md
+++ b/docs/rules/this-in-template.md
@@ -24,8 +24,11 @@
 
 Default is set to `never`.
 
-```
-'vue/this-in-template': [2, 'always'|'never']
+```json
+{
+  "vue/this-in-template": [2, "always" | "never"]
+}
+
 ```
 
 ### `"always"` - Always use `this` while accessing properties from Vue

--- a/docs/rules/this-in-template.md
+++ b/docs/rules/this-in-template.md
@@ -28,7 +28,6 @@ Default is set to `never`.
 {
   "vue/this-in-template": [2, "always" | "never"]
 }
-
 ```
 
 ### `"always"` - Always use `this` while accessing properties from Vue

--- a/docs/rules/use-v-on-exact.md
+++ b/docs/rules/use-v-on-exact.md
@@ -30,6 +30,10 @@ This rule enforce usage of `exact` modifier on `v-on` when there is another `v-o
 - [vue/v-on-style](./v-on-style.md)
 - [vue/valid-v-on](./valid-v-on.md)
 
+## :books: Further reading
+
+- [Guide - .exact Modifier](https://vuejs.org/v2/guide/events.html#exact-Modifier)
+
 ## :mag: Implementation
 
 - [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/use-v-on-exact.js)

--- a/docs/rules/use-v-on-exact.md
+++ b/docs/rules/use-v-on-exact.md
@@ -25,7 +25,7 @@ This rule enforce usage of `exact` modifier on `v-on` when there is another `v-o
 }
 ```
 
-## Related rules
+## :couple: Related rules
 
 - [vue/v-on-style](./v-on-style.md)
 - [vue/valid-v-on](./valid-v-on.md)

--- a/docs/rules/use-v-on-exact.md
+++ b/docs/rules/use-v-on-exact.md
@@ -5,7 +5,7 @@
 This rule enforce usage of `exact` modifier on `v-on` when there is another `v-on` with modifier.
 
 <eslint-code-block :rules="{'vue/use-v-on-exact': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <button @click="foo" :click="foo"></button>

--- a/docs/rules/v-bind-style.md
+++ b/docs/rules/v-bind-style.md
@@ -7,7 +7,7 @@
 
 This rule enforces `v-bind` directive style which you should use shorthand or long form.
 
-<eslint-code-block :rules="{'vue/v-bind-style': ['error']}">
+<eslint-code-block fix :rules="{'vue/v-bind-style': ['error']}">
 ```vue
 <template>
   <!-- ✓ GOOD -->
@@ -33,7 +33,7 @@ Default is set to `shorthand`.
 
 ### `"longform"`
 
-<eslint-code-block :rules="{'vue/v-bind-style': ['error', 'longform']}">
+<eslint-code-block fix :rules="{'vue/v-bind-style': ['error', 'longform']}">
 ```vue
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/v-bind-style.md
+++ b/docs/rules/v-bind-style.md
@@ -32,6 +32,13 @@ This rule enforces `v-bind` directive style which you should use shorthand or lo
 ```
 
 ## :wrench: Options
+Default is set to `shorthand`.
+
+```json
+{
+  "vue/v-bind-style": [2, "shorthand" | "longform"]
+}
+```
 
 - `"shorthand"` (default) ... requires using shorthand.
 - `"longform"` ... requires using long form.

--- a/docs/rules/v-bind-style.md
+++ b/docs/rules/v-bind-style.md
@@ -3,33 +3,21 @@
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-This rule enforces `v-bind` directive style which you should use shorthand or long form.
-
 ## :book: Rule Details
 
-:-1: Examples of **incorrect** code for this rule:
+This rule enforces `v-bind` directive style which you should use shorthand or long form.
 
+<eslint-code-block :rules="{'vue/v-bind-style': ['error']}">
 ```html
-<div v-bind:foo="bar"/>
+<template>
+  <!-- ✓ GOOD -->
+  <div :foo="bar"/>
+
+  <!-- ✗ BAD -->
+  <div v-bind:foo="bar"/>
+</template>
 ```
-
-:+1: Examples of **correct** code for this rule:
-
-```html
-<div :foo="bar"/>
-```
-
-:-1: Examples of **incorrect** code for this rule with `"longform"` option:
-
-```html
-<div :foo="bar"/>
-```
-
-:+1: Examples of **correct** code for this rule with `"longform"` option:
-
-```html
-<div v-bind:foo="bar"/>
-```
+</eslint-code-block>
 
 ## :wrench: Options
 Default is set to `shorthand`.
@@ -42,6 +30,21 @@ Default is set to `shorthand`.
 
 - `"shorthand"` (default) ... requires using shorthand.
 - `"longform"` ... requires using long form.
+
+### `"longform"`
+
+<eslint-code-block :rules="{'vue/v-bind-style': ['error', 'longform']}">
+```html
+<template>
+  <!-- ✓ GOOD -->
+  <div v-bind:foo="bar"/>
+
+  <!-- ✗ BAD -->
+  <div :foo="bar"/>
+</template>
+```
+</eslint-code-block>
+
 
 ## Related links
 

--- a/docs/rules/v-bind-style.md
+++ b/docs/rules/v-bind-style.md
@@ -45,8 +45,7 @@ Default is set to `shorthand`.
 ```
 </eslint-code-block>
 
-
-## Related links
+## :books: Further reading
 
 - [Style guide - Directive shorthands](https://vuejs.org/v2/style-guide/#Directive-shorthands-strongly-recommended)
 

--- a/docs/rules/v-bind-style.md
+++ b/docs/rules/v-bind-style.md
@@ -8,7 +8,7 @@
 This rule enforces `v-bind` directive style which you should use shorthand or long form.
 
 <eslint-code-block :rules="{'vue/v-bind-style': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div :foo="bar"/>
@@ -34,7 +34,7 @@ Default is set to `shorthand`.
 ### `"longform"`
 
 <eslint-code-block :rules="{'vue/v-bind-style': ['error', 'longform']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-bind:foo="bar"/>

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -32,6 +32,13 @@ This rule enforces `v-on` directive style which you should use shorthand or long
 ```
 
 ## :wrench: Options
+Default is set to `shorthand`.
+
+```json
+{
+  "vue/v-on-style": [2, "shorthand" | "longform"]
+}
+```
 
 - `"shorthand"` (default) ... requires using shorthand.
 - `"longform"` ... requires using long form.

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -3,7 +3,6 @@
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-
 ## :book: Rule Details
 
 This rule enforces `v-on` directive style which you should use shorthand or long form.

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -7,7 +7,7 @@
 
 This rule enforces `v-on` directive style which you should use shorthand or long form.
 
-<eslint-code-block :rules="{'vue/v-on-style': ['error']}">
+<eslint-code-block fix :rules="{'vue/v-on-style': ['error']}">
 ```vue
 <template>
   <!-- ✓ GOOD -->
@@ -33,7 +33,7 @@ Default is set to `shorthand`.
 
 ### `"longform"`
 
-<eslint-code-block :rules="{'vue/v-on-style': ['error', 'longform']}">
+<eslint-code-block fix :rules="{'vue/v-on-style': ['error', 'longform']}">
 ```vue
 <template>
   <!-- ✓ GOOD -->

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -3,33 +3,22 @@
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-This rule enforces `v-on` directive style which you should use shorthand or long form.
 
 ## :book: Rule Details
 
-:-1: Examples of **incorrect** code for this rule:
+This rule enforces `v-on` directive style which you should use shorthand or long form.
 
+<eslint-code-block :rules="{'vue/v-on-style': ['error']}">
 ```html
-<div v-on:click="foo"/>
+<template>
+  <!-- ✓ GOOD -->
+  <div @click="foo"/>
+
+  <!-- ✗ BAD -->
+  <div v-on:click="foo"/>
+</template>
 ```
-
-:+1: Examples of **correct** code for this rule:
-
-```html
-<div @click="foo"/>
-```
-
-:-1: Examples of **incorrect** code for this rule with `"longform"` option:
-
-```html
-<div @click="foo"/>
-```
-
-:+1: Examples of **correct** code for this rule with `"longform"` option:
-
-```html
-<div v-on:click="foo"/>
-```
+</eslint-code-block>
 
 ## :wrench: Options
 Default is set to `shorthand`.
@@ -42,6 +31,21 @@ Default is set to `shorthand`.
 
 - `"shorthand"` (default) ... requires using shorthand.
 - `"longform"` ... requires using long form.
+
+### `"longform"`
+
+<eslint-code-block :rules="{'vue/v-on-style': ['error', 'longform']}">
+```html
+<template>
+  <!-- ✓ GOOD -->
+  <div v-on:click="foo"/>
+
+  <!-- ✗ BAD -->
+  <div @click="foo"/>
+</template>
+```
+</eslint-code-block>
+
 
 ## Related links
 

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -46,8 +46,7 @@ Default is set to `shorthand`.
 ```
 </eslint-code-block>
 
-
-## Related links
+## :books: Further reading
 
 - [Style guide - Directive shorthands](https://vuejs.org/v2/style-guide/#Directive-shorthands-strongly-recommended)
 

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -9,7 +9,7 @@
 This rule enforces `v-on` directive style which you should use shorthand or long form.
 
 <eslint-code-block :rules="{'vue/v-on-style': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div @click="foo"/>
@@ -35,7 +35,7 @@ Default is set to `shorthand`.
 ### `"longform"`
 
 <eslint-code-block :rules="{'vue/v-on-style': ['error', 'longform']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-on:click="foo"/>

--- a/docs/rules/valid-v-bind.md
+++ b/docs/rules/valid-v-bind.md
@@ -16,7 +16,7 @@ This rule does not report `v-bind` directives which do not have their argument (
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
 <eslint-code-block :rules="{'vue/valid-v-bind': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-bind="foo"/>

--- a/docs/rules/valid-v-cloak.md
+++ b/docs/rules/valid-v-cloak.md
@@ -13,7 +13,7 @@ This rule reports `v-cloak` directives in the following cases:
 - The directive has that attribute value. E.g. `<div v-cloak="ccc"></div>`
 
 <eslint-code-block :rules="{'vue/valid-v-cloak': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-cloak/>

--- a/docs/rules/valid-v-else-if.md
+++ b/docs/rules/valid-v-else-if.md
@@ -14,8 +14,6 @@ This rule reports `v-else-if` directives in the following cases:
 - The directive is on the elements that the previous element don't have `v-if`/`v-else-if` directives. E.g. `<div v-else-if="bar"></div>`
 - The directive is on the elements which have `v-if`/`v-else` directives. E.g. `<div v-if="foo" v-else-if="bar"></div>`
 
-This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
-
 <eslint-code-block :rules="{'vue/valid-v-else-if': ['error']}">
 ```vue
 <template>
@@ -31,6 +29,10 @@ This rule does not check syntax errors in directives because it's checked by [no
 ```
 </eslint-code-block>
 
+::: warning Note
+This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
+:::
+
 ## :wrench: Options
 
 Nothing.
@@ -42,9 +44,9 @@ Nothing.
 - [no-parsing-error]
 
 
-[valid-v-if]:   valid-v-if.md
+[valid-v-if]: valid-v-if.md
 [valid-v-else]: valid-v-else.md
-[no-parsing-error]:   no-parsing-error.md
+[no-parsing-error]: no-parsing-error.md
 
 ## :mag: Implementation
 

--- a/docs/rules/valid-v-else-if.md
+++ b/docs/rules/valid-v-else-if.md
@@ -17,7 +17,7 @@ This rule reports `v-else-if` directives in the following cases:
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
 <eslint-code-block :rules="{'vue/valid-v-else-if': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-if="foo"/>

--- a/docs/rules/valid-v-else.md
+++ b/docs/rules/valid-v-else.md
@@ -15,7 +15,7 @@ This rule reports `v-else` directives in the following cases:
 - The directive is on the elements which have `v-if`/`v-if-else` directives. E.g. `<div v-if="foo" v-else></div>`
 
 <eslint-code-block :rules="{'vue/valid-v-else': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-if="foo"/>

--- a/docs/rules/valid-v-for.md
+++ b/docs/rules/valid-v-for.md
@@ -23,7 +23,7 @@ The following cases are syntax errors:
 - The alias is not LHS. E.g. `<div v-for="foo() in list"></div>`
 
 <eslint-code-block :rules="{'vue/valid-v-for': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-for="todo in todos"/>

--- a/docs/rules/valid-v-for.md
+++ b/docs/rules/valid-v-for.md
@@ -14,13 +14,7 @@ This rule reports `v-for` directives in the following cases:
 - If the element which has the directive is a custom component, the component does not have `v-bind:key` directive. E.g. `<your-component v-for="item in list"></your-component>`
 - The `v-bind:key` directive does not use the variables which are defined by the `v-for` directive. E.g. `<div v-for="x in list" :key="foo"></div>`
 
-If the element which has the directive is a reserved element, this rule does not report even if the element does not have `v-bind:key` directive because it's not fatal error. [require-v-for-key] rule reports it.
-
-This rule does not check syntax errors in directives. [no-parsing-error] rule reports it.
-The following cases are syntax errors:
-
-- The directive's value is not the form `alias in expr`. E.g. `<div v-for="foo"></div>`
-- The alias is not LHS. E.g. `<div v-for="foo() in list"></div>`
+If the element which has the directive is a reserved element, this rule does not report it even if the element does not have `v-bind:key` directive because it's not fatal error. [require-v-for-key] rule reports it.
 
 <eslint-code-block :rules="{'vue/valid-v-for': ['error']}">
 ```vue
@@ -53,6 +47,14 @@ The following cases are syntax errors:
 </template>
 ```
 </eslint-code-block>
+
+::: warning Note
+This rule does not check syntax errors in directives. [no-parsing-error] rule reports it.
+The following cases are syntax errors:
+
+- The directive's value isn't `alias in expr`. E.g. `<div v-for="foo"></div>`
+- The alias isn't LHS. E.g. `<div v-for="foo() in list"></div>`
+:::
 
 ## :wrench: Options
 

--- a/docs/rules/valid-v-html.md
+++ b/docs/rules/valid-v-html.md
@@ -15,7 +15,7 @@ This rule reports `v-html` directives in the following cases:
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
 <eslint-code-block :rules="{'vue/valid-v-html': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-html="foo"/>

--- a/docs/rules/valid-v-if.md
+++ b/docs/rules/valid-v-if.md
@@ -16,7 +16,7 @@ This rule reports `v-if` directives in the following cases:
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
 <eslint-code-block :rules="{'vue/valid-v-if': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-if="foo"/>

--- a/docs/rules/valid-v-model.md
+++ b/docs/rules/valid-v-model.md
@@ -19,7 +19,7 @@ This rule reports `v-model` directives in the following cases:
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
 <eslint-code-block :rules="{'vue/valid-v-model': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <input v-model="foo">

--- a/docs/rules/valid-v-on.md
+++ b/docs/rules/valid-v-on.md
@@ -36,24 +36,28 @@ This rule does not check syntax errors in directives because it's checked by [no
 
 ## :wrench: Options
 
+```json
+{
+  "vue/prop-name-casing": ["error", {
+    "modifiers": []
+  }]
+}
+```
+
 This rule has an object option:
 
-`"modifiers"`: [] (default) array of additional allowed modifiers.
+`"modifiers"` array of additional allowed modifiers.
 
-### Example:
+### `"modifiers": ["foo"]`
 
-```json
-"vue/valid-v-on": [2, {
-  modifiers: ['foo']
-}]
-```
-
-:+1: Examples of **correct** code for this rule:
-
+<eslint-code-block :rules="{'vue/valid-v-on': ['error', { modifiers: ['foo']}]}">
 ```html
-<div @click.foo="foo"/>
-<div v-on:click.foo="foo"/>
+<template>
+  <div @click.foo="foo"/>
+  <div v-on:click.foo="foo"/>
+</template>
 ```
+</eslint-code-block>
 
 ## :couple: Related rules
 

--- a/docs/rules/valid-v-on.md
+++ b/docs/rules/valid-v-on.md
@@ -15,7 +15,7 @@ This rule reports `v-on` directives in the following cases:
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
 <eslint-code-block :rules="{'vue/valid-v-on': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-on="foo"/>
@@ -51,7 +51,7 @@ This rule has an object option:
 ### `"modifiers": ["foo"]`
 
 <eslint-code-block :rules="{'vue/valid-v-on': ['error', { modifiers: ['foo']}]}">
-```html
+```vue
 <template>
   <div @click.foo="foo"/>
   <div v-on:click.foo="foo"/>

--- a/docs/rules/valid-v-once.md
+++ b/docs/rules/valid-v-once.md
@@ -13,7 +13,7 @@ This rule reports `v-once` directives in the following cases:
 - The directive has that attribute value. E.g. `<div v-once="ccc"></div>`
 
 <eslint-code-block :rules="{'vue/valid-v-once': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-once/>

--- a/docs/rules/valid-v-pre.md
+++ b/docs/rules/valid-v-pre.md
@@ -13,7 +13,7 @@ This rule reports `v-pre` directives in the following cases:
 - The directive has that attribute value. E.g. `<div v-pre="ccc"></div>`
 
 <eslint-code-block :rules="{'vue/valid-v-pre': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-pre/>

--- a/docs/rules/valid-v-show.md
+++ b/docs/rules/valid-v-show.md
@@ -16,7 +16,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 
 
 <eslint-code-block :rules="{'vue/valid-v-show': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-show="foo"/>

--- a/docs/rules/valid-v-text.md
+++ b/docs/rules/valid-v-text.md
@@ -15,7 +15,7 @@ This rule reports `v-text` directives in the following cases:
 This rule does not check syntax errors in directives because it's checked by [no-parsing-error] rule.
 
 <eslint-code-block :rules="{'vue/valid-v-text': ['error']}">
-```html
+```vue
 <template>
   <!-- ✓ GOOD -->
   <div v-text="foo"/>

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -7,6 +7,9 @@ Use [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/) to install.
 ```bash
 npm install --save-dev eslint eslint-plugin-vue@next
 ```
+```bash
+yarn add eslint eslint-plugin-vue@next --dev
+```
 
 ::: tip Requirements
 - ESLint v5.0.0 or later

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -80,6 +80,37 @@ Example **.vscode/settings.json**:
 }
 ```
 
+If you use `Vetur` plugin, set `"vetur.validation.template": false` to avoid default Vetur template validation. Check out [vetur documentation](https://vuejs.github.io/vetur/linting-error.html) for more info.
+
+#### Sublime Text
+
+Use [SublimeLinter-eslint](https://github.com/SublimeLinter/SublimeLinter-eslint) extension that SublimeLinter provides for eslint.
+
+You have to open command-palette via `cmd/ctrl+shift+p` and type `Preferences: SublimeLinter Settings`, paste to the config on the right side:
+
+```json
+{
+  "linters": {
+    "eslint": {
+      "selector": "text.html.vue, source.js - meta.attribute-with-value"
+    }
+  }
+}
+```
+
+#### Atom editor
+
+You need to go into `Settings -> Packages -> linter-eslint`, under the option "List of scopes to run eslint on", add `text.html.vue`. You may need to restart Atom.
+
+#### IntelliJ IDEA / JetBrains WebStorm
+
+In the **Settings/Preferences** dialog (`Ctrl+Alt+S`), choose JavaScript under **Languages and Frameworks** and then choose **ESLint** under **Code Quality Tools**.
+On the **ESLint page** that opens, select the *Enable* checkbox.
+
+If your ESLint configuration is updated (manually or from your version control), open it in the editor and choose **Apply ESLint Code Style Rules** on the context menu.
+
+read more: [JetBrains - ESLint](https://www.jetbrains.com/help/idea/eslint.html)
+
 ### The code of components
 
 All component-related rules are being applied to code that passes any of the following checks:
@@ -155,29 +186,17 @@ See also: "[Use together with custom parsers](#use-together-with-custom-parsers)
 
 1. Make sure you don't have `eslint-plugin-html` in your config. The `eslint-plugin-html` extracts the content from `<script>` tags, but `eslint-plugin-vue` requires `<script>` tags and `<template>` tags in order to distinguish template and script in single file components.
 
-    ```diff
-      "plugins": [
-        "vue",
-    -   "html"
-      ]
-    ```
+  ```diff
+    "plugins": [
+      "vue",
+  -   "html"
+    ]
+  ```
 
 2. Make sure your tool is set to lint `.vue` files.
-    - CLI targets only `.js` files by default. You have to specify additional extensions by `--ext` option or glob patterns. E.g. `eslint "src/**/*.{js,vue}"` or `eslint src --ext .vue`. If you use `@vue/cli-plugin-eslint` and the `vue-cli-service lint` command - you don't have to worry about it.
-    - VSCode targets only JavaScript or HTML files by default. You have to add `"vue"` to the `"eslint.validate"` array in vscode settings. e.g. `"eslint.validate": [ "javascript", "javascriptreact", "vue" ]`
-    - If you use `Vetur` plugin in VSCode - set `"vetur.validation.template": false` to avoid default Vetur template validation. Check out [vetur documentation](https://github.com/vuejs/vetur/blob/master/docs/linting-error.md) for more info.
-    - For Atom editor, you need to go into Settings -> Packages -> linter-eslint, under the option “List of scopes to run eslint on”, add `text.html.vue`.
-    - For Sublime Text, you need to open command-pallete via cmd+shift+p (cmd => ctrl for windows) and type "Preferences: SublimeLinter Settings", paste to the config on the right side:
-      ```json
-      {
-        "linters": {
-          "eslint": {
-            "selector": "source.js, text.html.vue"
-          }
-        }
-      }
-      ```
- 
+  - CLI targets only `.js` files by default. You have to specify additional extensions by `--ext` option or glob patterns. E.g. `eslint "src/**/*.{js,vue}"` or `eslint src --ext .vue`. If you use `@vue/cli-plugin-eslint` and the `vue-cli-service lint` command - you don't have to worry about it.
+  - If you are having issues with configuring editor please read [editor integrations](#editor-integrations)
+
 ## 🚥 Versioning policy
 
 This plugin is following [Semantic Versioning](https://semver.org/) and [ESLint's Semantic Versioning Policy](https://github.com/eslint/eslint#semantic-versioning-policy).

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,6 +1,6 @@
 # User Guide
 
-## 💿 Installation
+## :cd: Installation
 
 Use [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/) to install.
 
@@ -13,7 +13,7 @@ npm install --save-dev eslint eslint-plugin-vue@next
 - Node.js v6.5.0 or later
 :::
 
-## 📖 Usage
+## :book: Usage
 
 ### Configuration
 
@@ -158,7 +158,7 @@ For example:
 
 If you want to disallow `eslint-disable` functionality in `<template>`, disable [vue/comment-directive](../rules/comment-directive.md) rule.
 
-## ❓ FAQ
+## :question: FAQ
 
 ### What is the "Use the latest vue-eslint-parser" error?
 
@@ -197,14 +197,14 @@ See also: "[Use together with custom parsers](#use-together-with-custom-parsers)
   - CLI targets only `.js` files by default. You have to specify additional extensions by `--ext` option or glob patterns. E.g. `eslint "src/**/*.{js,vue}"` or `eslint src --ext .vue`. If you use `@vue/cli-plugin-eslint` and the `vue-cli-service lint` command - you don't have to worry about it.
   - If you are having issues with configuring editor please read [editor integrations](#editor-integrations)
 
-## 🚥 Versioning policy
+## :traffic_light: Versioning policy
 
 This plugin is following [Semantic Versioning](https://semver.org/) and [ESLint's Semantic Versioning Policy](https://github.com/eslint/eslint#semantic-versioning-policy).
 
-## 📰 Changelog
+## :newspaper: Changelog
 
 We are using [GitHub Releases](https://github.com/vuejs/eslint-plugin-vue/releases).
 
-## 🔒 License
+## :lock: License
 
 See the [LICENSE](https://github.com/vuejs/eslint-plugin-vue/blob/master/LICENSE) file for license rights and limitations (MIT).

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -117,7 +117,7 @@ You can use `<!-- eslint-disable -->`-like HTML comments in `<template>` of `.vu
 
 For example:
 
-```html
+```vue
 <template>
   <!-- eslint-disable-next-line vue/max-attributes-per-line -->
   <div a="1" b="2" c="3" d="4">

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -35,7 +35,7 @@ module.exports = {
 }
 ```
 
-See [the rule list](../README.md) to get the `extends` &amp; `rules` that this plugin provides.
+See [the rule list](../rules/README.md) to get the `extends` &amp; `rules` that this plugin provides.
 
 #### Use together with custom parsers
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "typescript": "^3.1.3",
     "typescript-eslint-parser": "^20.0.0",
     "vue-eslint-editor": "^0.1.0",
-    "vuepress": "^0.14.4"
+    "vuepress": "^0.14.5"
   }
 }

--- a/tools/update-docs.js
+++ b/tools/update-docs.js
@@ -54,10 +54,6 @@ class DocFile {
     const title = `# ${meta.docs.description} (${ruleId})`
     const notes = []
 
-    if (categoryIndex >= 0) {
-      const presets = categories.slice(categoryIndex).map(category => `\`"plugin:vue/${category.categoryId}"\``)
-      notes.push(`- :gear: This rule is included in ${formatItems(presets)}.`)
-    }
     if (meta.deprecated) {
       if (meta.docs.replacedBy) {
         const replacedRules = meta.docs.replacedBy.map(name => `[vue/${name}](${name}.md) rule`)
@@ -65,6 +61,9 @@ class DocFile {
       } else {
         notes.push(`- :warning: This rule was **deprecated**.`)
       }
+    } else if (categoryIndex >= 0) {
+      const presets = categories.slice(categoryIndex).map(category => `\`"plugin:vue/${category.categoryId}"\``)
+      notes.push(`- :gear: This rule is included in ${formatItems(presets)}.`)
     }
     if (meta.fixable) {
       notes.push(`- :wrench: The \`--fix\` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.`)

--- a/tools/update-docs.js
+++ b/tools/update-docs.js
@@ -86,6 +86,16 @@ class DocFile {
     return this
   }
 
+  updateCodeBlocks () {
+    const { meta } = this.rule
+
+    this.content = this.content.replace(
+      /<eslint-code-block\s(:?fix[^\s]*)?\s*/g,
+      `<eslint-code-block ${meta.fixable ? 'fix ' : ''}`
+    )
+    return this
+  }
+
   updateFooter () {
     const { name } = this.rule
     const footerPattern = /## :mag: Implementation.+$/s
@@ -109,5 +119,6 @@ for (const rule of rules) {
     .read(rule)
     .updateHeader()
     .updateFooter()
+    .updateCodeBlocks()
     .write()
 }

--- a/tools/update.js
+++ b/tools/update.js
@@ -8,4 +8,4 @@
 require('./update-lib-configs')
 require('./update-lib-index')
 require('./update-docs')
-require('./update-readme')
+require('./update-docs-rules-index')


### PR DESCRIPTION
Issues:
- `vue/comment-directive` is not supported: https://github.com/mysticatea/vue-eslint-editor/pull/1 PR
- `vue/multiline-html-element-content-newline` has issue with example: #663 PR
- `vue/return-in-computed-property` has issue with example: #655 PR
- `vue/require-render-return` has issue with example: #655 PR

Missing rule detail / description
- [ ] `vue/attribute-hyphenation` [link](https://armano2.github.io/eslint-plugin-vue/rules/attribute-hyphenation.html)
- [ ] `vue/this-in-template` [link](https://armano2.github.io/eslint-plugin-vue/rules/this-in-template.html)

demo: https://armano2.github.io/eslint-plugin-vue/