### PR TITLE
Fix: Add `registeredComponentsOnly` option to `component-name-in-template-casing` rule

### DIFF
--- a/docs/rules/component-name-in-template-casing.md
+++ b/docs/rules/component-name-in-template-casing.md
@@ -35,7 +35,6 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
     default `true`
 - `globalRegisteredComponents` (`string[]`) ... (Only available when `registeredComponentsOnly` is `true`) The name of globally registered components.
 - `globalRegisteredComponentPatterns` (`string[]`) ... (Only available when `registeredComponentsOnly` is `true`) The pattern of the names of globally registered components.
-    default `true`
 - `ignores` (`string[]`) ... The element names to ignore. Sets the element name to allow. For example, a custom element or a non-Vue component.
 
 ### `"PascalCase", { registeredComponentsOnly: true }` (default)

--- a/docs/rules/component-name-in-template-casing.md
+++ b/docs/rules/component-name-in-template-casing.md
@@ -20,7 +20,10 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
 
 ```json
 {
-  "vue/component-name-in-template-casing": ["error", "PascalCase" | "kebab-case", { 
+  "vue/component-name-in-template-casing": ["error", "PascalCase" | "kebab-case", {
+    "registeredComponentsOnly": true,
+    "globalRegisteredComponents": [],
+    "globalRegisteredComponentPatterns": [],
     "ignores": []
   }]
 }
@@ -28,55 +31,165 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
 
 - `"PascalCase"` (default) ... enforce tag names to pascal case. E.g. `<CoolComponent>`. This is consistent with the JSX practice.
 - `"kebab-case"` ... enforce tag names to kebab case: E.g. `<cool-component>`. This is consistent with the HTML practice which is case-insensitive originally.
+- `registeredComponentsOnly` ... If `true`, only registered components are checked. If `false`, check all.
+    default `true`
+- `globalRegisteredComponents` (`string[]`) ... (Only available when `registeredComponentsOnly` is `true`) The name of globally registered components.
+- `globalRegisteredComponentPatterns` (`string[]`) ... (Only available when `registeredComponentsOnly` is `true`) The pattern of the names of globally registered components.
+    default `true`
 - `ignores` (`string[]`) ... The element names to ignore. Sets the element name to allow. For example, a custom element or a non-Vue component.
 
-### `"PascalCase"`
+### `"PascalCase", { registeredComponentsOnly: true }` (default)
 
 <eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error']}">
-```
+
+```html
 <template>
   <!-- ✓ GOOD -->
-  <TheComponent />
+  <CoolComponent />
   
   <!-- ✗ BAD -->
-  <the-component />
-  <theComponent />
-  <The-component />
+  <cool-component />
+  <coolComponent />
+  <Cool-component />
+
+  <!-- ignore -->
+  <UnregisteredComponent />
+  <unregistered-component />
 </template>
+<script>
+export default {
+  components: {
+    CoolComponent
+  }
+}
+</script>
 ```
+
 </eslint-code-block>
 
 ### `"kebab-case"`
 
 <eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'kebab-case']}">
+
 ```
 <template>
   <!-- ✓ GOOD -->
-  <the-component />
+  <cool-component />
 
   <!-- ✗ BAD -->
-  <TheComponent />
-  <theComponent />
-  <Thecomponent />
-  <The-component />
+  <CoolComponent />
+  <coolComponent />
+  <Cool-component />
+
+  <!-- ignore -->
+  <unregistered-component />
+  <UnregisteredComponent />
 </template>
+<script>
+export default {
+  components: {
+    CoolComponent
+  }
+}
+</script>
 ```
+
 </eslint-code-block>
 
+### `"PascalCase", { globalRegisteredComponents: ["GlobalComponent"] }`
 
-### `"PascalCase", { ignores: ["custom-element"] }`
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', { globalRegisteredComponents: ['GlobalComponent'] }]}">
 
