### PR TITLE
⭐️New: Add `vue/dot-location` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -146,6 +146,7 @@ For example:
 | [vue/camelcase](./camelcase.md) | enforce camelcase naming convention |  |
 | [vue/comma-dangle](./comma-dangle.md) | require or disallow trailing commas | :wrench: |
 | [vue/component-name-in-template-casing](./component-name-in-template-casing.md) | enforce specific casing for the component naming style in template | :wrench: |
+| [vue/dot-location](./dot-location.md) | enforce consistent newlines before and after dots | :wrench: |
 | [vue/eqeqeq](./eqeqeq.md) | require the use of `===` and `!==` | :wrench: |
 | [vue/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in object literal properties | :wrench: |
 | [vue/match-component-file-name](./match-component-file-name.md) | require component name property to match its file name |  |

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -1,0 +1,23 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/dot-location
+description: enforce consistent newlines before and after dots
+---
+# vue/dot-location
+> enforce consistent newlines before and after dots
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [dot-location] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [dot-location]
+
+[dot-location]: https://eslint.org/docs/rules/dot-location
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/dot-location.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/dot-location.js)

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -10,6 +10,7 @@ module.exports = {
     'vue/block-spacing': 'off',
     'vue/brace-style': 'off',
     'vue/comma-dangle': 'off',
+    'vue/dot-location': 'off',
     'vue/html-closing-bracket-newline': 'off',
     'vue/html-closing-bracket-spacing': 'off',
     'vue/html-indent': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'comma-dangle': require('./rules/comma-dangle'),
     'comment-directive': require('./rules/comment-directive'),
     'component-name-in-template-casing': require('./rules/component-name-in-template-casing'),
+    'dot-location': require('./rules/dot-location'),
     'eqeqeq': require('./rules/eqeqeq'),
     'html-closing-bracket-newline': require('./rules/html-closing-bracket-newline'),
     'html-closing-bracket-spacing': require('./rules/html-closing-bracket-spacing'),

--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -1,0 +1,9 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line
+module.exports = wrapCoreRule(require('eslint/lib/rules/dot-location'))

--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -1,0 +1,80 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/dot-location')
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('dot-location', rule, {
+  valid: [
+    `<template>
+      <div
+        :attr="foo.
+          bar"
+      />
+    </template>`,
+    {
+      code: `
+      <template>
+        <div
+          :attr="foo
+            .bar"
+        />
+      </template>`,
+      options: ['property']
+    }
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div
+          :attr="foo
+            .bar"
+        />
+      </template>`,
+      output: `
+      <template>
+        <div
+          :attr="foo.
+            bar"
+        />
+      </template>`,
+      errors: [
+        {
+          message: 'Expected dot to be on same line as object.',
+          line: 5
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div
+          :attr="foo.
+            bar"
+        />
+      </template>`,
+      options: ['property'],
+      output: `
+      <template>
+        <div
+          :attr="foo
+            .bar"
+        />
+      </template>`,
+      errors: [
+        {
+          message: 'Expected dot to be on same line as property.',
+          line: 4
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [dot-location](https://eslint.org/docs/rules/dot-location) core rule to apply to the expressions in `<template>`.