### PR TITLE
Use correct 'v-on-function-call' rule name in options example

### DIFF
--- a/docs/rules/v-on-function-call.md
+++ b/docs/rules/v-on-function-call.md
@@ -32,7 +32,7 @@ description: enforce or forbid parentheses after method calls without arguments 
 Default is set to `never`.
 
 ```
-'vue/v-on-parens': [2, 'always'|'never']
+'vue/v-on-function-call': [2, 'always'|'never']
 ```
 
 ### `"always"` - Always use parentheses in `v-on` directives


### PR DESCRIPTION
Seems like it was missed in the original #481 PR.