-<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', {ignores: ['custom-element']}]}">
+```html
+<template>
+  <!-- ✓ GOOD -->
+  <CoolComponent />
+  <GlobalComponent />
+  
+  <!-- ✗ BAD -->
+  <cool-component />
+  <global-component />
+</template>
+<script>
+export default {
+  components: {
+    CoolComponent
+  }
+}
+</script>
+```
+
+</eslint-code-block>
+
+### `"PascalCase", { globalRegisteredComponentPatterns: ["^Global"] }`
+
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', { globalRegisteredComponentPatterns: ['^Global'] }]}">
+
+```html
+<template>
+  <!-- ✓ GOOD -->
+  <CoolComponent />
+  <GlobalButton />
+  <GlobalCard />
+  <GlobalGrid />
+  
+  <!-- ✗ BAD -->
+  <cool-component />
+  <global-button />
+  <global-card />
+  <global-grid />
+</template>
+<script>
+export default {
+  components: {
+    CoolComponent
+  }
+}
+</script>
+```
+
+</eslint-code-block>
+
+### `"PascalCase", { registeredComponentsOnly: false }`
+
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', { registeredComponentsOnly: false }]}">
+
+```html
+<template>
+  <!-- ✓ GOOD -->
+  <CoolComponent />
+  <UnregisteredComponent />
+  
+  <!-- ✗ BAD -->
+  <cool-component />
+  <unregistered-component />
+</template>
+<script>
+export default {
+  components: {
+    CoolComponent
+  }
+}
+</script>
+```
+
+</eslint-code-block>
+
+### `"PascalCase", { ignores: ["custom-element"], registeredComponentsOnly: false }`
+
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', {ignores: ['custom-element'], registeredComponentsOnly: false}]}">
+
 ```
 <template>
   <!-- ✓ GOOD -->
-  <TheComponent/>
+  <CoolComponent/>
   <custom-element></custom-element>
   
   <!-- ✗ BAD -->
   <magic-element></magic-element>
 </template>
 ```
+
 </eslint-code-block>
 
 ## :books: Further reading

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -39,6 +39,21 @@ module.exports = {
             items: { type: 'string' },
             uniqueItems: true,
             additionalItems: false
+          },
+          registeredComponentsOnly: {
+            type: 'boolean'
+          },
+          globalRegisteredComponents: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+            additionalItems: false
+          },
+          globalRegisteredComponentPatterns: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+            additionalItems: false
           }
         },
         additionalProperties: false
@@ -51,7 +66,46 @@ module.exports = {
     const options = context.options[1] || {}
     const caseType = allowedCaseOptions.indexOf(caseOption) !== -1 ? caseOption : defaultCase
     const ignores = options.ignores || []
+    const registeredComponentsOnly = options.registeredComponentsOnly !== false
+    const registeredComponents = options.globalRegisteredComponents || []
+    const globalRegisteredComponentPatterns = (options.globalRegisteredComponentPatterns || []).map(s => new RegExp(s))
     const tokens = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
+
+    /**
+     * Checks whether the given node is the verification target node.
+     * @param {VElement} node element node
+     * @returns {boolean} `true` if the given node is the verification target node.
+     */
+    function isVerifyTarget (node) {
+      if (ignores.indexOf(node.rawName) >= 0) {
+        // ignore
+        return false
+      }
+
+      if (!registeredComponentsOnly) {
+        // If the user specifies registeredComponentsOnly as false, it checks all component tags.
+        if ((!utils.isHtmlElementNode(node) && !utils.isSvgElementNode(node)) ||
+          utils.isHtmlWellKnownElementName(node.rawName) ||
+          utils.isSvgWellKnownElementName(node.rawName)
+        ) {
+          return false
+        }
+        return true
+      }
+
+      // We only verify the components registered in the component.
+      if (registeredComponents
+        .filter(name => casing.pascalCase(name) === name) // When defining a component with PascalCase, you can use either case
+        .some(name => node.rawName === name || casing.pascalCase(node.rawName) === name)) {
+        return true
+      }
+
+      if (globalRegisteredComponentPatterns
+        .some(re => node.rawName.match(re) || casing.pascalCase(node.rawName).match(re))) {
+        return true
+      }
+      return false
+    }
 
     let hasInvalidEOF = false
 
@@ -61,18 +115,11 @@ module.exports = {
           return
         }
 
-        if (
-          (!utils.isHtmlElementNode(node) && !utils.isSvgElementNode(node)) ||
-          utils.isHtmlWellKnownElementName(node.rawName) ||
-          utils.isSvgWellKnownElementName(node.rawName)
-        ) {
+        if (!isVerifyTarget(node)) {
           return
         }
 
         const name = node.rawName
-        if (ignores.indexOf(name) >= 0) {
-          return
-        }
         const casingName = casing.getConverter(caseType)(name)
         if (casingName !== name) {
           const startTag = node.startTag
@@ -100,10 +147,18 @@ module.exports = {
           })
         }
       }
