### PR TITLE
Fix: make strict for flatten ternary expr (fixes #625)

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -984,12 +984,16 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
     },
 
     ConditionalExpression (node) {
+      const prevToken = tokenStore.getTokenBefore(node)
       const firstToken = tokenStore.getFirstToken(node)
       const questionToken = tokenStore.getTokenAfter(node.test, isNotRightParen)
       const consequentToken = tokenStore.getTokenAfter(questionToken)
       const colonToken = tokenStore.getTokenAfter(node.consequent, isNotRightParen)
       const alternateToken = tokenStore.getTokenAfter(colonToken)
-      const isFlat = (node.test.loc.end.line === node.consequent.loc.start.line)
+      const isFlat =
+        prevToken &&
+        prevToken.loc.end.line !== node.loc.start.line &&
+        node.test.loc.end.line === node.consequent.loc.start.line
 
       if (isFlat) {
         setOffset([questionToken, consequentToken, colonToken, alternateToken], 0, firstToken)

--- a/tests/fixtures/script-indent/issue625.vue
+++ b/tests/fixtures/script-indent/issue625.vue
@@ -1,0 +1,12 @@
+<!--{}-->
+<script>
+export default {
+  data() {
+    const hours = new Date().getHours();
+    return {
+      imgUrl: hours > 21 && hours < 6 ? 'night.png' :
+        'day.png',
+    };
+  },
+}
+</script>


### PR DESCRIPTION
This PR fixes #625.

The logic to implement indentation like [Conditional Types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#conditional-types) (a.k.a., flatten ternary expressions) did false positive.
I made stricter it.