### PR TITLE
⭐️New: Add vue/no-deprecated-slot-scope-attribute rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -153,6 +153,7 @@ For example:
 | [vue/match-component-file-name](./match-component-file-name.md) | require component name property to match its file name |  |
 | [vue/no-boolean-default](./no-boolean-default.md) | disallow boolean defaults | :wrench: |
 | [vue/no-deprecated-scope-attribute](./no-deprecated-scope-attribute.md) | disallow deprecated `scope` attribute (in Vue.js 2.5.0+) | :wrench: |
+| [vue/no-deprecated-slot-scope-attribute](./no-deprecated-slot-scope-attribute.md) | disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+) | :wrench: |
 | [vue/no-empty-pattern](./no-empty-pattern.md) | disallow empty destructuring patterns |  |
 | [vue/no-restricted-syntax](./no-restricted-syntax.md) | disallow specified syntax |  |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |

--- a/docs/rules/no-deprecated-slot-scope-attribute.md
+++ b/docs/rules/no-deprecated-slot-scope-attribute.md
@@ -1,0 +1,44 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-deprecated-slot-scope-attribute
+description: disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+)
+---
+# vue/no-deprecated-slot-scope-attribute
+> disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+)
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports deprecated `slot-scope` attribute in Vue.js v2.6.0+.
+
+<eslint-code-block fix :rules="{'vue/no-deprecated-slot-scope-attribute': ['error']}">
+
+```vue
+<template>
+  <ListComponent>
+    <!-- ✓ GOOD -->
+    <template v-slot="props">
+      {{ props.title }}
+    </template>
+  </ListComponent>
+  <ListComponent>
+    <!-- ✗ BAD -->
+    <template slot-scope="props">
+      {{ props.title }}
+    </template>
+  </ListComponent>
+</template>
+```
+
+</eslint-code-block>
+
+## :books: Further reading
+
+- [API - slot-scope](https://vuejs.org/v2/api/#slot-scope-deprecated)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-deprecated-slot-scope-attribute.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-deprecated-slot-scope-attribute.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-boolean-default': require('./rules/no-boolean-default'),
     'no-confusing-v-for-v-if': require('./rules/no-confusing-v-for-v-if'),
     'no-deprecated-scope-attribute': require('./rules/no-deprecated-scope-attribute'),
+    'no-deprecated-slot-scope-attribute': require('./rules/no-deprecated-slot-scope-attribute'),
     'no-dupe-keys': require('./rules/no-dupe-keys'),
     'no-duplicate-attributes': require('./rules/no-duplicate-attributes'),
     'no-empty-pattern': require('./rules/no-empty-pattern'),

--- a/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -1,0 +1,28 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const utils = require('../utils')
+const slotScopeAttribute = require('./syntaxes/slot-scope-attribute')
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+)',
+      category: undefined,
+      url: 'https://eslint.vuejs.org/rules/no-deprecated-slot-scope-attribute.html'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      forbiddenSlotScopeAttribute: '`slot-scope` are deprecated.'
+    }
+  },
+  create (context) {
+    const templateBodyVisitor = slotScopeAttribute.createTemplateBodyVisitor(context, { fixToUpgrade: true })
+    return utils.defineTemplateBodyVisitor(context, templateBodyVisitor)
+  }
+}

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -12,15 +12,28 @@ module.exports = {
     /**
      * Checks whether the given node can convert to the `v-slot`.
      * @param {VAttribute | null} slotAttr node of `slot`
+     * @param {VElement} slotAttr node of `slot`
      * @returns {boolean} `true` if the given node can convert to the `v-slot`
      */
-    function canConvertToVSlot (slotAttr) {
-      if (!slotAttr || !slotAttr.value) {
-        return true
+    function canConvertToVSlot (slotAttr, element) {
+      if (slotAttr) {
+        if (!slotAttr.value) {
+          return true
+        }
+        const slotName = slotAttr.value.value
+        // If non-Latin characters are included it can not be converted.
+        return !/[^a-z]/i.test(slotName)
       }
-      const slotName = slotAttr.value.value
-      // If non-Latin characters are included it can not be converted.
-      return !/[^a-z]/i.test(slotName)
+
+      const vBindSlotAttr = element.attributes
+        .find(attr =>
+          attr.directive === true &&
+          attr.key.name.name === 'bind' &&
+          attr.key.argument &&
+          attr.key.argument.name === 'slot')
+      // if the element have `v-bind:slot` it can not be converted.
+      // Conversion of `v-bind:slot` is done with `vue/no-deprecated-slot-attribute`.
+      return !vBindSlotAttr
     }
 
     /**
@@ -62,7 +75,7 @@ module.exports = {
             const element = scopeAttr.parent
             const slotAttr = element.attributes
               .find(attr => attr.directive === false && attr.key.name === 'slot')
-            if (!canConvertToVSlot(slotAttr)) {
+            if (!canConvertToVSlot(slotAttr, element)) {
               return null
             }
             return fixSlotToVSlot(fixer, slotAttr, scopeAttr)

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -1,0 +1,60 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+module.exports = {
+  deprecated: '2.6.0',
+  supported: '2.5.0',
+  createTemplateBodyVisitor (context, { fixToUpgrade } = {}) {
+    const sourceCode = context.getSourceCode()
+    /**
+     * Convert to `v-slot`.
+     * @param {object} fixer fixer
+     * @param {VAttribute | null} slotAttr node of `slot`
+     * @param {VAttribute | null} scopeAttr node of `slot-scope`
+     * @returns {*} fix data
+     */
+    function fixSlotToVSlot (fixer, slotAttr, scopeAttr) {
+      const nameArgument = slotAttr && slotAttr.value && slotAttr && slotAttr.value.value
+        ? `:${slotAttr.value.value}`
+        : ''
+      const scopeValue = scopeAttr && scopeAttr.value
+        ? `=${sourceCode.getText(scopeAttr.value)}`
+        : ''
+
+      const replaceText = `v-slot${nameArgument}${scopeValue}`
+      const fixers = [
+        fixer.replaceText(slotAttr || scopeAttr, replaceText)
+      ]
+      if (slotAttr && scopeAttr) {
+        fixers.push(fixer.remove(scopeAttr))
+      }
+      return fixers
+    }
+    /**
+     * Reports `slot-scope` node
+     * @param {VAttribute} scopeAttr node of `slot-scope`
+     * @returns {void}
+     */
+    function reportSlotScope (scopeAttr) {
+      context.report({
+        node: scopeAttr.key,
+        messageId: 'forbiddenSlotScopeAttribute',
+        fix: fixToUpgrade
+          // fix to use `v-slot`
+          ? (fixer) => {
+            const element = scopeAttr.parent
+            const slotAttr = element.attributes
+              .find(attr => attr.directive === false && attr.key.name === 'slot')
+            return fixSlotToVSlot(fixer, slotAttr, scopeAttr)
+          }
+          : null
+      })
+    }
+
+    return {
+      "VAttribute[directive=true][key.name.name='slot-scope']": reportSlotScope
+    }
+  }
+}

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -8,6 +8,21 @@ module.exports = {
   supported: '2.5.0',
   createTemplateBodyVisitor (context, { fixToUpgrade } = {}) {
     const sourceCode = context.getSourceCode()
+
+    /**
+     * Checks whether the given node can convert to the `v-slot`.
+     * @param {VAttribute | null} slotAttr node of `slot`
+     * @returns {boolean} `true` if the given node can convert to the `v-slot`
+     */
+    function canConvertToVSlot (slotAttr) {
+      if (!slotAttr || !slotAttr.value) {
+        return true
+      }
+      const slotName = slotAttr.value.value
+      // If non-Latin characters are included it can not be converted.
+      return !/[^a-z]/i.test(slotName)
+    }
+
     /**
      * Convert to `v-slot`.
      * @param {object} fixer fixer
@@ -16,7 +31,7 @@ module.exports = {
      * @returns {*} fix data
      */
     function fixSlotToVSlot (fixer, slotAttr, scopeAttr) {
-      const nameArgument = slotAttr && slotAttr.value && slotAttr && slotAttr.value.value
+      const nameArgument = slotAttr && slotAttr.value && slotAttr.value.value
         ? `:${slotAttr.value.value}`
         : ''
       const scopeValue = scopeAttr && scopeAttr.value
@@ -47,6 +62,9 @@ module.exports = {
             const element = scopeAttr.parent
             const slotAttr = element.attributes
               .find(attr => attr.directive === false && attr.key.name === 'slot')
+            if (!canConvertToVSlot(slotAttr)) {
+              return null
+            }
             return fixSlotToVSlot(fixer, slotAttr, scopeAttr)
           }
           : null

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -11,54 +11,49 @@ module.exports = {
 
     /**
      * Checks whether the given node can convert to the `v-slot`.
-     * @param {VAttribute | null} slotAttr node of `slot`
-     * @param {VElement} slotAttr node of `slot`
+     * @param {VStartTag} startTag node of `<element v-slot ... >`
      * @returns {boolean} `true` if the given node can convert to the `v-slot`
      */
-    function canConvertToVSlot (slotAttr, element) {
-      if (slotAttr) {
-        if (!slotAttr.value) {
-          return true
-        }
-        const slotName = slotAttr.value.value
-        // If non-Latin characters are included it can not be converted.
-        return !/[^a-z]/i.test(slotName)
+    function canConvertToVSlot (startTag) {
+      if (startTag.parent.name !== 'template') {
+        return false
       }
 
-      const vBindSlotAttr = element.attributes
+      const slotAttr = startTag.attributes
+        .find(attr => attr.directive === false && attr.key.name === 'slot')
+      if (slotAttr) {
+        // if the element have `slot` it can not be converted.
+        // Conversion of `slot` is done with `vue/no-deprecated-slot-attribute`.
+        return false
+      }
+
+      const vBindSlotAttr = startTag.attributes
         .find(attr =>
           attr.directive === true &&
           attr.key.name.name === 'bind' &&
           attr.key.argument &&
           attr.key.argument.name === 'slot')
-      // if the element have `v-bind:slot` it can not be converted.
-      // Conversion of `v-bind:slot` is done with `vue/no-deprecated-slot-attribute`.
-      return !vBindSlotAttr
+      if (vBindSlotAttr) {
+        // if the element have `v-bind:slot` it can not be converted.
+        // Conversion of `v-bind:slot` is done with `vue/no-deprecated-slot-attribute`.
+        return false
+      }
+      return true
     }
 
     /**
      * Convert to `v-slot`.
      * @param {object} fixer fixer
-     * @param {VAttribute | null} slotAttr node of `slot`
      * @param {VAttribute | null} scopeAttr node of `slot-scope`
      * @returns {*} fix data
      */
-    function fixSlotToVSlot (fixer, slotAttr, scopeAttr) {
-      const nameArgument = slotAttr && slotAttr.value && slotAttr.value.value
-        ? `:${slotAttr.value.value}`
-        : ''
+    function fixSlotScopeToVSlot (fixer, scopeAttr) {
       const scopeValue = scopeAttr && scopeAttr.value
         ? `=${sourceCode.getText(scopeAttr.value)}`
         : ''
 
-      const replaceText = `v-slot${nameArgument}${scopeValue}`
-      const fixers = [
-        fixer.replaceText(slotAttr || scopeAttr, replaceText)
-      ]
-      if (slotAttr && scopeAttr) {
-        fixers.push(fixer.remove(scopeAttr))
-      }
-      return fixers
+      const replaceText = `v-slot${scopeValue}`
+      return fixer.replaceText(scopeAttr, replaceText)
     }
     /**
      * Reports `slot-scope` node
@@ -72,13 +67,11 @@ module.exports = {
         fix: fixToUpgrade
           // fix to use `v-slot`
           ? (fixer) => {
-            const element = scopeAttr.parent
-            const slotAttr = element.attributes
-              .find(attr => attr.directive === false && attr.key.name === 'slot')
-            if (!canConvertToVSlot(slotAttr, element)) {
+            const startTag = scopeAttr.parent
+            if (!canConvertToVSlot(startTag)) {
               return null
             }
-            return fixSlotToVSlot(fixer, slotAttr, scopeAttr)
+            return fixSlotScopeToVSlot(fixer, scopeAttr)
           }
           : null
       })

--- a/tests/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-deprecated-slot-scope-attribute')
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2015
+  }
+})
+
+tester.run('no-deprecated-slot-scope-attribute', rule, {
+  valid: [
+    `<template>
+      <LinkList>
+        <a v-slot:name />
+      </LinkList>
+    </template>`,
+    `<template>
+      <LinkList>
+        <a #name />
+      </LinkList>
+    </template>`,
+    `<template>
+      <LinkList>
+        <a v-slot="{a}" />
+      </LinkList>
+    </template>`,
+    `<template>
+      <LinkList>
+        <a #default="{a}" />
+      </LinkList>
+    </template>`,
+    `<template>
+      <LinkList>
+        <a slot="name" />
+      </LinkList>
+    </template>`,
+    `<template>
+      <LinkList>
+        <a />
+      </LinkList>
+    </template>`
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <LinkList>
+          <a slot="name" disabled slot-scope="{a}"/>
+        </LinkList>
+      </template>`,
+      output: `
+      <template>
+        <LinkList>
+          <a v-slot:name="{a}" disabled />
+        </LinkList>
+      </template>`,
+      errors: [
+        {
+          message: '`slot-scope` are deprecated.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <LinkList>
+          <a slot-scope />
+        </LinkList>
+      </template>`,
+      output: `
+      <template>
+        <LinkList>
+          <a v-slot />
+        </LinkList>
+      </template>`,
+      errors: [
+        {
+          message: '`slot-scope` are deprecated.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <LinkList>
+          <a slot-scope="{a}" />
+        </LinkList>
+      </template>`,
+      output: `
+      <template>
+        <LinkList>
+          <a v-slot="{a}" />
+        </LinkList>
+      </template>`,
+      errors: [
+        {
+          message: '`slot-scope` are deprecated.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <LinkList>
+          <a slot-scope="{a}" slot="name"/>
+        </LinkList>
+      </template>`,
+      output: `
+      <template>
+        <LinkList>
+          <a  v-slot:name="{a}"/>
+        </LinkList>
+      </template>`,
+      errors: [
+        {
+          message: '`slot-scope` are deprecated.',
+          line: 4
+        }
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -139,6 +139,21 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
           line: 4
         }
       ]
+    },
+    {
+      code: `
+      <template>
+        <LinkList>
+          <a slot-scope="{a}" :slot="arg"/>
+        </LinkList>
+      </template>`,
+      output: null,
+      errors: [
+        {
+          message: '`slot-scope` are deprecated.',
+          line: 4
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -123,6 +123,22 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
           line: 4
         }
       ]
+    },
+    // cannot fix
+    {
+      code: `
+      <template>
+        <LinkList>
+          <a slot-scope="{a}" slot="f o o"/>
+        </LinkList>
+      </template>`,
+      output: null,
+      errors: [
+        {
+          message: '`slot-scope` are deprecated.',
+          line: 4
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -14,22 +14,27 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
   valid: [
     `<template>
       <LinkList>
-        <a v-slot:name />
+        <template v-slot:name><a /></template>
       </LinkList>
     </template>`,
     `<template>
       <LinkList>
-        <a #name />
+        <template #name><a /></template>
       </LinkList>
     </template>`,
     `<template>
       <LinkList>
-        <a v-slot="{a}" />
+        <template v-slot="{a}"><a /></template>
+      </LinkList>
+    </template>`,
+    `<template>
+      <LinkList v-slot="{a}">
+        <a />
       </LinkList>
     </template>`,
     `<template>
       <LinkList>
-        <a #default="{a}" />
+        <template #default="{a}"><a /></template>
       </LinkList>
     </template>`,
     `<template>
@@ -39,22 +44,26 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
     </template>`,
     `<template>
       <LinkList>
-        <a />
+        <template><a /></template>
       </LinkList>
-    </template>`
+    </template>`,
+    `<template>
+      <LinkList>
+        <a />
+      </LinkList>`
   ],
   invalid: [
     {
       code: `
       <template>
         <LinkList>
-          <a slot="name" disabled slot-scope="{a}"/>
+          <template slot-scope="{a}"><a /></template>
         </LinkList>
       </template>`,
       output: `
       <template>
         <LinkList>
-          <a v-slot:name="{a}" disabled />
+          <template v-slot="{a}"><a /></template>
         </LinkList>
       </template>`,
       errors: [
@@ -68,53 +77,13 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
       code: `
       <template>
         <LinkList>
-          <a slot-scope />
+          <template slot-scope><a /></template>
         </LinkList>
       </template>`,
       output: `
       <template>
         <LinkList>
-          <a v-slot />
-        </LinkList>
-      </template>`,
-      errors: [
-        {
-          message: '`slot-scope` are deprecated.',
-          line: 4
-        }
-      ]
-    },
-    {
-      code: `
-      <template>
-        <LinkList>
-          <a slot-scope="{a}" />
-        </LinkList>
-      </template>`,
-      output: `
-      <template>
-        <LinkList>
-          <a v-slot="{a}" />
-        </LinkList>
-      </template>`,
-      errors: [
-        {
-          message: '`slot-scope` are deprecated.',
-          line: 4
-        }
-      ]
-    },
-    {
-      code: `
-      <template>
-        <LinkList>
-          <a slot-scope="{a}" slot="name"/>
-        </LinkList>
-      </template>`,
-      output: `
-      <template>
-        <LinkList>
-          <a  v-slot:name="{a}"/>
+          <template v-slot><a /></template>
         </LinkList>
       </template>`,
       errors: [
@@ -129,7 +98,7 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
       code: `
       <template>
         <LinkList>
-          <a slot-scope="{a}" slot="f o o"/>
+          <a slot-scope="{a}" />
         </LinkList>
       </template>`,
       output: null,
@@ -144,7 +113,22 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
       code: `
       <template>
         <LinkList>
-          <a slot-scope="{a}" :slot="arg"/>
+          <template slot-scope="{a}" slot="foo"><a /></template>
+        </LinkList>
+      </template>`,
+      output: null,
+      errors: [
+        {
+          message: '`slot-scope` are deprecated.',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <LinkList>
+          <template slot-scope="{a}" :slot="arg"><a /></template>
         </LinkList>
       </template>`,
       output: null,


### PR DESCRIPTION
`vue/no-deprecated-slot-scope-attribute` rule reports deprecated `slot-scope` attribute in Vue.js v2.6.0+.

```vue
<template>
  <ListComponent>
    <!-- ✓ GOOD -->
    <template v-slot="props">
      {{ props.title }}
    </template>
  </ListComponent>
  <ListComponent>
    <!-- ✗ BAD -->
    <template slot-scope="props">
      {{ props.title }}
    </template>
  </ListComponent>
</template>
```

---

refs https://github.com/vuejs/eslint-plugin-vue/issues/800#issuecomment-460646676