-    }, {
-      Program (node) {
-        hasInvalidEOF = utils.hasInvalidEOF(node)
-      }
-    })
+    },
+    Object.assign(
+      {
+        Program (node) {
+          hasInvalidEOF = utils.hasInvalidEOF(node)
+        }
+      },
+      registeredComponentsOnly
+        ? utils.executeOnVue(context, (obj) => {
+          registeredComponents.push(...utils.getRegisteredComponents(obj).map(n => n.name))
+        })
+        : {}
+    ))
   }
 }

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -10,6 +10,7 @@
 
 const utils = require('../utils')
 const casing = require('../utils/casing')
+const { toRegExp } = require('../utils/regexp')
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -17,25 +18,6 @@ const casing = require('../utils/casing')
 
 const allowedCaseOptions = ['PascalCase', 'kebab-case']
 const defaultCase = 'PascalCase'
-
-const RE_REGEXP_CHAR = /[\\^$.*+?()[\]{}|]/gu
-const RE_HAS_REGEXP_CHAR = new RegExp(RE_REGEXP_CHAR.source)
-function escapeRegExp (string) {
-  return (string && RE_HAS_REGEXP_CHAR.test(string))
-    ? string.replace(RE_REGEXP_CHAR, '\\$&')
-    : string
-}
-
-const RE_REGEXP_STR = /^\/(.+)\/(.*)$/u
-function toRegExpList (array) {
-  return array.map(str => {
-    const parts = RE_REGEXP_STR.exec(str)
-    if (parts) {
-      return new RegExp(parts[1], parts[2])
-    }
-    return new RegExp(`^${escapeRegExp(str)}$`)
-  })
-}
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -76,7 +58,7 @@ module.exports = {
     const caseOption = context.options[0]
     const options = context.options[1] || {}
     const caseType = allowedCaseOptions.indexOf(caseOption) !== -1 ? caseOption : defaultCase
-    const ignores = toRegExpList(options.ignores || [])
+    const ignores = (options.ignores || []).map(toRegExp)
     const registeredComponentsOnly = options.registeredComponentsOnly !== false
     const tokens = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
 

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -11,8 +11,32 @@
 const utils = require('../utils')
 const casing = require('../utils/casing')
 
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
 const allowedCaseOptions = ['PascalCase', 'kebab-case']
 const defaultCase = 'PascalCase'
+
+const RE_REGEXP_STR = /^\/(.+)\/(.*)$/u
+const RE_REGEXP_CHAR = /[\\^$.*+?()[\]{}|]/g
+const RE_HAS_REGEXP_CHAR = new RegExp(RE_REGEXP_CHAR.source)
+
+function escapeRegExp (string) {
+  return (string && RE_HAS_REGEXP_CHAR.test(string))
+    ? string.replace(RE_REGEXP_CHAR, '\\$&')
+    : string
+}
+
+function toRegExpList (array) {
+  return array.map(str => {
+    const parts = RE_REGEXP_STR.exec(str)
+    if (parts) {
+      return new RegExp(parts[1], parts[2])
+    }
+    return new RegExp(`^${escapeRegExp(str)}$`)
+  })
+}
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -42,18 +66,6 @@ module.exports = {
           },
           registeredComponentsOnly: {
             type: 'boolean'
-          },
-          globalRegisteredComponents: {
-            type: 'array',
-            items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
-          },
-          globalRegisteredComponentPatterns: {
-            type: 'array',
-            items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
           }
         },
         additionalProperties: false
