### PR TITLE
Fix no async with empty returns

### DIFF
--- a/lib/rules/no-async-in-computed-properties.js
+++ b/lib/rules/no-async-in-computed-properties.js
@@ -138,8 +138,11 @@ module.exports = {
 
         'ReturnStatement' (node) {
           if (
-            node.argument.type === 'ObjectExpression' ||
-            node.argument.type === 'ArrayExpression'
+            node.argument &&
+            (
+              node.argument.type === 'ObjectExpression' ||
+              node.argument.type === 'ArrayExpression'
+            )
           ) {
             allowedScopes.push(node.argument)
           }

--- a/tests/lib/rules/no-async-in-computed-properties.js
+++ b/tests/lib/rules/no-async-in-computed-properties.js
@@ -29,6 +29,19 @@ ruleTester.run('no-async-in-computed-properties', rule, {
       filename: 'test.vue',
       code: `
         export default {
+          computed: {
+            foo: function () {
+              return;
+            },
+          }
+        }
+      `,
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
           ...foo,
           computed: {
             ...mapGetters({


### PR DESCRIPTION
no-async-in-computed-properties errors out when there is no return value in a function.