### PR TITLE
Update: Add `allowEmptyLines` option to `vue/multiline-html-element-content-newline` rule

### DIFF
--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -79,7 +79,7 @@ This rule enforces a line break before and after the contents of a multiline ele
     "vue/multiline-html-element-content-newline": ["error", {
         "ignoreWhenEmpty": true,
         "ignores": ["pre", "textarea"],
-        "arrowEmptyLine": false
+        "allowEmptyLine": false
     }]
 }
 ```
@@ -88,7 +88,7 @@ This rule enforces a line break before and after the contents of a multiline ele
     default `true`
 - `ignores` ... the configuration for element names to ignore line breaks style.  
     default `["pre", "textarea"]`
-- `arrowEmptyLine` ... if `true`, allow empty line. If disallow multiple empty lines, use [no-multiple-empty-lines] in combination.  
+- `allowEmptyLine` ... if `true`, allow empty line. If disallow multiple empty lines, use [no-multiple-empty-lines] in combination.  
     default `false`
 
 ### `"ignores": ["VueComponent", "pre", "textarea"]`
@@ -112,9 +112,9 @@ This rule enforces a line break before and after the contents of a multiline ele
 
 </eslint-code-block>
 
-### `"arrowEmptyLine": true`
+### `"allowEmptyLine": true`
 
-<eslint-code-block fix :rules="{'vue/multiline-html-element-content-newline': ['error', { arrowEmptyLine: true }]}">
+<eslint-code-block fix :rules="{'vue/multiline-html-element-content-newline': ['error', { allowEmptyLine: true }]}">
 
 ```vue
 <template>

--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -78,7 +78,8 @@ This rule enforces a line break before and after the contents of a multiline ele
 {
     "vue/multiline-html-element-content-newline": ["error", {
         "ignoreWhenEmpty": true,
-        "ignores": ["pre", "textarea"]
+        "ignores": ["pre", "textarea"],
+        "arrowEmptyLine": false,
     }]
 }
 ```
@@ -87,6 +88,8 @@ This rule enforces a line break before and after the contents of a multiline ele
     default `true`
 - `ignores` ... the configuration for element names to ignore line breaks style.  
     default `["pre", "textarea"]`
+- `arrowEmptyLine` ... if `true`, allow empty line. If disallow multiple empty lines, use [no-multiple-empty-lines] in combination.  
+    default `false`
 
 ### `"ignores": ["VueComponent", "pre", "textarea"]`
 
@@ -108,6 +111,36 @@ This rule enforces a line break before and after the contents of a multiline ele
 ```
 
 </eslint-code-block>
+
+### `"arrowEmptyLine": true`
+
+<eslint-code-block fix :rules="{'vue/multiline-html-element-content-newline': ['error', { arrowEmptyLine: true }]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <div>
+    content
+  </div>
+  <div>
+
+    content
+
+  </div>
+
+  <!-- ✗ BAD -->
+  <div>content
+    content</div>
+</template>
+```
+
+</eslint-code-block>
+
+## :books: Further reading
+
+- [no-multiple-empty-lines]
+
+[no-multiple-empty-lines]: https://eslint.org/docs/rules/no-multiple-empty-lines
 
 ## :mag: Implementation
 

--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -79,7 +79,7 @@ This rule enforces a line break before and after the contents of a multiline ele
     "vue/multiline-html-element-content-newline": ["error", {
         "ignoreWhenEmpty": true,
         "ignores": ["pre", "textarea"],
-        "allowEmptyLine": false
+        "allowEmptyLines": false
     }]
 }
 ```
@@ -88,7 +88,7 @@ This rule enforces a line break before and after the contents of a multiline ele
     default `true`
 - `ignores` ... the configuration for element names to ignore line breaks style.  
     default `["pre", "textarea"]`
-- `allowEmptyLine` ... if `true`, allow empty line. If disallow multiple empty lines, use [no-multiple-empty-lines] in combination.  
+- `allowEmptyLines` ... if `true`, it allows empty lines around content. If you want to disallow multiple empty lines, use [no-multiple-empty-lines] in combination.  
     default `false`
 
 ### `"ignores": ["VueComponent", "pre", "textarea"]`
