### PR TITLE
fix(html-indent): Don't nest closeBracket of closing tag

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -909,7 +909,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
       const closeToken = tokenStore.getLastToken(node)
 
       if (closeToken.type.endsWith('TagClose')) {
-        setOffset(closeToken, options.closeBracket, openToken)
+        setOffset(closeToken, 0, openToken)
       }
     },
 

--- a/tests/fixtures/html-indent/close-bracket-01.vue
+++ b/tests/fixtures/html-indent/close-bracket-01.vue
@@ -1,0 +1,14 @@
+<!--{}-->
+<template>
+  <a
+    href="#"
+  >Link 1</a
+  >
+  <a
+    href="#"
+  >
+    Link 2</a
+  >
+  <div>Content</div
+  >
+</template>

--- a/tests/fixtures/html-indent/close-bracket-02.vue
+++ b/tests/fixtures/html-indent/close-bracket-02.vue
@@ -2,7 +2,13 @@
 <template>
   <a
     href="#"
+    >Link 1</a
+  >
+  <a
+    href="#"
     >
-    Content</a
+    Link 2</a
+  >
+  <div>Content</div
   >
 </template>

--- a/tests/fixtures/html-indent/close-bracket-02.vue
+++ b/tests/fixtures/html-indent/close-bracket-02.vue
@@ -1,0 +1,8 @@
+<!--{"options":[2, { "closeBracket": 1 }]}-->
+<template>
+  <a
+    href="#"
+    >
+    Content</a
+  >
+</template>

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -381,33 +381,6 @@ tester.run('html-indent', rule, loadPatterns(
         text <span /> <!-- comment --></pre>
         </template>
       `
-    },
-    // Close bracket
-    {
-      filename: 'test.vue',
-      code: unIndent`
-        <template>
-          <a
-            href="#"
-            >Content</a
-          >
-        </template>
-      `,
-      options: [2, {
-        closeBracket: 1
-      }]
-    },
-    {
-      filename: 'test.vue',
-      code: unIndent`
-        <template>
-          <div>Content</div
-          >
-        </template>
-      `,
-      options: [2, {
-        closeBracket: 2
-      }]
     }
   ],
 
@@ -782,65 +755,6 @@ tester.run('html-indent', rule, loadPatterns(
         { message: 'Expected indentation of 6 spaces but found 0 spaces.', line: 6 },
         { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 7 },
         { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 8 }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: unIndent`
-        <template>
-        <a
-        href="#"
-        >
-        Content</a
-        >
-        </template>
-      `,
-      output: unIndent`
-        <template>
-          <a
-            href="#"
-          >
-            Content</a
-          >
-        </template>
-      `,
-      errors: [
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 4 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 5 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 6 }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: unIndent`
-        <template>
-        <a
-        href="#"
-        >
-        Content</a
-        >
-        </template>
-      `,
-      options: [2, {
-        closeBracket: 1
-      }],
-      output: unIndent`
-        <template>
-          <a
-            href="#"
-            >
-            Content</a
-          >
-        </template>
-      `,
-      errors: [
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 4 },
-        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 5 },
-        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 6 }
       ]
     }
   ]

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -381,6 +381,33 @@ tester.run('html-indent', rule, loadPatterns(
         text <span /> <!-- comment --></pre>
         </template>
       `
+    },
+    // Close bracket
+    {
+      filename: 'test.vue',
+      code: unIndent`
+        <template>
+          <a
+            href="#"
+            >Content</a
+          >
+        </template>
+      `,
+      options: [2, {
+        closeBracket: 1
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: unIndent`
+        <template>
+          <div>Content</div
+          >
+        </template>
+      `,
+      options: [2, {
+        closeBracket: 2
+      }]
     }
   ],
 
@@ -755,6 +782,65 @@ tester.run('html-indent', rule, loadPatterns(
         { message: 'Expected indentation of 6 spaces but found 0 spaces.', line: 6 },
         { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 7 },
         { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 8 }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: unIndent`
+        <template>
+        <a
+        href="#"
+        >
+        Content</a
+        >
+        </template>
+      `,
+      output: unIndent`
+        <template>
+          <a
+            href="#"
+          >
+            Content</a
+          >
+        </template>
+      `,
+      errors: [
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
+        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 4 },
+        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 5 },
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 6 }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: unIndent`
+        <template>
+        <a
+        href="#"
+        >
+        Content</a
+        >
+        </template>
+      `,
+      options: [2, {
+        closeBracket: 1
+      }],
+      output: unIndent`
+        <template>
+          <a
+            href="#"
+            >
+            Content</a
+          >
+        </template>
+      `,
+      errors: [
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 2 },
+        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 3 },
+        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 4 },
+        { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 5 },
+        { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 6 }
       ]
     }
   ]


### PR DESCRIPTION
This PR ignores `closeBracket` option for closing tags. Fixes #728 