### PR TITLE
Rule documentation should match change in #606

### DIFF
--- a/docs/rules/no-unused-components.md
+++ b/docs/rules/no-unused-components.md
@@ -74,7 +74,7 @@ This rule reports components that haven't been used in the template.
 </eslint-code-block>
 
 ::: warning Note
-Components registered under other than `PascalCase` name have to be called directly under the specified name, whereas if you register it using `PascalCase` you can call it however you like, except using `snake_case`.
+Components registered under `PascalCase` or `camelCase` names have may be called however you like, except using `snake_case`. Otherwise, they will need to be called directly under the specified name.
 :::
 
 ## :wrench: Options


### PR DESCRIPTION
In #606, the rule `no-unused-component` was updated to detect component usage when registered using camelCase as well as PascalCase.

There's a line of text in the documentation that still states PascalCase as required.  It'd be nice to update that.