@@ -112,9 +112,9 @@ This rule enforces a line break before and after the contents of a multiline ele
 
 </eslint-code-block>
 
-### `"allowEmptyLine": true`
+### `"allowEmptyLines": true`
 
-<eslint-code-block fix :rules="{'vue/multiline-html-element-content-newline': ['error', { allowEmptyLine: true }]}">
+<eslint-code-block fix :rules="{'vue/multiline-html-element-content-newline': ['error', { allowEmptyLines: true }]}">
 
 ```vue
 <template>

--- a/docs/rules/multiline-html-element-content-newline.md
+++ b/docs/rules/multiline-html-element-content-newline.md
@@ -79,7 +79,7 @@ This rule enforces a line break before and after the contents of a multiline ele
     "vue/multiline-html-element-content-newline": ["error", {
         "ignoreWhenEmpty": true,
         "ignores": ["pre", "textarea"],
-        "arrowEmptyLine": false,
+        "arrowEmptyLine": false
     }]
 }
 ```

--- a/lib/rules/multiline-html-element-content-newline.js
+++ b/lib/rules/multiline-html-element-content-newline.js
@@ -22,7 +22,8 @@ function isMultilineElement (element) {
 function parseOptions (options) {
   return Object.assign({
     ignores: ['pre', 'textarea'],
-    ignoreWhenEmpty: true
+    ignoreWhenEmpty: true,
+    arrowEmptyLine: false
   }, options)
 }
 
@@ -69,6 +70,9 @@ module.exports = {
           items: { type: 'string' },
           uniqueItems: true,
           additionalItems: false
+        },
+        arrowEmptyLine: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -83,6 +87,7 @@ module.exports = {
     const options = parseOptions(context.options[0])
     const ignores = options.ignores
     const ignoreWhenEmpty = options.ignoreWhenEmpty
+    const arrowEmptyLine = options.arrowEmptyLine
     const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
     const sourceCode = context.getSourceCode()
 
@@ -92,6 +97,14 @@ module.exports = {
       return ignores.includes(node.name) ||
         ignores.includes(casing.pascalCase(node.rawName)) ||
         ignores.includes(casing.kebabCase(node.rawName))
+    }
+
+    function isInvalidLineBreaks (lineBreaks) {
+      if (arrowEmptyLine) {
+        return lineBreaks === 0
+      } else {
+        return lineBreaks !== 1
+      }
     }
 
     return utils.defineTemplateBodyVisitor(context, {
@@ -127,7 +140,7 @@ module.exports = {
 
         const beforeLineBreaks = contentFirst.loc.start.line - node.startTag.loc.end.line
         const afterLineBreaks = node.endTag.loc.start.line - contentLast.loc.end.line
-        if (beforeLineBreaks !== 1) {
+        if (isInvalidLineBreaks(beforeLineBreaks)) {
           context.report({
             node: template.getLastToken(node.startTag),
             loc: {
@@ -150,7 +163,7 @@ module.exports = {
           return
         }
 
-        if (afterLineBreaks !== 1) {
+        if (isInvalidLineBreaks(afterLineBreaks)) {
           context.report({
             node: template.getFirstToken(node.endTag),
             loc: {

--- a/lib/rules/multiline-html-element-content-newline.js
+++ b/lib/rules/multiline-html-element-content-newline.js
@@ -23,7 +23,7 @@ function parseOptions (options) {
   return Object.assign({
     ignores: ['pre', 'textarea'],
     ignoreWhenEmpty: true,
-    arrowEmptyLine: false
+    allowEmptyLine: false
   }, options)
 }
 
@@ -71,7 +71,7 @@ module.exports = {
           uniqueItems: true,
           additionalItems: false
         },
-        arrowEmptyLine: {
+        allowEmptyLine: {
           type: 'boolean'
         }
       },
@@ -87,7 +87,7 @@ module.exports = {
     const options = parseOptions(context.options[0])
     const ignores = options.ignores
     const ignoreWhenEmpty = options.ignoreWhenEmpty
-    const arrowEmptyLine = options.arrowEmptyLine
+    const allowEmptyLine = options.allowEmptyLine
     const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
     const sourceCode = context.getSourceCode()
 
@@ -100,7 +100,7 @@ module.exports = {
     }
 
     function isInvalidLineBreaks (lineBreaks) {
-      if (arrowEmptyLine) {
+      if (allowEmptyLine) {
         return lineBreaks === 0
       } else {
         return lineBreaks !== 1

--- a/lib/rules/multiline-html-element-content-newline.js
+++ b/lib/rules/multiline-html-element-content-newline.js
@@ -23,7 +23,7 @@ function parseOptions (options) {
   return Object.assign({
     ignores: ['pre', 'textarea'],
     ignoreWhenEmpty: true,
-    allowEmptyLine: false
+    allowEmptyLines: false
   }, options)
 }
 
@@ -71,7 +71,7 @@ module.exports = {
           uniqueItems: true,
           additionalItems: false
         },
-        allowEmptyLine: {
+        allowEmptyLines: {
           type: 'boolean'
         }
       },
@@ -87,7 +87,7 @@ module.exports = {
     const options = parseOptions(context.options[0])
     const ignores = options.ignores
     const ignoreWhenEmpty = options.ignoreWhenEmpty
-    const allowEmptyLine = options.allowEmptyLine
+    const allowEmptyLines = options.allowEmptyLines
     const template = context.parserServices.getTemplateBodyTokenStore && context.parserServices.getTemplateBodyTokenStore()
     const sourceCode = context.getSourceCode()
 
@@ -100,7 +100,7 @@ module.exports = {
     }
 
     function isInvalidLineBreaks (lineBreaks) {
-      if (allowEmptyLine) {
+      if (allowEmptyLines) {
         return lineBreaks === 0
       } else {
         return lineBreaks !== 1

--- a/tests/lib/rules/multiline-html-element-content-newline.js
+++ b/tests/lib/rules/multiline-html-element-content-newline.js
@@ -72,7 +72,7 @@ tester.run('multiline-html-element-content-newline', rule, {
           class="panel">
         </div>
       </template>`,
-    // allowEmptyLine
+    // allowEmptyLines
     {
       code: `
         <template>
@@ -81,7 +81,7 @@ tester.run('multiline-html-element-content-newline', rule, {
 
           </div>
         </template>`,
-      options: [{ allowEmptyLine: true, ignoreWhenEmpty: false }]
+      options: [{ allowEmptyLines: true, ignoreWhenEmpty: false }]
     },
     {
       code: `
@@ -93,7 +93,7 @@ tester.run('multiline-html-element-content-newline', rule, {
 
           </div>
         </template>`,
-      options: [{ allowEmptyLine: true }]
+      options: [{ allowEmptyLines: true }]
     },
     {
       code: `
@@ -107,7 +107,7 @@ tester.run('multiline-html-element-content-newline', rule, {
 
           </div>
         </template>`,
-      options: [{ allowEmptyLine: true }]
+      options: [{ allowEmptyLines: true }]
     },
     // self closing
     `
@@ -476,7 +476,7 @@ content
         'Expected 1 line break before closing tag (`</div>`), but 2 line breaks found.'
       ]
     },
-    // allowEmptyLine
+    // allowEmptyLines
     {
       code: `
         <template>
@@ -487,7 +487,7 @@ content
           <div
             class="panel"></div>
         </template>`,
-      options: [{ allowEmptyLine: true, ignoreWhenEmpty: false }],
+      options: [{ allowEmptyLines: true, ignoreWhenEmpty: false }],
       output: `
         <template>
           <div
@@ -515,7 +515,7 @@ content
             content</div>
         </template>
       `,
-      options: [{ allowEmptyLine: true }],
+      options: [{ allowEmptyLines: true }],
       output: `
         <template>
           <div>

--- a/tests/lib/rules/multiline-html-element-content-newline.js
+++ b/tests/lib/rules/multiline-html-element-content-newline.js
@@ -72,7 +72,7 @@ tester.run('multiline-html-element-content-newline', rule, {
           class="panel">
         </div>
       </template>`,
-    // arrowEmptyLine
+    // allowEmptyLine
     {
       code: `
         <template>
@@ -81,7 +81,7 @@ tester.run('multiline-html-element-content-newline', rule, {
 
           </div>
         </template>`,
-      options: [{ arrowEmptyLine: true, ignoreWhenEmpty: false }]
+      options: [{ allowEmptyLine: true, ignoreWhenEmpty: false }]
     },
     {
       code: `
@@ -93,7 +93,7 @@ tester.run('multiline-html-element-content-newline', rule, {
 
           </div>
         </template>`,
-      options: [{ arrowEmptyLine: true }]
+      options: [{ allowEmptyLine: true }]
     },
     {
       code: `
@@ -107,7 +107,7 @@ tester.run('multiline-html-element-content-newline', rule, {
 
           </div>
         </template>`,
-      options: [{ arrowEmptyLine: true }]
+      options: [{ allowEmptyLine: true }]
     },
     // self closing
     `
@@ -476,7 +476,7 @@ content
         'Expected 1 line break before closing tag (`</div>`), but 2 line breaks found.'
       ]
     },
-    // arrowEmptyLine
+    // allowEmptyLine
     {
       code: `
         <template>
@@ -487,7 +487,7 @@ content
           <div
             class="panel"></div>
         </template>`,
-      options: [{ arrowEmptyLine: true, ignoreWhenEmpty: false }],
+      options: [{ allowEmptyLine: true, ignoreWhenEmpty: false }],
       output: `
         <template>
           <div
@@ -515,7 +515,7 @@ content
             content</div>
         </template>
       `,
-      options: [{ arrowEmptyLine: true }],
+      options: [{ allowEmptyLine: true }],
       output: `
         <template>
           <div>

--- a/tests/lib/rules/multiline-html-element-content-newline.js
+++ b/tests/lib/rules/multiline-html-element-content-newline.js
@@ -72,6 +72,43 @@ tester.run('multiline-html-element-content-newline', rule, {
           class="panel">
         </div>
       </template>`,
+    // arrowEmptyLine
+    {
+      code: `
+        <template>
+          <div
+            class="panel">
+
+          </div>
+        </template>`,
+      options: [{ arrowEmptyLine: true, ignoreWhenEmpty: false }]
+    },
+    {
+      code: `
+        <template>
+          <div
+            class="panel">
+
+            contents
+
+          </div>
+        </template>`,
+      options: [{ arrowEmptyLine: true }]
+    },
+    {
+      code: `
+        <template>
+          <div
+            class="panel">
+
+
+            contents
+
+
+          </div>
+        </template>`,
+      options: [{ arrowEmptyLine: true }]
+    },
     // self closing
     `
       <template>
@@ -437,6 +474,65 @@ content
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but 2 line breaks found.',
         'Expected 1 line break before closing tag (`</div>`), but 2 line breaks found.'
+      ]
+    },
+    // arrowEmptyLine
+    {
+      code: `
+        <template>
+          <div
+            class="panel">
+
+          </div>
+          <div
+            class="panel"></div>
+        </template>`,
+      options: [{ arrowEmptyLine: true, ignoreWhenEmpty: false }],
+      output: `
+        <template>
+          <div
+            class="panel">
+
+          </div>
+          <div
+            class="panel">
+</div>
+        </template>`,
+      errors: [
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div>
+
+            content
+            content
+
+          </div>
+          <div>content
+            content</div>
+        </template>
+      `,
+      options: [{ arrowEmptyLine: true }],
+      output: `
+        <template>
+          <div>
+
+            content
+            content
+
+          </div>
+          <div>
+content
+            content
+</div>
+        </template>
+      `,
+      errors: [
+        'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
+        'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
       ]
     },
     // mustache


### PR DESCRIPTION
Close #683

This PR adds `allowEmptyLines` option to `vue/multiline-html-element-content-newline` rule.

- `allowEmptyLines` ... if `true`, it allows empty lines around content. If you want to disallow multiple empty lines, use [no-multiple-empty-lines] in combination.  
    default `false`

[no-multiple-empty-lines]: https://eslint.org/docs/rules/no-multiple-empty-lines