### PR TITLE
Fix: no-boolean-default with 'default-false' on boolean props with unset default

### DIFF
--- a/lib/rules/no-boolean-default.js
+++ b/lib/rules/no-boolean-default.js
@@ -78,10 +78,13 @@ module.exports = {
             break
 
           case 'default-false':
-            if (defaultNode.value.value !== false) {
+            if (
+              defaultNode &&
+              defaultNode.value.value !== false
+            ) {
               context.report({
                 node: defaultNode,
-                message: 'Boolean prop should be defaulted to false.'
+                message: 'Boolean prop should only be defaulted to false.'
               })
             }
             break

--- a/tests/lib/rules/no-boolean-default.js
+++ b/tests/lib/rules/no-boolean-default.js
@@ -38,11 +38,73 @@ ruleTester.run('no-boolean-default', rule, {
     {
       filename: 'test.vue',
       code: `
+        export default {
+          props: {
+            enabled: Boolean
+          }
+        }
+      `,
+      options: ['no-default']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: {
+            enabled: Boolean
+          }
+        }
+      `,
+      options: ['default-false']
+    },
+    {
+      filename: 'test.vue',
+      code: `
         const props = {};
         export default {
           props: {
             ...props,
             enabled: Boolean
+          }
+        }
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const props = {};
+        export default {
+          props: {
+            ...props,
+            enabled: Boolean
+          }
+        }
+      `,
+      options: ['no-default']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const props = {};
+        export default {
+          props: {
+            ...props,
+            enabled: Boolean
+          }
+        }
+      `,
+      options: ['default-false']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const data = {};
+        export default {
+          props: {
+            enabled: {
+              type: Boolean,
+              ...data
+            }
           }
         }
       `
@@ -61,6 +123,21 @@ ruleTester.run('no-boolean-default', rule, {
         }
       `,
       options: ['no-default']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const data = {};
+        export default {
+          props: {
+            enabled: {
+              type: Boolean,
+              ...data
+            }
+          }
+        }
+      `,
+      options: ['default-false']
     },
     {
       filename: 'test.vue',
@@ -95,12 +172,64 @@ ruleTester.run('no-boolean-default', rule, {
         const data = {};
         export default {
           props: {
+            enabled: data
+          }
+        }
+      `,
+      options: ['no-default']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const data = {};
+        export default {
+          props: {
+            enabled: data
+          }
+        }
+      `,
+      options: ['default-false']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const data = {};
+        export default {
+          props: {
             enabled: {
               ...data
             }
           }
         }
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const data = {};
+        export default {
+          props: {
+            enabled: {
+              ...data
+            }
+          }
+        }
+      `,
+      options: ['no-default']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const data = {};
+        export default {
+          props: {
+            enabled: {
+              ...data
+            }
+          }
+        }
+      `,
+      options: ['default-false']
     }
   ],
 
@@ -119,7 +248,7 @@ ruleTester.run('no-boolean-default', rule, {
       `,
       options: ['default-false'],
       errors: [{
-        message: 'Boolean prop should be defaulted to false.',
+        message: 'Boolean prop should only be defaulted to false.',
         line: 6
       }]
     },
@@ -137,7 +266,7 @@ ruleTester.run('no-boolean-default', rule, {
       `,
       options: ['default-false'],
       errors: [{
-        message: 'Boolean prop should be defaulted to false.',
+        message: 'Boolean prop should only be defaulted to false.',
         line: 6
       }]
     },
@@ -149,6 +278,24 @@ ruleTester.run('no-boolean-default', rule, {
             enabled: {
               type: Boolean,
               default: false,
+            }
+          }
+        }
+      `,
+      options: ['no-default'],
+      errors: [{
+        message: 'Boolean prop should not set a default (Vue defaults it to false).',
+        line: 6
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: {
+            enabled: {
+              type: Boolean,
+              default: true,
             }
           }
         }


### PR DESCRIPTION
Currently the rule `no-boolean-default` breaks when used with option `'default-false'` on a boolean prop that does not have `default` property, with exception:
```
TypeError: Cannot read property 'value' of undefined
      at booleanProps.forEach.propDef (lib/rules/no-boolean-default.js:7:2342)
      at Array.forEach (<anonymous>)
      at utils.executeOnVueComponent.obj (lib/rules/no-boolean-default.js:7:1808)
      at ExportDefaultDeclaration:exit (lib/utils/index.js:174:251)
      at listeners.(anonymous function).forEach.listener (node_modules/eslint/lib/util/safe-emitter.js:45:58)
      at Array.forEach (<anonymous>)
      at Object.emit (node_modules/eslint/lib/util/safe-emitter.js:45:38)
      at NodeEventGenerator.applySelector (node_modules/eslint/lib/util/node-event-generator.js:251:26)
      at NodeEventGenerator.applySelectors (node_modules/eslint/lib/util/node-event-generator.js:280:22)
      at NodeEventGenerator.leaveNode (node_modules/eslint/lib/util/node-event-generator.js:303:14)
      at CodePathAnalyzer.leaveNode (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:654:23)
      at nodeQueue.forEach.traversalInfo (node_modules/eslint/lib/linter.js:752:28)
      at Array.forEach (<anonymous>)
      at runRules (node_modules/eslint/lib/linter.js:746:15)
      at Linter._verifyWithoutProcessors (node_modules/eslint/lib/linter.js:891:31)
      at preprocess.map.textBlock (node_modules/eslint/lib/linter.js:940:35)
      at Array.map (<anonymous>)
      at Linter.verify (node_modules/eslint/lib/linter.js:939:42)
      at runRuleForItem (node_modules/eslint/lib/testers/rule-tester.js:385:34)
      at testValidTemplate (node_modules/eslint/lib/testers/rule-tester.js:412:28)
      at Context.RuleTester.it (node_modules/eslint/lib/testers/rule-tester.js:584:25)
```

This PR adds tests that expose the issue (simply the same cases but applied without options and with each option where applicable) and a check for a falsy value returned from `getDefaultNode(propDef)`.

Also, changed the error message for `'default-false'` option a bit, as "Boolean prop should be defaulted to false." may mean that it "should be defaulted", while the logic is "can be defaulted or not, but if it is, it must only be false".