### PR TITLE
Chore: Add link to Playground on documentation page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -47,7 +47,8 @@ module.exports = {
     nav: [
       { text: 'User Guide', link: '/user-guide/' },
       { text: 'Developer Guide', link: '/developer-guide/' },
-      { text: 'Rules', link: '/rules/' }
+      { text: 'Rules', link: '/rules/' },
+      { text: 'Demo', link: 'https://mysticatea.github.io/vue-eslint-demo' }
     ],
 
     sidebar: {


### PR DESCRIPTION
Added a link to [Playground](https://mysticatea.github.io/vue-eslint-demo) on the [documentation page](https://vuejs.github.io/eslint-plugin-vue/).