### PR TITLE
Fix: copy/paste error in `valid-v-on`

### DIFF
--- a/docs/rules/valid-v-on.md
+++ b/docs/rules/valid-v-on.md
@@ -49,7 +49,7 @@ This rule does not check syntax errors in directives because it's checked by [no
 
 ```json
 {
-  "vue/prop-name-casing": ["error", {
+  "vue/valid-v-on": ["error", {
     "modifiers": []
   }]
 }


### PR DESCRIPTION
This had the wrong name for the rule in the example.