### PR TITLE
⭐️attributes-order: Allow customize order for specific attribute

### DIFF
--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -39,7 +39,17 @@ function getAttributeType (name, isDirective) {
   }
 }
 function getPosition (attribute, attributePosition) {
-  const attributeType = attribute.directive && attribute.key.name === 'bind'
+  const isBind = attribute.directive && attribute.key.name === 'bind'
+  let attributeName = attribute.key.name
+  if (isBind) {
+    attributeName = `:${attribute.key.argument}`
+  } else if (attribute.directive) {
+    attributeName = `v-${attribute.key.name}`
+  }
+  if (attributePosition.hasOwnProperty(attributeName)) {
+    return attributePosition[attributeName]
+  }
+  const attributeType = isBind
     ? getAttributeType(attribute.key.argument, false)
     : getAttributeType(attribute.key.name, attribute.directive)
   return attributePosition.hasOwnProperty(attributeType) ? attributePosition[attributeType] : -1

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -282,6 +282,7 @@ tester.run('attributes-order', rule, {
       code:
         `<template>
           <div
+            v-important
             class="content"
             :class="className"
             v-if="!visible"
@@ -292,36 +293,7 @@ tester.run('attributes-order', rule, {
       options: [
         { order:
           [
-            ['class', ':class'],
-            'DEFINITION',
-            'LIST_RENDERING',
-            'CONDITIONALS',
-            'RENDER_MODIFIERS',
-            'GLOBAL',
-            'UNIQUE',
-            'TWO_WAY_BINDING',
-            'OTHER_DIRECTIVES',
-            'OTHER_ATTR',
-            'EVENTS',
-            'CONTENT'
-          ]
-        }]
-    },
-    {
-      filename: 'test.vue',
-      code:
-        `<template>
-          <div
-            v-important
-            v-if="!visible"
-            v-foo
-            >
-          </div>
-        </template>`,
-      options: [
-        { order:
-          [
-            'v-important',
+            ['class', ':class', 'v-important'],
             'DEFINITION',
             'LIST_RENDERING',
             'CONDITIONALS',
@@ -343,6 +315,7 @@ tester.run('attributes-order', rule, {
           <div
             class="content"
             v-if="!visible"
+            v-directive
             :class="className"
             >
           </div>
@@ -362,6 +335,36 @@ tester.run('attributes-order', rule, {
             'OTHER_ATTR',
             'EVENTS',
             'CONTENT'
+          ]
+        }]
+    },
+    {
+      filename: 'test.vue',
+      code:
+        `<template>
+          <div
+            v-text="textContent"
+            v-model="model"
+            class="content"
+            :class="className"
+            >
+          </div>
+        </template>`,
+      options: [
+        { order:
+          [
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'UNIQUE',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT',
+            ['class', ':class', 'v-model']
           ]
         }]
     }

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -276,6 +276,94 @@ tester.run('attributes-order', rule, {
             'GLOBAL'
           ]
         }]
+    },
+    {
+      filename: 'test.vue',
+      code:
+        `<template>
+          <div
+            class="content"
+            :class="className"
+            v-if="!visible"
+            v-text="textContent"
+            >
+          </div>
+        </template>`,
+      options: [
+        { order:
+          [
+            ['class', ':class'],
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'UNIQUE',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT'
+          ]
+        }]
+    },
+    {
+      filename: 'test.vue',
+      code:
+        `<template>
+          <div
+            v-important
+            v-if="!visible"
+            v-foo
+            >
+          </div>
+        </template>`,
+      options: [
+        { order:
+          [
+            'v-important',
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'UNIQUE',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT'
+          ]
+        }]
+    },
+    {
+      filename: 'test.vue',
+      code:
+        `<template>
+          <div
+            class="content"
+            v-if="!visible"
+            :class="className"
+            >
+          </div>
+        </template>`,
+      options: [
+        { order:
+          [
+            'class',
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'UNIQUE',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT'
+          ]
+        }]
     }
   ],
 
@@ -581,6 +669,49 @@ tester.run('attributes-order', rule, {
       errors: [
         {
           message: 'Attribute "v-if" should go before "class".',
+          nodeType: 'VIdentifier'
+        }
+      ]
+    },
+    {
+      code:
+        `<template>
+          <div
+            class="content"
+            :class="className"
+            v-if="!visible"
+            >
+          </div>
+        </template>`,
+      options: [
+        { order:
+          [
+            'class',
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'UNIQUE',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT'
+          ]
+        }],
+      output:
+        `<template>
+          <div
+            class="content"
+            v-if="!visible"
+            :class="className"
+            >
+          </div>
+        </template>`,
+      errors: [
+        {
+          message: 'Attribute "v-if" should go before ":class".',
           nodeType: 'VIdentifier'
         }
       ]

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -718,6 +718,47 @@ tester.run('attributes-order', rule, {
           nodeType: 'VIdentifier'
         }
       ]
+    },
+    {
+      code:
+        `<template>
+          <div
+            class="content"
+            v-text="textContent"
+            >
+          </div>
+        </template>`,
+      options: [
+        { order:
+          [
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'UNIQUE',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT',
+            'class'
+          ]
+        }],
+      output:
+        `<template>
+          <div
+            v-text="textContent"
+            class="content"
+            >
+          </div>
+        </template>`,
+      errors: [
+        {
+          message: 'Attribute "v-text" should go before "class".',
+          nodeType: 'VIdentifier'
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
This PR allow customize order for specific attributes.

e.g. place `class` before other attributes:

```javascript
{
  "vue/attributes-order": ["error", {
    "order": [
      ["class", ":class"],
      // ...DEFAULT_ORDERS
    ]
  }]
}
```