### PR TITLE
⭐️New: Add `vue/block-spacing` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -140,6 +140,7 @@ For example:
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [vue/array-bracket-spacing](./array-bracket-spacing.md) | enforce consistent spacing inside array brackets | :wrench: |
+| [vue/block-spacing](./block-spacing.md) | disallow or enforce spaces inside of blocks after opening block and before closing block | :wrench: |
 | [vue/component-name-in-template-casing](./component-name-in-template-casing.md) | enforce specific casing for the component naming style in template | :wrench: |
 | [vue/eqeqeq](./eqeqeq.md) | require the use of `===` and `!==` | :wrench: |
 | [vue/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in object literal properties | :wrench: |

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -1,0 +1,23 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/block-spacing
+description: disallow or enforce spaces inside of blocks after opening block and before closing block
+---
+# vue/block-spacing
+> disallow or enforce spaces inside of blocks after opening block and before closing block
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [block-spacing] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [block-spacing]
+
+[block-spacing]: https://eslint.org/docs/rules/block-spacing
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/block-spacing.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/block-spacing.js)

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -6,6 +6,7 @@
 module.exports = {
   rules: {
     'vue/array-bracket-spacing': 'off',
+    'vue/block-spacing': 'off',
     'vue/html-closing-bracket-newline': 'off',
     'vue/html-closing-bracket-spacing': 'off',
     'vue/html-indent': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ module.exports = {
     'array-bracket-spacing': require('./rules/array-bracket-spacing'),
     'attribute-hyphenation': require('./rules/attribute-hyphenation'),
     'attributes-order': require('./rules/attributes-order'),
+    'block-spacing': require('./rules/block-spacing'),
     'comment-directive': require('./rules/comment-directive'),
     'component-name-in-template-casing': require('./rules/component-name-in-template-casing'),
     'eqeqeq': require('./rules/eqeqeq'),

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -1,0 +1,9 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line
+module.exports = wrapCoreRule(require('eslint/lib/rules/block-spacing'))

--- a/tests/lib/rules/block-spacing.js
+++ b/tests/lib/rules/block-spacing.js
@@ -1,0 +1,115 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/block-spacing')
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('block-spacing', rule, {
+  valid: [
+    '<template><div :attr="function foo() { return true; }" /></template>',
+    {
+      code: '<template><div :attr="function foo() {return true;}" /></template>',
+      options: ['never']
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        <template>
+          <div :attr="function foo() {return true;}" />
+        </template>`,
+      output: `
+        <template>
+          <div :attr="function foo() { return true; }" />
+        </template>`,
+      errors: [
+        {
+          messageId: 'missing',
+          data: {
+            location: 'after',
+            token: '{'
+          },
+          // message: 'Requires a space after \'{\'',
+          line: 3
+        },
+        {
+          messageId: 'missing',
+          data: {
+            location: 'before',
+            token: '}'
+          },
+          // message: 'Requires a space before \'}\'',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <button @click="() => {return true;}" />
+        </template>`,
+      output: `
+        <template>
+          <button @click="() => { return true; }" />
+        </template>`,
+      errors: [
+        {
+          messageId: 'missing',
+          data: {
+            location: 'after',
+            token: '{'
+          },
+          // message: 'Requires a space after \'{\'',
+          line: 3
+        },
+        {
+          messageId: 'missing',
+          data: {
+            location: 'before',
+            token: '}'
+          },
+          // message: 'Requires a space before \'}\'',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div :attr="function foo() { return true; }" />
+        </template>`,
+      options: ['never'],
+      output: `
+        <template>
+          <div :attr="function foo() {return true;}" />
+        </template>`,
+      errors: [
+        {
+          messageId: 'extra',
+          data: {
+            location: 'after',
+            token: '{'
+          },
+          // message: 'Unexpected space(s) after \'{\'',
+          line: 3
+        },
+        {
+          messageId: 'extra',
+          data: {
+            location: 'before',
+            token: '}'
+          },
+          // message: 'Unexpected space(s) before \'}\'',
+          line: 3
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the `block-spacing` core rule to apply to the expressions in `<template>`.