### PR TITLE
⭐️New: Add `vue/arrow-spacing` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -140,6 +140,7 @@ For example:
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [vue/array-bracket-spacing](./array-bracket-spacing.md) | enforce consistent spacing inside array brackets | :wrench: |
+| [vue/arrow-spacing](./arrow-spacing.md) | enforce consistent spacing before and after the arrow in arrow functions | :wrench: |
 | [vue/component-name-in-template-casing](./component-name-in-template-casing.md) | enforce specific casing for the component naming style in template | :wrench: |
 | [vue/eqeqeq](./eqeqeq.md) | require the use of `===` and `!==` | :wrench: |
 | [vue/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in object literal properties | :wrench: |

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -1,0 +1,23 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/arrow-spacing
+description: enforce consistent spacing before and after the arrow in arrow functions
+---
+# vue/arrow-spacing
+> enforce consistent spacing before and after the arrow in arrow functions
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [arrow-spacing] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [arrow-spacing]
+
+[arrow-spacing]: https://eslint.org/docs/rules/arrow-spacing
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/arrow-spacing.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/arrow-spacing.js)

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -6,6 +6,7 @@
 module.exports = {
   rules: {
     'vue/array-bracket-spacing': 'off',
+    'vue/arrow-spacing': 'off',
     'vue/html-closing-bracket-newline': 'off',
     'vue/html-closing-bracket-spacing': 'off',
     'vue/html-indent': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@
 module.exports = {
   rules: {
     'array-bracket-spacing': require('./rules/array-bracket-spacing'),
+    'arrow-spacing': require('./rules/arrow-spacing'),
     'attribute-hyphenation': require('./rules/attribute-hyphenation'),
     'attributes-order': require('./rules/attributes-order'),
     'comment-directive': require('./rules/comment-directive'),

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -1,0 +1,9 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line
+module.exports = wrapCoreRule(require('eslint/lib/rules/arrow-spacing'))

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -1,0 +1,125 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/arrow-spacing')
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('arrow-spacing', rule, {
+  valid: [
+    `<template>
+      <div :attr="() => a" />
+    </template>`,
+    `<template>
+      <div @click="() => a" />
+    </template>`,
+    `<template>
+      <div @click="
+        const fn = () => a
+        fn()
+      " />
+    </template>`,
+    {
+      code: `
+        <template>
+          <div :attr="()=>a" />
+        </template>`,
+      options: [{ before: false, after: false }]
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        <template>
+          <div :attr="()=>a" />
+        </template>`,
+      output: `
+        <template>
+          <div :attr="() => a" />
+        </template>`,
+      errors: [
+        {
+          message: 'Missing space before =>.',
+          line: 3
+        },
+        {
+          message: 'Missing space after =>.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div @click="()=>a" />
+        </template>`,
+      output: `
+        <template>
+          <div @click="() => a" />
+        </template>`,
+      errors: [
+        {
+          message: 'Missing space before =>.',
+          line: 3
+        },
+        {
+          message: 'Missing space after =>.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div @click="
+            const fn = ()=>a
+            fn()
+          " />
+        </template>`,
+      output: `
+        <template>
+          <div @click="
+            const fn = () => a
+            fn()
+          " />
+        </template>`,
+      errors: [
+        {
+          message: 'Missing space before =>.',
+          line: 4
+        },
+        {
+          message: 'Missing space after =>.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div :attr="() => a" />
+        </template>`,
+      options: [{ before: false, after: false }],
+      output: `
+        <template>
+          <div :attr="()=>a" />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected space before =>.',
+          line: 3
+        },
+        {
+          message: 'Unexpected space after =>.',
+          line: 3
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the `arrow-spacing` core rule to apply to the expressions in `<template>`.