### PR TITLE
Chore: move component-name-in-template-casing rule to uncategorized

### DIFF
--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -23,7 +23,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce specific casing for the component naming style in template',
-      category: 'strongly-recommended',
+      category: undefined,
       url: 'https://github.com/vuejs/eslint-plugin-vue/blob/v5.0.0/docs/rules/component-name-in-template-casing.md'
     },
     fixable: 'code',


### PR DESCRIPTION
This PR moves `component-name-in-template-casing` to uncategorized from `strongly-recommended` category.

There are some reasons:

1. This rule can break user code by autofix. If a user uses `x-element` Web Component, the rule breaks it. To avoid this broken, the user needs to configure `ignores` option. Therefore, this rule doesn't fit `vue/strongly-recommended` preset.
1. There is a bikeshedding. https://github.com/vuejs/eslint-plugin-vue/pull/397#issuecomment-443663855, https://github.com/vuejs/eslint-plugin-vue/pull/397#issuecomment-443886771, https://github.com/vuejs/eslint-plugin-vue/issues/691#issuecomment-443400173, and https://github.com/vuejs/eslint-plugin-vue/issues/691#issuecomment-443400290. Users which use kebab-casing is much and our style guide allows it.