### PR TITLE
add instruction about the linter on contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ In order to add a new rule, you should:
 - Write test scenarios & implement logic
 - Describe the rule in the generated `docs` file
 - Make sure all tests are passing
+- Run `npm run lint` and fix any errors
 - Run `npm run update` in order to update readme and recommended configuration
 - Create PR and link created issue in description
 


### PR DESCRIPTION
After my first PR  (#668) the circle CI checks failed because of a linter error. I tried to follow the "Contributing Guide" section on the `README.md` closely but unfortunately this step was missing there.

This PR adds one bullet to the "Contributing Guide" list that suggest to run `npm run lint` and fix any errors.