### PR TITLE
Chore: update vue-eslint-parser to v4

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -14,7 +14,7 @@ const assert = require('assert')
 // Helpers
 // ------------------------------------------------------------------------------
 
-const KNOWN_NODES = new Set(['ArrayExpression', 'ArrayPattern', 'ArrowFunctionExpression', 'AssignmentExpression', 'AssignmentPattern', 'AwaitExpression', 'BinaryExpression', 'BlockStatement', 'BreakStatement', 'CallExpression', 'CatchClause', 'ClassBody', 'ClassDeclaration', 'ClassExpression', 'ConditionalExpression', 'ContinueStatement', 'DebuggerStatement', 'DoWhileStatement', 'EmptyStatement', 'ExperimentalRestProperty', 'ExperimentalSpreadProperty', 'ExportAllDeclaration', 'ExportDefaultDeclaration', 'ExportNamedDeclaration', 'ExportSpecifier', 'ExpressionStatement', 'ForInStatement', 'ForOfStatement', 'ForStatement', 'FunctionDeclaration', 'FunctionExpression', 'Identifier', 'IfStatement', 'ImportDeclaration', 'ImportDefaultSpecifier', 'ImportNamespaceSpecifier', 'ImportSpecifier', 'LabeledStatement', 'Literal', 'LogicalExpression', 'MemberExpression', 'MetaProperty', 'MethodDefinition', 'NewExpression', 'ObjectExpression', 'ObjectPattern', 'Program', 'Property', 'RestElement', 'ReturnStatement', 'SequenceExpression', 'SpreadElement', 'Super', 'SwitchCase', 'SwitchStatement', 'TaggedTemplateExpression', 'TemplateElement', 'TemplateLiteral', 'ThisExpression', 'ThrowStatement', 'TryStatement', 'UnaryExpression', 'UpdateExpression', 'VariableDeclaration', 'VariableDeclarator', 'WhileStatement', 'WithStatement', 'YieldExpression', 'VAttribute', 'VDirectiveKey', 'VDocumentFragment', 'VElement', 'VEndTag', 'VExpressionContainer', 'VForExpression', 'VIdentifier', 'VLiteral', 'VOnExpression', 'VSlotScopeExpression', 'VStartTag', 'VText'])
+const KNOWN_NODES = new Set(['ArrayExpression', 'ArrayPattern', 'ArrowFunctionExpression', 'AssignmentExpression', 'AssignmentPattern', 'AwaitExpression', 'BinaryExpression', 'BlockStatement', 'BreakStatement', 'CallExpression', 'CatchClause', 'ClassBody', 'ClassDeclaration', 'ClassExpression', 'ConditionalExpression', 'ContinueStatement', 'DebuggerStatement', 'DoWhileStatement', 'EmptyStatement', 'ExperimentalRestProperty', 'ExperimentalSpreadProperty', 'ExportAllDeclaration', 'ExportDefaultDeclaration', 'ExportNamedDeclaration', 'ExportSpecifier', 'ExpressionStatement', 'ForInStatement', 'ForOfStatement', 'ForStatement', 'FunctionDeclaration', 'FunctionExpression', 'Identifier', 'IfStatement', 'ImportDeclaration', 'ImportDefaultSpecifier', 'ImportNamespaceSpecifier', 'ImportSpecifier', 'LabeledStatement', 'Literal', 'LogicalExpression', 'MemberExpression', 'MetaProperty', 'MethodDefinition', 'NewExpression', 'ObjectExpression', 'ObjectPattern', 'Program', 'Property', 'RestElement', 'ReturnStatement', 'SequenceExpression', 'SpreadElement', 'Super', 'SwitchCase', 'SwitchStatement', 'TaggedTemplateExpression', 'TemplateElement', 'TemplateLiteral', 'ThisExpression', 'ThrowStatement', 'TryStatement', 'UnaryExpression', 'UpdateExpression', 'VariableDeclaration', 'VariableDeclarator', 'WhileStatement', 'WithStatement', 'YieldExpression', 'VAttribute', 'VDirectiveKey', 'VDocumentFragment', 'VElement', 'VEndTag', 'VExpressionContainer', 'VFilter', 'VFilterSequenceExpression', 'VForExpression', 'VIdentifier', 'VLiteral', 'VOnExpression', 'VSlotScopeExpression', 'VStartTag', 'VText'])
 const LT_CHAR = /[\r\n\u2028\u2029]/
 const LINES = /[^\r\n\u2028\u2029]+(?:$|\r\n|[\r\n\u2028\u2029])/g
 const BLOCK_COMMENT_PREFIX = /^\s*\*/
