### PR TITLE
⭐️New: Add `vue/no-empty-pattern` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -150,6 +150,7 @@ For example:
 | [vue/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in object literal properties | :wrench: |
 | [vue/match-component-file-name](./match-component-file-name.md) | require component name property to match its file name |  |
 | [vue/no-boolean-default](./no-boolean-default.md) | disallow boolean defaults | :wrench: |
+| [vue/no-empty-pattern](./no-empty-pattern.md) | disallow empty destructuring patterns |  |
 | [vue/no-restricted-syntax](./no-restricted-syntax.md) | disallow specified syntax |  |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |
 | [vue/require-direct-export](./require-direct-export.md) | require the component to be directly exported |  |

--- a/docs/rules/no-empty-pattern.md
+++ b/docs/rules/no-empty-pattern.md
@@ -1,0 +1,21 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-empty-pattern
+description: disallow empty destructuring patterns
+---
+# vue/no-empty-pattern
+> disallow empty destructuring patterns
+
+This rule is the same rule as core [no-empty-pattern] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [no-empty-pattern]
+
+[no-empty-pattern]: https://eslint.org/docs/rules/no-empty-pattern
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-empty-pattern.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-empty-pattern.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ module.exports = {
     'no-confusing-v-for-v-if': require('./rules/no-confusing-v-for-v-if'),
     'no-dupe-keys': require('./rules/no-dupe-keys'),
     'no-duplicate-attributes': require('./rules/no-duplicate-attributes'),
+    'no-empty-pattern': require('./rules/no-empty-pattern'),
     'no-multi-spaces': require('./rules/no-multi-spaces'),
     'no-parsing-error': require('./rules/no-parsing-error'),
     'no-reserved-keys': require('./rules/no-reserved-keys'),

--- a/lib/rules/no-empty-pattern.js
+++ b/lib/rules/no-empty-pattern.js
@@ -1,0 +1,9 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line
+module.exports = wrapCoreRule(require('eslint/lib/rules/no-empty-pattern'))

--- a/tests/lib/rules/no-empty-pattern.js
+++ b/tests/lib/rules/no-empty-pattern.js
@@ -1,0 +1,252 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-empty-pattern')
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: { ecmaVersion: 2018 }
+})
+
+tester.run('no-empty-pattern', rule, {
+  valid: [
+    `<template>
+      <div
+        @attr="() => {
+          var {a = {}} = foo;
+          var {a = []} = foo;
+        }"
+      />
+    </template>`,
+    `<template>
+      <div
+        @attr="function foo({a = {}}) {}"
+      />
+    </template>`,
+    `<template>
+      <div
+        @attr="function foo({a = []}) {}"
+      />
+    </template>`,
+    `<template>
+      <div
+        @attr="({a = {}}) => a"
+      />
+    </template>`,
+    `<template>
+      <div
+        @attr="({a = []}) => a"
+      />
+    </template>`,
+    `<template>
+      <div
+        slot-scope="{a = []}"
+      />
+    </template>`
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div
+          @attr="() => {
+            var {} = foo;
+            var [] = foo;
+            var {a: {}} = foo;
+            var {a: []} = foo;
+          }"
+        />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 5
+        },
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 6
+        },
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 7
+        },
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 8
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="function foo({}) {}"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="function foo([]) {}"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="function foo({a: {}}) {}"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="function foo({a: []}) {}"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="({}) => foo()"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="([]) => foo()"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="({a: {}}) => a"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+          <div
+            @attr="({a: []}) => a"
+          />
+        </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div
+          slot-scope="{}"
+        />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div
+          slot-scope="[]"
+        />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div
+          slot-scope="{a: {}}"
+        />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty object pattern.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div
+          slot-scope="{a: []}"
+        />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected empty array pattern.',
+          line: 4
+        }
+      ]
+    }
+
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [no-empty-pattern](https://eslint.org/docs/rules/no-empty-pattern) core rule to apply to the expressions in `<template>`.