### PR TITLE
Chore: improve editor style in vuepress

### DIFF
--- a/docs/.vuepress/components/eslint-code-block.vue
+++ b/docs/.vuepress/components/eslint-code-block.vue
@@ -1,18 +1,20 @@
 <template>
-  <eslint-editor
-    :linter="linter"
-    :config="config"
-    :code="code"
-    :style="{ height }"
-    class="eslint-code-block"
-    filename="example.vue"
-    language="html"
-    :preprocess="preprocess"
-    :postprocess="postprocess"
-    dark
-    :format="format"
-    :fix="fix"
-  />
+  <div class="eslint-code-container">
+    <eslint-editor
+      :linter="linter"
+      :config="config"
+      :code="code"
+      :style="{ height }"
+      class="eslint-code-block"
+      filename="example.vue"
+      language="html"
+      :preprocess="preprocess"
+      :postprocess="postprocess"
+      dark
+      :format="format"
+      :fix="fix"
+    />
+  </div>
 </template>
 
 <script>
@@ -92,7 +94,7 @@ export default {
 
     height () {
       const lines = this.code.split('\n').length
-      return `${Math.max(120, 20 * (1 + lines))}px`
+      return `${Math.max(120, 19 * lines)}px`
     }
   },
 
@@ -129,8 +131,18 @@ export default {
 </script>
 
 <style>
+.eslint-code-container {
+  border-radius: 6px;
+  padding: 1.25rem 0;
+  margin: 1em 0;
+  background-color: #1e1e1e;
+}
+
 .eslint-code-block {
   width: 100%;
-  margin: 1em 0;
+}
+
+.eslint-editor-actions {
+  bottom: -0.9rem;
 }
 </style>


### PR DESCRIPTION
> The bottom padding of the interactive code examples seems a little excessive and I think might also be increasing a little with each line in the initial code.

https://github.com/vuejs/eslint-plugin-vue/pull/534#pullrequestreview-180095362

After: https://armano2.github.io/eslint-plugin-vue/rules/no-dupe-keys.html
Before: https://vuejs.github.io/eslint-plugin-vue/rules/no-dupe-keys.html

-----------

![image](https://user-images.githubusercontent.com/625469/49482120-1fc52d00-f82e-11e8-9d35-d1101f59f047.png)