@@ -203,6 +203,15 @@ function isNotComment (token) {
  */
 function isNotEmptyTextNode (node) {
   return !(node.type === 'VText' && node.value.trim() === '')
+}
+
+/**
+ * Check whether the given token is a pipe operator.
+ * @param {Token} token The token to check.
+ * @returns {boolean} `true` if the token is a pipe operator.
+ */
+function isPipeOperator (token) {
+  return token != null && token.type === 'Punctuator' && token.value === '|'
 }
 
 /**
@@ -913,6 +922,34 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
         setOffset(childToken, 1, startQuoteToken)
         setOffset(endQuoteToken, 0, startQuoteToken)
       }
+    },
+
+    VFilter (node) {
+      const idToken = tokenStore.getFirstToken(node)
+      const lastToken = tokenStore.getLastToken(node)
+      if (isRightParen(lastToken)) {
+        const leftParenToken = tokenStore.getTokenAfter(node.callee)
+        setOffset(leftParenToken, 1, idToken)
+        processNodeList(node.arguments, leftParenToken, lastToken, 1)
+      }
+    },
+
+    VFilterSequenceExpression (node) {
+      if (node.filters.length === 0) {
+        return
+      }
+
+      const firstToken = tokenStore.getFirstToken(node)
+      const tokens = []
+
+      for (const filter of node.filters) {
+        tokens.push(
+          tokenStore.getTokenBefore(filter, isPipeOperator),
+          tokenStore.getFirstToken(filter)
+        )
+      }
+
+      setOffset(tokens, 1, firstToken)
     },
 
     VForExpression (node) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^5.0.0"
   },
   "dependencies": {
-    "vue-eslint-parser": "^3.2.1"
+    "vue-eslint-parser": "^4.0.2"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",

--- a/tests/fixtures/html-indent/v-filter-sequence-expression-01.vue
+++ b/tests/fixtures/html-indent/v-filter-sequence-expression-01.vue
@@ -1,0 +1,8 @@
+<!--{}-->
+<template>
+  <div :attr="
+    value
+      |
+      filter
+  " />
+</template>

--- a/tests/fixtures/html-indent/v-filter-sequence-expression-02.vue
+++ b/tests/fixtures/html-indent/v-filter-sequence-expression-02.vue
@@ -1,0 +1,9 @@
+<!--{}-->
+<template>
+  <div :attr="
+    value
+      | filter1
+      | filter2
+      | filter3
+  " />
+</template>

--- a/tests/fixtures/html-indent/v-filter-sequence-expression-03.vue
+++ b/tests/fixtures/html-indent/v-filter-sequence-expression-03.vue
@@ -1,0 +1,9 @@
+<!--{}-->
+<template>
+  <div :attr="
+    value |
+      filter1 |
+      filter2 |
+      filter3
+  " />
+</template>

--- a/tests/fixtures/html-indent/v-filter-sequence-expression-04.vue
+++ b/tests/fixtures/html-indent/v-filter-sequence-expression-04.vue
@@ -1,0 +1,9 @@
+<!--{}-->
+<template>
+  <div :attr="
+    value | filter(
+      a,
+      b
+    )
+  " />
+</template>

--- a/tests/fixtures/html-indent/v-filter-sequence-expression-05.vue
+++ b/tests/fixtures/html-indent/v-filter-sequence-expression-05.vue
@@ -1,0 +1,6 @@
+<!--{}-->
+<template>
+  <div :attr="
+    value | filter(a, b)
+  " />
+</template>

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -46,6 +46,9 @@ tester.run('no-unused-vars', rule, {
     },
     {
       code: '<template><div v-for="(v, i, c) in foo">{{c}}</div></template>'
+    },
+    {
+      code: '<template><div v-for="x in foo">{{value | f(x)}}</div></template>'
     }
   ],
   invalid: [
@@ -80,6 +83,10 @@ tester.run('no-unused-vars', rule, {
     {
       code: '<template><div v-for="(item, key) in items" :key="item.id">{{item.name}}</div></template>',
       errors: ["'key' is defined but never used."]
+    },
+    {
+      code: '<template><div v-for="x in items">{{value | x}}</div></template>',
+      errors: ["'x' is defined but never used."]
     }
   ]
 })


### PR DESCRIPTION
This PR updates `vue-eslint-parser` to v4.

I have published [vue-eslint-parser@4.0.0](https://github.com/mysticatea/vue-eslint-parser/releases/tag/v4.0.0) and it changed the AST about Vue.js Filters syntax. Before, the syntax is expressed by `BinaryExpression` because `|` is so in JavaScript. Now, the syntax is expressed by a special node `VFilterSequenceExpression`.

```
interface VFilterSequenceExpression <: Expression {
    type: "VFilterSequenceExpression"
    expression: Expression
    filters: [ VFilter ]
}

interface VFilter <: Node {
    type: "VFilter"
    callee: Identifier
    arguments: [ Expression ]
}
```

This update fixes some bugs:

- Fixes #687
- Fixes the bug that `vue/no-unused-vars` rule flags variables as used by the filter names.

Also, this PR updates `vue/html-indent` rule to support the new nodes.