@@ -65,11 +77,11 @@ module.exports = {
     const caseOption = context.options[0]
     const options = context.options[1] || {}
     const caseType = allowedCaseOptions.indexOf(caseOption) !== -1 ? caseOption : defaultCase
-    const ignores = options.ignores || []
+    const ignores = toRegExpList(options.ignores || [])
     const registeredComponentsOnly = options.registeredComponentsOnly !== false
-    const registeredComponents = options.globalRegisteredComponents || []
-    const globalRegisteredComponentPatterns = (options.globalRegisteredComponentPatterns || []).map(s => new RegExp(s))
     const tokens = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
+
+    const registeredComponents = []
 
     /**
      * Checks whether the given node is the verification target node.
@@ -77,7 +89,7 @@ module.exports = {
      * @returns {boolean} `true` if the given node is the verification target node.
      */
     function isVerifyTarget (node) {
-      if (ignores.indexOf(node.rawName) >= 0) {
+      if (ignores.some(re => re.test(node.rawName))) {
         // ignore
         return false
       }
@@ -92,7 +104,6 @@ module.exports = {
         }
         return true
       }
-
       // We only verify the components registered in the component.
       if (registeredComponents
         .filter(name => casing.pascalCase(name) === name) // When defining a component with PascalCase, you can use either case
@@ -100,10 +111,6 @@ module.exports = {
         return true
       }
 
-      if (globalRegisteredComponentPatterns
-        .some(re => node.rawName.match(re) || casing.pascalCase(node.rawName).match(re))) {
-        return true
-      }
       return false
     }
 

--- a/lib/utils/regexp.js
+++ b/lib/utils/regexp.js
@@ -1,0 +1,38 @@
+const RE_REGEXP_CHAR = /[\\^$.*+?()[\]{}|]/gu
+const RE_HAS_REGEXP_CHAR = new RegExp(RE_REGEXP_CHAR.source)
+
+const RE_REGEXP_STR = /^\/(.+)\/(.*)$/u
+
+/**
+ * Escapes the `RegExp` special characters "^", "$", "\", ".", "*", "+",
+ * "?", "(", ")", "[", "]", "{", "}", and "|" in `string`.
+ *
+ * @param {string} string The string to escape.
+ * @returns {string} Returns the escaped string.
+ */
+function escape (string) {
+  return (string && RE_HAS_REGEXP_CHAR.test(string))
+    ? string.replace(RE_REGEXP_CHAR, '\\$&')
+    : string
+}
+
+/**
+ * Convert a string to the `RegExp`.
+ * Normal strings (e.g. `"foo"`) is converted to `/^foo$/` of `RegExp`.
+ * Strings like `"/^foo/i"` are converted to `/^foo/i` of `RegExp`.
+ *
+ * @param {string} string The string to convert.
+ * @returns {string} Returns the `RegExp`.
+ */
+function toRegExp (string) {
+  const parts = RE_REGEXP_STR.exec(string)
+  if (parts) {
+    return new RegExp(parts[1], parts[2])
+  }
+  return new RegExp(`^${escape(string)}$`)
+}
+
+module.exports = {
+  escape,
+  toRegExp
+}

--- a/tests/lib/autofix.js
+++ b/tests/lib/autofix.js
@@ -95,7 +95,7 @@ describe('Complex autofix test cases', () => {
           'component': 'never'
         }
       }],
-      'vue/component-name-in-template-casing': ['error', 'kebab-case']
+      'vue/component-name-in-template-casing': ['error', 'kebab-case', { registeredComponentsOnly: false }]
     }})
 
     const pascalConfig = Object.assign({}, baseConfig, { 'rules': {
@@ -104,7 +104,7 @@ describe('Complex autofix test cases', () => {
           'component': 'never'
         }
       }],
-      'vue/component-name-in-template-casing': ['error']
+      'vue/component-name-in-template-casing': ['error', 'PascalCase', { registeredComponentsOnly: false }]
     }})
 
     it('Even if set kebab-case, the output should be as expected.', () => {

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -92,13 +92,13 @@ tester.run('component-name-in-template-casing', rule, {
     {
       code: `
         <template>
-          <GlobalButton />
-          <GlobalCard />
-          <GlobalGrid />
+          <global-button />
+          <globalCard />
+          <global-grid />
         </template>
       `,
       filename: 'test.vue',
-      options: ['PascalCase', { registeredComponentsOnly: false, ignores: ['/^Global/'] }]
+      options: ['PascalCase', { registeredComponentsOnly: false, ignores: ['/^global/'] }]
     },
 
     // Invalid EOF

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -79,32 +79,6 @@ tester.run('component-name-in-template-casing', rule, {
       options: ['kebab-case', { registeredComponentsOnly: false }]
     },
 
-    // globalRegisteredComponents
-    {
-      code: `
-        <template>
-          <GlobalButton />
-          <GlobalCard />
-          <GlobalGrid />
-        </template>
-      `,
-      filename: 'test.vue',
-      options: ['PascalCase', { globalRegisteredComponents: ['GlobalButton', 'GlobalCard', 'GlobalGrid'] }]
-    },
-
-    // globalRegisteredComponentPatterns
-    {
-      code: `
-        <template>
-          <GlobalButton />
-          <GlobalCard />
-          <GlobalGrid />
-        </template>
-      `,
-      filename: 'test.vue',
-      options: ['PascalCase', { globalRegisteredComponentPatterns: ['^Global'] }]
-    },
-
     // ignores
     {
       code: '<template><custom-element></custom-element></template>',
@@ -114,6 +88,19 @@ tester.run('component-name-in-template-casing', rule, {
       code: '<template><custom-element><TheComponent/></custom-element></template>',
       options: ['PascalCase', { ignores: ['custom-element'], registeredComponentsOnly: false }]
     },
+    // regexp ignores
+    {
+      code: `
+        <template>
+          <GlobalButton />
+          <GlobalCard />
+          <GlobalGrid />
+        </template>
+      `,
+      filename: 'test.vue',
+      options: ['PascalCase', { registeredComponentsOnly: false, ignores: ['/^Global/'] }]
+    },
+
     // Invalid EOF
     { code: '<template><the-component a=">test</the-component></template>', options: ['PascalCase', { registeredComponentsOnly: false }] },
     { code: '<template><the-component><!--test</the-component></template>', options: ['PascalCase', { registeredComponentsOnly: false }] }
@@ -230,16 +217,25 @@ tester.run('component-name-in-template-casing', rule, {
           <the-component />
         </svg>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <svg>
           <TheComponent />
         </svg>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -250,16 +246,25 @@ tester.run('component-name-in-template-casing', rule, {
           <!-- comment -->
         </the-component>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent id="id">
           <!-- comment -->
         </TheComponent>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -270,16 +275,25 @@ tester.run('component-name-in-template-casing', rule, {
           content
         </the-component>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent :is="componentName">
           content
         </TheComponent>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -288,14 +302,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <the-component id="id"/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent id="id"/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -348,15 +371,24 @@ tester.run('component-name-in-template-casing', rule, {
         <the-component
           id="id"/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent
           id="id"/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -365,14 +397,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <the-component/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -381,14 +422,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <the-component></the-component>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -397,14 +447,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <theComponent/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "theComponent" is not PascalCase.']
     },
@@ -413,12 +472,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <theComponent/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['kebab-case', { globalRegisteredComponents: ['TheComponent'] }],
+      filename: 'test.vue',
+      options: ['kebab-case'],
       output: `
       <template>
         <the-component/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "theComponent" is not kebab-case.']
     },
@@ -427,14 +497,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <The-component/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "The-component" is not PascalCase.']
     },
@@ -443,12 +522,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <The-component/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['kebab-case', { globalRegisteredComponentPatterns: ['Component$'] }],
+      filename: 'test.vue',
+      options: ['kebab-case'],
       output: `
       <template>
         <the-component/>
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "The-component" is not kebab-case.']
     },
@@ -471,14 +561,23 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <the-component></the-component  >
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent  >
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -488,15 +587,24 @@ tester.run('component-name-in-template-casing', rule, {
         <the-component></the-component
         >
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent
         >
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
@@ -505,93 +613,28 @@ tester.run('component-name-in-template-casing', rule, {
       <template>
         <the-component></the-component end-tag-attr="attr" >
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
-      options: ['PascalCase', {
-        globalRegisteredComponents: ['TheComponent']
-      }],
+      filename: 'test.vue',
+      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent end-tag-attr="attr" >
       </template>
+      <script>
+      export default {
+        components: {TheComponent}
+      }
+      </script>
       `,
       errors: ['Component name "the-component" is not PascalCase.']
     },
 
-    // globalRegisteredComponents
-    {
-      code: `
-        <template>
-          <global-button />
-          <global-card />
-          <global-grid />
-        </template>
-      `,
-      filename: 'test.vue',
-      options: ['PascalCase', { globalRegisteredComponents: ['GlobalButton', 'GlobalCard', 'GlobalGrid'] }],
-      output: `
-        <template>
-          <GlobalButton />
-          <GlobalCard />
-          <GlobalGrid />
-        </template>
-      `,
-      errors: [
-        'Component name "global-button" is not PascalCase.',
-        'Component name "global-card" is not PascalCase.',
-        'Component name "global-grid" is not PascalCase.'
-      ]
-    },
-
-    // globalRegisteredComponentPatterns
-    {
-      code: `
-        <template>
-          <global-button />
-          <global-card />
-          <global-grid />
-        </template>
-      `,
-      filename: 'test.vue',
-      options: ['PascalCase', { globalRegisteredComponentPatterns: ['^Global'] }],
-      output: `
-        <template>
-          <GlobalButton />
-          <GlobalCard />
-          <GlobalGrid />
-        </template>
-      `,
-      errors: [
-        'Component name "global-button" is not PascalCase.',
-        'Component name "global-card" is not PascalCase.',
-        'Component name "global-grid" is not PascalCase.'
-      ]
-    },
-
     // ignores
-    {
-      code: `
-      <template>
-        <custom-element>
-          <the-component />
-        </custom-element>
-        <custom-component />
-      </template>`,
-      output: `
-      <template>
-        <custom-element>
-          <TheComponent />
-        </custom-element>
-        <CustomComponent />
-      </template>`,
-      options: ['PascalCase', {
-        ignores: ['custom-element'],
-        globalRegisteredComponentPatterns: ['^the', '^custom']
-      }],
-      errors: [
-        'Component name "the-component" is not PascalCase.',
-        'Component name "custom-component" is not PascalCase.'
-      ]
-    },
     {
       code: `
       <template>
@@ -611,7 +654,7 @@ tester.run('component-name-in-template-casing', rule, {
       </template>`,
       options: ['PascalCase', {
         ignores: ['custom-element1', 'custom-element2'],
-        globalRegisteredComponentPatterns: ['^the', '^custom']
+        registeredComponentsOnly: false
       }],
       errors: [
         'Component name "the-component" is not PascalCase.',
@@ -636,7 +679,7 @@ tester.run('component-name-in-template-casing', rule, {
         <TheComponent />
       </template>`,
       options: ['PascalCase', {
-        ignores: ['custom-element1', 'custom-element2'],
+        ignores: ['/^custom-element/'],
         registeredComponentsOnly: false
       }],
       errors: [

--- a/tests/lib/utils/regexp.js
+++ b/tests/lib/utils/regexp.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { escape, toRegExp } = require('../../../lib/utils/regexp')
+const chai = require('chai')
+
+const assert = chai.assert
+
+const ESCAPED = '\\^\\$\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\\\'
+const UNESCAPED = '^$.*+?()[]{}|\\'
+
+describe('escape()', () => {
+  it('should escape values', () => {
+    assert.strictEqual(escape(UNESCAPED), ESCAPED)
+    assert.strictEqual(escape(UNESCAPED + UNESCAPED), ESCAPED + ESCAPED)
+  })
+
+  it('should handle strings with nothing to escape', () => {
+    assert.strictEqual(escape('abc'), 'abc')
+  })
+
+  it('should return an empty string for empty values', () => {
+    assert.strictEqual(escape(null), null)
+    assert.strictEqual(escape(undefined), undefined)
+    assert.strictEqual(escape(''), '')
+  })
+})
+
+describe('toRegExp()', () => {
+  it('should be convert to RegExp', () => {
+    assert.deepEqual(toRegExp('foo'), /^foo$/)
+    assert.deepEqual(toRegExp(UNESCAPED), new RegExp(`^${ESCAPED}$`))
+  })
+
+  it('RegExp like string should be convert to RegExp', () => {
+    assert.deepEqual(toRegExp('/^foo/i'), /^foo/i)
+    assert.deepEqual(toRegExp('/.*/ius'), /.*/ius)
+    assert.deepEqual(toRegExp(`${/^bar/i}`), /^bar/i)
+    assert.deepEqual(toRegExp(`${/[\sA-Z]+/u}`), /[\sA-Z]+/u)
+  })
+})

--- a/tests/lib/utils/regexp.js
+++ b/tests/lib/utils/regexp.js
@@ -33,7 +33,7 @@ describe('toRegExp()', () => {
 
   it('RegExp like string should be convert to RegExp', () => {
     assert.deepEqual(toRegExp('/^foo/i'), /^foo/i)
-    assert.deepEqual(toRegExp('/.*/ius'), /.*/ius)
+    assert.deepEqual(toRegExp('/.*/iu'), /.*/iu)
     assert.deepEqual(toRegExp(`${/^bar/i}`), /^bar/i)
     assert.deepEqual(toRegExp(`${/[\sA-Z]+/u}`), /[\sA-Z]+/u)
   })


### PR DESCRIPTION
This PR makes the following changes to `component-name-in-template-casing` rule.

- Add `registeredComponentsOnly` option.
- Change the default for `registeredComponentsOnly` options to true.
- ~~Add `globalRegisteredComponents` option.~~
- ~~Add `globalRegisteredComponentPatterns` option.~~
- Changed to be able to set regexp for `ignores` option.

The feature of each additional option is as follows.

- `registeredComponentsOnly` ... If `true`, only registered components (in PascalCase) are checked. If `false`, check all.
    default `true`
- ~~`globalRegisteredComponents` (`string[]`) ... (Only available when `registeredComponentsOnly` is `true`) The name of globally registered components.~~
- ~~`globalRegisteredComponentPatterns` (`string[]`) ... (Only available when `registeredComponentsOnly` is `true`) The pattern of the names of globally registered components.~~

---

https://vuejs.org/v2/guide/components-registration.html#Name-Casing

Since the casing of the globally registered component is unknown, we made an option to check only the local registered components that are explicitly used.
Also, I changed this option to work by default.

This fixes the problem pointed out below.
- https://github.com/vuejs/eslint-plugin-vue/pull/397#issuecomment-443663855
- #710

Fixed #710 #705

