### PR TITLE
⭐️New: Add `vue/comma-spacing` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -141,6 +141,7 @@ For example:
 |:--------|:------------|:---|
 | [vue/array-bracket-spacing](./array-bracket-spacing.md) | enforce consistent spacing inside array brackets | :wrench: |
 | [vue/arrow-spacing](./arrow-spacing.md) | enforce consistent spacing before and after the arrow in arrow functions | :wrench: |
+| [vue/comma-spacing](./comma-spacing.md) | enforce consistent spacing before and after commas | :wrench: |
 | [vue/component-name-in-template-casing](./component-name-in-template-casing.md) | enforce specific casing for the component naming style in template | :wrench: |
 | [vue/eqeqeq](./eqeqeq.md) | require the use of `===` and `!==` | :wrench: |
 | [vue/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in object literal properties | :wrench: |

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -1,0 +1,23 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/comma-spacing
+description: enforce consistent spacing before and after commas
+---
+# vue/comma-spacing
+> enforce consistent spacing before and after commas
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [comma-spacing] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [comma-spacing]
+
+[comma-spacing]: https://eslint.org/docs/rules/comma-spacing
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/comma-spacing.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/comma-spacing.js)

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -7,6 +7,7 @@ module.exports = {
   rules: {
     'vue/array-bracket-spacing': 'off',
     'vue/arrow-spacing': 'off',
+    'vue/comma-spacing': 'off',
     'vue/html-closing-bracket-newline': 'off',
     'vue/html-closing-bracket-spacing': 'off',
     'vue/html-indent': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ module.exports = {
     'arrow-spacing': require('./rules/arrow-spacing'),
     'attribute-hyphenation': require('./rules/attribute-hyphenation'),
     'attributes-order': require('./rules/attributes-order'),
+    'comma-spacing': require('./rules/comma-spacing'),
     'comment-directive': require('./rules/comment-directive'),
     'component-name-in-template-casing': require('./rules/component-name-in-template-casing'),
     'eqeqeq': require('./rules/eqeqeq'),

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -1,0 +1,9 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line
+module.exports = wrapCoreRule(require('eslint/lib/rules/comma-spacing'))

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -22,9 +22,24 @@ const vueEslintParser = require('vue-eslint-parser')
  * @param {TokenStore} tokenStore The token store object for template.
  */
 function wrapContextToOverrideTokenMethods (context, tokenStore) {
-  const sourceCode = new Proxy(context.getSourceCode(), {
+  const eslintSourceCode = context.getSourceCode()
+  let tokensAndComments
+  function getTokensAndComments () {
+    if (tokensAndComments) {
+      return tokensAndComments
+    }
+    const templateBody = eslintSourceCode.ast.templateBody
+    tokensAndComments = templateBody ? tokenStore.getTokens(templateBody, {
+      includeComments: true
+    }) : []
+    return tokensAndComments
+  }
+  const sourceCode = new Proxy(Object.assign({}, eslintSourceCode), {
     get (object, key) {
-      return key in tokenStore ? tokenStore[key] : object[key]
+      if (key === 'tokensAndComments') {
+        return getTokensAndComments()
+      }
+      return key in tokenStore ? tokenStore[key] : eslintSourceCode[key]
     }
   })
 

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -1,0 +1,274 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/comma-spacing')
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('comma-spacing', rule, {
+  valid: [
+    `<template>
+      <button @click="
+        var foo = 1, bar = 2;
+      ">
+        OK
+      </button>
+    </template>`,
+    `<template>
+      <DateInput :value="[2000, 12, 31]" />
+    </template>`,
+    `<template>
+      <DateInput :value="{y: 2000, m: 12, d: 31}" />
+    </template>`,
+    `<template>
+      <CustomDlg @ok="foo(a, b)" />
+    </template>`,
+    `<template>
+      <CustomDlg @ok="(a, b) => {}" />
+    </template>`,
+    `<template>
+      <CustomDlg @ok="function (a, b) {}" />
+    </template>`,
+    `<template>
+      <CustomList>
+        <li slot-scope="a, b">{{ a }}</li>
+      </CustomList>
+    </template>`,
+    {
+      code: `
+        <template>
+          <button @click="
+            fn(a ,b)
+          "/>
+        </template>`,
+      options: [{ before: true, after: false }]
+    },
+    `<script>
+    fn = (a,b) => {}
+    </script>`,
+    `fn = (a,b) => {}`
+  ],
+  invalid: [
+    {
+      code: `
+        <template>
+          <button @click="
+            var foo = 1 ,bar = 2;
+          ">
+            NG
+          </button>
+        </template>`,
+      output: `
+        <template>
+          <button @click="
+            var foo = 1, bar = 2;
+          ">
+            NG
+          </button>
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 4,
+          column: 25
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 4,
+          column: 25
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <DateInput :value="[2000 ,12 ,31]" />
+        </template>`,
+      output: `
+        <template>
+          <DateInput :value="[2000, 12, 31]" />
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        },
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <DateInput :value="{y: 2000 ,m: 12 ,d: 31}" />
+        </template>`,
+      output: `
+        <template>
+          <DateInput :value="{y: 2000, m: 12, d: 31}" />
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        },
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <CustomDlg @ok="foo(a ,b)" />
+        </template>`,
+      output: `
+        <template>
+          <CustomDlg @ok="foo(a, b)" />
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <CustomDlg @ok="(a ,b) => {}" />
+        </template>`,
+      output: `
+        <template>
+          <CustomDlg @ok="(a, b) => {}" />
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <CustomDlg @ok="function (a ,b) {}" />
+        </template>`,
+      output: `
+        <template>
+          <CustomDlg @ok="function (a, b) {}" />
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <CustomList>
+            <li slot-scope="a ,b">{{ a }}</li>
+          </CustomList>
+        </template>`,
+      output: `
+        <template>
+          <CustomList>
+            <li slot-scope="a, b">{{ a }}</li>
+          </CustomList>
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 4
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          {{ [a /*comment*/ ,/*comment*/b] }}
+        </template>`,
+      output: `
+        <template>
+          {{ [a /*comment*/, /*comment*/b] }}
+        </template>`,
+      errors: [
+        {
+          message: 'There should be no space before \',\'.',
+          line: 3
+        },
+        {
+          message: 'A space is required after \',\'.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <button @click="
+            fn(a, b)
+          "/>
+        </template>`,
+      options: [{ before: true, after: false }],
+      output: `
+        <template>
+          <button @click="
+            fn(a ,b)
+          "/>
+        </template>`,
+      errors: [
+        {
+          message: 'A space is required before \',\'.',
+          line: 4
+        },
+        {
+          message: 'There should be no space after \',\'.',
+          line: 4
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the `comma-spacing` core rule to apply to the expressions in `<template>`.
