### PR TITLE
fix(no-unused-components): crash when `:is` in `<component>` is empty

### DIFF
--- a/lib/rules/no-unused-components.js
+++ b/lib/rules/no-unused-components.js
@@ -56,7 +56,11 @@ module.exports = {
         usedComponents.add(node.rawName)
       },
       "VAttribute[directive=true][key.name='bind'][key.argument='is']" (node) {
-        if (node.value.type !== 'VExpressionContainer') return
+        if (
+          !node.value ||  // `<component :is>`
+          node.value.type !== 'VExpressionContainer' ||
+          !node.value.expression  // `<component :is="">`
+        ) return
 
         if (node.value.expression.type === 'Literal') {
           usedComponents.add(node.value.expression.value)

--- a/tests/lib/rules/no-unused-components.js
+++ b/tests/lib/rules/no-unused-components.js
@@ -411,6 +411,22 @@ tester.run('no-unused-components', rule, {
           }
         }
       </script>`
+    },
+
+    // empty `:is`
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <component :is=""></component>
+      </template>`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <component :is></component>
+      </template>`
     }
   ],
   invalid: [
@@ -511,6 +527,44 @@ tester.run('no-unused-components', rule, {
       }, {
         message: 'The "Bar" component has been registered but not used.',
         line: 14
+      }]
+    },
+
+    // empty `:is`
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <component :is=""></component>
+      </template>
+      <script>
+        export default {
+          components: {
+            Foo,
+          },
+        }
+      </script>`,
+      errors: [{
+        message: 'The "Foo" component has been registered but not used.',
+        line: 8
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <component :is></component>
+      </template>
+      <script>
+        export default {
+          components: {
+            Foo,
+          },
+        }
+      </script>`,
+      errors: [{
+        message: 'The "Foo" component has been registered but not used.',
+        line: 8
       }]
     }
   ]


### PR DESCRIPTION
Fixed #789