### PR TITLE
Fix: order in components for node 11

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -168,7 +168,7 @@ module.exports = {
         const propertiesAbove = properties.slice(0, i)
         const unorderedProperties = propertiesAbove
           .filter(p => orderMap.get(p.name) > orderMap.get(property.name))
-          .sort((p1, p2) => orderMap.get(p1.name) > orderMap.get(p2.name))
+          .sort((p1, p2) => orderMap.get(p1.name) > orderMap.get(p2.name) ? 1 : -1)
 
         const firstUnorderedProperty = unorderedProperties[0]
 


### PR DESCRIPTION
when running tests on node 11 we are getting a lot of errors related to sort function in order in components, this change make sure that results are going to be consistent....

https://v8.dev/blog/array-sort
https://mathiasbynens.be/demo/sort-stability

 > the V8 implementation changed from QuickSort to TimSort

https://github.com/nodejs/node/issues/24294

------ 

Not sure if we should add node 11 to circleci build env