### PR TITLE
Chore: update vue-eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^5.0.0"
   },
   "dependencies": {
-    "vue-eslint-parser": "^4.0.2"
+    "vue-eslint-parser": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -36,10 +36,10 @@ tester.run('no-unused-vars', rule, {
       code: '<template><ol v-for="i in data"><li v-for="f in i">{{ f.bar.baz }}</li></ol></template>'
     },
     {
-      code: '<template scope="props">{{props}}</template>'
+      code: '<template><template scope="props">{{props}}</template></template>'
     },
     {
-      code: '<template scope="props"><span v-if="props"></span></template>'
+      code: '<template><template scope="props"><span v-if="props"></span></template></template>'
     },
     {
       code: '<template><div v-for="(item, key) in items" :key="key">{{item.name}}</div></template>'
@@ -61,7 +61,15 @@ tester.run('no-unused-vars', rule, {
       errors: ["'props' is defined but never used."]
     },
     {
-      code: '<template><template v-for="i in 5"><comp v-for="j in 10">{{i}}{{i}}</comp></template></template>',
+      code: '<template><span slot-scope="props"></span></template>',
+      errors: ["'props' is defined but never used."]
+    },
+    {
+      code: '<template><span><template scope="props"></template></span></template>',
+      errors: ["'props' is defined but never used."]
+    },
+    {
+      code: '<template><div v-for="i in 5"><comp v-for="j in 10">{{i}}{{i}}</comp></div></template>',
       errors: ["'j' is defined but never used."]
     },
     {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -57,11 +57,11 @@ tester.run('no-unused-vars', rule, {
       errors: ["'i' is defined but never used."]
     },
     {
-      code: '<template scope="props"></template>',
+      code: '<template><template scope="props"></template></template>',
       errors: ["'props' is defined but never used."]
     },
     {
-      code: '<template v-for="i in 5"><comp v-for="j in 10">{{i}}{{i}}</comp></template>',
+      code: '<template><template v-for="i in 5"><comp v-for="j in 10">{{i}}{{i}}</comp></template></template>',
       errors: ["'j' is defined but never used."]
     },
     {

--- a/tests/lib/rules/valid-v-else-if.js
+++ b/tests/lib/rules/valid-v-else-if.js
@@ -43,7 +43,7 @@ tester.run('valid-v-else-if', rule, {
   invalid: [
     {
       filename: 'test.vue',
-      code: '<template v-else-if="foo"><div></div></template>',
+      code: '<template><template v-else-if="foo"><div></div></template></template>',
       errors: ["'v-else-if' directives require being preceded by the element which has a 'v-if' or 'v-else-if' directive."]
     },
     {

--- a/tests/lib/rules/valid-v-else.js
+++ b/tests/lib/rules/valid-v-else.js
@@ -43,7 +43,7 @@ tester.run('valid-v-else', rule, {
   invalid: [
     {
       filename: 'test.vue',
-      code: '<template v-else><div></div></template>',
+      code: '<template><template v-else><div></div></template></template>',
       errors: ["'v-else' directives require being preceded by the element which has a 'v-if' or 'v-else' directive."]
     },
     {

--- a/tests/lib/rules/valid-v-for.js
+++ b/tests/lib/rules/valid-v-for.js
@@ -90,24 +90,30 @@ tester.run('valid-v-for', rule, {
     {
       filename: 'test.vue',
       code: `
-        <template v-for="x in xs">
-          <template v-for="y in x.ys">
-            <li v-for="z in y.zs" :key="z.id">
-              123
-            </li>
+        <template>
+          <template v-for="x in xs">
+            <template v-for="y in x.ys">
+              <li v-for="z in y.zs" :key="z.id">
+                123
+              </li>
+            </template>
           </template>
-        </template>`
+        </template>
+      `
     },
     {
       filename: 'test.vue',
       code: `
-        <template v-for="x in xs">
-          <template v-for="y in ys">
-            <li v-for="z in zs" :key="x.id + y.id + z.id">
-              123
-            </li>
+        <template>
+          <template v-for="x in xs">
+            <template v-for="y in ys">
+              <li v-for="z in zs" :key="x.id + y.id + z.id">
+                123
+              </li>
+            </template>
           </template>
-        </template>`
+        </template>
+      `
     }
   ],
   invalid: [
@@ -215,37 +221,46 @@ tester.run('valid-v-for', rule, {
       filename: 'test.vue',
       errors: ["Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."],
       code: `
-        <template v-for="x in xs">
-          <template v-for="y in a.ys">
-            <li v-for="z in y.zs" :key="z.id">
-              123
-            </li>
+        <template>
+          <template v-for="x in xs">
+            <template v-for="y in a.ys">
+              <li v-for="z in y.zs" :key="z.id">
+                123
+              </li>
+            </template>
           </template>
-        </template>`
+        </template>
+      `
     },
     {
       filename: 'test.vue',
       errors: ["Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."],
       code: `
-        <template v-for="x in xs">
-          <template v-for="y in x.ys">
-            <li v-for="z in a.zs" :key="z.id">
-              123
-            </li>
+        <template>
+          <template v-for="x in xs">
+            <template v-for="y in x.ys">
+              <li v-for="z in a.zs" :key="z.id">
+                123
+              </li>
+            </template>
           </template>
-        </template>`
+        </template>
+      `
     },
     {
       filename: 'test.vue',
       errors: ["Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."],
       code: `
-        <template v-for="x in xs">
-          <template v-for="y in x.ys">
-            <li v-for="z in x.zs" :key="z.id">
-              123
-            </li>
+        <template>
+          <template v-for="x in xs">
+            <template v-for="y in x.ys">
+              <li v-for="z in x.zs" :key="z.id">
+                123
+              </li>
+            </template>
           </template>
-        </template>`
+        </template>
+      `
     }
 
   ]

--- a/tests/lib/rules/valid-v-for.js
+++ b/tests/lib/rules/valid-v-for.js
@@ -77,11 +77,11 @@ tester.run('valid-v-for', rule, {
     },
     {
       filename: 'test.vue',
-      code: '<template v-for="x of list"><slot name="item" /></template>'
+      code: '<template><template v-for="x of list"><slot name="item" /></template></template>'
     },
     {
       filename: 'test.vue',
-      code: '<template v-for="x of list">foo<div></div></template>'
+      code: '<template><template v-for="x of list">foo<div></div></template></template>'
     },
     {
       filename: 'test.vue',
@@ -262,6 +262,5 @@ tester.run('valid-v-for', rule, {
         </template>
       `
     }
-
   ]
 })


### PR DESCRIPTION
Fixes #716
Fiees #722
Fixes #733

See the release note https://github.com/mysticatea/vue-eslint-parser/releases/tag/v5.0.0 for details.

- No rule looks to depend on `VSlotScopeExpression#id` property that was removed.
- As a side effect, it gets ignoring expressions in the attributes of the top-level tags. This affects some test cases and I wrapped those tests by `<template>` element.