### PR TITLE
New: add vue/no-unused-properties rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -155,6 +155,7 @@ For example:
 | [vue/no-deprecated-scope-attribute](./no-deprecated-scope-attribute.md) | disallow deprecated `scope` attribute (in Vue.js 2.5.0+) | :wrench: |
 | [vue/no-empty-pattern](./no-empty-pattern.md) | disallow empty destructuring patterns |  |
 | [vue/no-restricted-syntax](./no-restricted-syntax.md) | disallow specified syntax |  |
+| [vue/no-unused-properties](./no-unused-properties.md) | disallow unused properties, data and computed properties |  |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |
 | [vue/require-direct-export](./require-direct-export.md) | require the component to be directly exported |  |
 | [vue/script-indent](./script-indent.md) | enforce consistent indentation in `<script>` | :wrench: |

--- a/docs/rules/no-unused-properties.md
+++ b/docs/rules/no-unused-properties.md
@@ -1,0 +1,129 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-unused-properties
+description: disallow unused properties, data and computed properties
+---
+# vue/no-unused-properties
+> disallow unused properties, data and computed properties
+
+## :book: Rule Details
+
+This rule disallows any unused properties, data and computed properties.
+
+```vue
+/* ✓ GOOD */
+
+<template>
+  <div>{{ count }}</div>
+</template>
+
+<script>
+  export default {
+    props: ['count']
+  }
+</script>
+```
+
+```vue
+/* ✗ BAD (`count` property not used) */
+
+<template>
+  <div>{{ cnt }}</div>
+</template>
+
+<script>
+  export default {
+    props: ['count']
+  }
+</script>
+```
+
+```vue
+/* ✓ GOOD */
+
+<script>
+  export default {
+    data() {
+      return {
+        count: null
+      }
+    },
+    created() {
+      this.count = 2
+    }
+  }
+</script>
+```
+
+```vue
+/* ✓ BAD (`count` data not used) */
+
+<script>
+  export default {
+    data() {
+      return {
+        count: null
+      }
+    },
+    created() {
+      this.cnt = 2
+    }
+  }
+</script>
+```
+
+```vue
+/* ✓ GOOD */
+
+<template>
+  <p>{{ reversedMessage }}</p>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        message: 'Hello'
+      }
+    },
+    computed: {
+      reversedMessage() {
+        return this.message.split('').reverse().join('')
+      }
+    }
+  }
+</script>
+```
+
+```vue
+/* ✓ BAD (`reversedMessage` computed property not used) */
+
+<template>
+  <p>{{ message }}</p>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        message: 'Hello'
+      }
+    },
+    computed: {
+      reversedMessage() {
+        return this.message.split('').reverse().join('')
+      }
+    }
+  }
+</script>
+```
+
+## :wrench: Options
+
+None.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-unused-properties.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-unused-properties.js)

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview Disallow unused properties, data and computed properties.
+ * @author Learning Equality
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const remove = require('lodash/remove')
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Constants
+// ------------------------------------------------------------------------------
+
+const GROUP_PROPERTY = 'props'
+const GROUP_DATA = 'data'
+const GROUP_COMPUTED_PROPERTY = 'computed'
+const GROUP_WATCHER = 'watch'
+
+const PROPERTY_LABEL = {
+  [GROUP_PROPERTY]: 'property',
+  [GROUP_DATA]: 'data',
+  [GROUP_COMPUTED_PROPERTY]: 'computed property'
+}
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+/**
+ * Extract names from references objects.
+ */
+const getReferencesNames = references => {
+  if (!references || !references.length) {
+    return []
+  }
+
+  return references.map(reference => {
+    if (!reference.id || !reference.id.name) {
+      return
+    }
+
+    return reference.id.name
+  })
+}
+
+/**
+ * Report all unused properties.
+ */
+const reportUnusedProperties = (context, properties) => {
+  if (!properties || !properties.length) {
+    return
+  }
+
+  properties.forEach(property => {
+    context.report({
+      node: property.node,
+      message: `Unused ${PROPERTY_LABEL[property.groupName]} found: "${property.name}"`
+    })
+  })
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow unused properties, data and computed properties',
+      category: undefined,
+      url: 'https://eslint.vuejs.org/rules/no-unused-properties.html'
+    },
+    fixable: null,
+    schema: []
+  },
+
+  create (context) {
+    let hasTemplate
+    let rootTemplateEnd
+    let unusedProperties = []
+    const thisExpressionsVariablesNames = []
+
+    const initialize = {
+      Program (node) {
+        if (context.parserServices.getTemplateBodyTokenStore == null) {
+          context.report({
+            loc: { line: 1, column: 0 },
+            message:
+              'Use the latest vue-eslint-parser. See also https://vuejs.github.io/eslint-plugin-vue/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error.'
+          })
+          return
+        }
+
+        hasTemplate = Boolean(node.templateBody)
+      }
+    }
+
+    const scriptVisitor = Object.assign(
+      {},
+      {
+        'MemberExpression[object.type="ThisExpression"][property.type="Identifier"][property.name]' (
+          node
+        ) {
+          thisExpressionsVariablesNames.push(node.property.name)
+        }
+      },
+      utils.executeOnVue(context, obj => {
+        unusedProperties = Array.from(
+          utils.iterateProperties(obj, new Set([GROUP_PROPERTY, GROUP_DATA, GROUP_COMPUTED_PROPERTY]))
+        )
+
+        const watchers = Array.from(utils.iterateProperties(obj, new Set([GROUP_WATCHER])))
+        const watchersNames = watchers.map(watcher => watcher.name)
+
+        remove(unusedProperties, property => {
+          return (
+            thisExpressionsVariablesNames.includes(property.name) ||
+            watchersNames.includes(property.name)
+          )
+        })
+
+        if (!hasTemplate && unusedProperties.length) {
+          reportUnusedProperties(context, unusedProperties)
+        }
+      })
+    )
+
+    const templateVisitor = {
+      'VExpressionContainer[expression!=null][references]' (node) {
+        const referencesNames = getReferencesNames(node.references)
+
+        remove(unusedProperties, property => {
+          return referencesNames.includes(property.name)
+        })
+      },
+      // save root template end location - just a helper to be used
+      // for a decision if a parser reached the end of the root template
+      "VElement[name='template']" (node) {
+        if (rootTemplateEnd) {
+          return
+        }
+
+        rootTemplateEnd = node.loc.end
+      },
+      "VElement[name='template']:exit" (node) {
+        if (node.loc.end !== rootTemplateEnd) {
+          return
+        }
+
+        if (unusedProperties.length) {
+          reportUnusedProperties(context, unusedProperties)
+        }
+      }
+    }
+
+    return Object.assign(
+      {},
+      initialize,
+      utils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+    )
+  }
+}

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -1,0 +1,646 @@
+/**
+ * @fileoverview Disallow unused properties, data and computed properties.
+ * @author Learning Equality
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-unused-properties')
+
+const tester = new RuleTester({
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  }
+})
+
+tester.run('no-unused-properties', rule, {
+  valid: [
+    // a property used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            props: ['count'],
+            created() {
+              alert(this.count + 1)
+            }
+          };
+        </script>
+      `
+    },
+
+    // a property being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            props: {
+              count: {
+                type: Number,
+                default: 0
+              }
+            },
+            watch: {
+              count() {
+                alert('Increased!');
+              },
+            },
+          };
+        </script>
+      `
+    },
+
+    // a property used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+        <script>
+          export default {
+            props: ['count']
+          }
+        </script>
+      `
+    },
+
+    // properties used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+        <script>
+          export default {
+            props: ['count1', 'count2']
+          };
+        </script>
+      `
+    },
+
+    // a property used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+        <script>
+          export default {
+            props: {
+              count: {
+                type: Number
+              }
+            }
+          };
+        </script>
+      `
+    },
+
+    // a property used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+        <script>
+          export default {
+            props: {
+              colors: {
+                type: Array,
+                default: () => []
+              }
+            }
+          };
+        </script>
+      `
+    },
+
+    // a property used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+        <script>
+          export default {
+            props: ['message']
+          };
+        </script>
+      `
+    },
+
+    // a property passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+        <script>
+          export default {
+            props: ['count']
+          };
+        </script>
+      `
+    },
+
+    // a property used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="alert(count)" />
+        </template>
+        <script>
+          export default {
+            props: ['count']
+          };
+        </script>
+      `
+    },
+
+    // data used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            },
+            created() {
+              alert(this.count + 1)
+            }
+          };
+        </script>
+      `
+    },
+
+    // data being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            data() {
+              return {
+                count: 2
+              };
+            },
+            watch: {
+              count() {
+                alert('Increased!');
+              },
+            },
+          };
+        </script>
+      `
+    },
+
+    // data used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          }
+        </script>
+      `
+    },
+
+    // data used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                count1: 1,
+                count2: 2
+              };
+            }
+          };
+        </script>
+      `
+    },
+
+    // data used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `
+    },
+
+    // data used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                colors: ["purple", "green"]
+              };
+            }
+          };
+        </script>
+      `
+    },
+
+    // data used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                message: "<span>Hey!</span>"
+              };
+            }
+          };
+        </script>
+      `
+    },
+
+    // data used in v-model
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <input v-model="count" />
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `
+    },
+
+    // data passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `
+    },
+
+    // data used in v-on
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <button @click="count++" />
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `
+    },
+
+    // computed property used in a script expression
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            },
+            created() {
+              const dummy = this.count + 1;
+            }
+          };
+        </script>
+      `
+    },
+
+    // computed property being watched
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            },
+            watch: {
+              count() {
+                alert('Increased!');
+              },
+            },
+          };
+        </script>
+      `
+    },
+
+    // computed property used as a template identifier
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count }}</div>
+        </template>
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `
+    },
+
+    // computed properties used in a template expression
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ count1 + count2 }}</div>
+        </template>
+        <script>
+          export default {
+            computed: {
+              count1() {
+                return 1;
+              },
+              count2() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `
+    },
+
+    // computed property used in v-if
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="count > 0"></div>
+        </template>
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `
+    },
+
+    // computed property used in v-for
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="color in colors">{{ color }}</div>
+        </template>
+        <script>
+          export default {
+            computed: {
+              colors() {
+                return ["purple", "green"];
+              }
+            }
+          };
+        </script>
+      `
+    },
+
+    // computed property used in v-html
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-html="message" />
+        </template>
+        <script>
+          export default {
+            computed: {
+              message() {
+                return "<span>Hey!</span>";
+              }
+            }
+          };
+        </script>
+      `
+    },
+
+    // computed property used in v-model
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <input v-model="fullName" />
+        </template>
+        <script>
+          export default {
+            data() {
+              return {
+                firstName: "David",
+                lastName: "Attenborough"
+              }
+            },
+            computed: {
+              fullName: {
+                get() {
+                  return this.firstName + ' ' + this.lastName
+                },
+                set(newValue) {
+                  var names = newValue.split(' ')
+                  this.firstName = names[0]
+                  this.lastName = names[names.length - 1]
+                }
+              }
+            }
+          };
+        </script>
+      `
+    },
+
+    // computed property passed in a component
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <counter :count="count" />
+        </template>
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          }
+        </script>
+      `
+    },
+
+    // ignores unused data when marked with eslint-disable
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                // eslint-disable-next-line
+                count: 2
+              };
+            }
+          };
+        </script>
+      `
+    }
+  ],
+
+  invalid: [
+    // unused property
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+        <script>
+          export default {
+            props: ['count']
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused property found: "count"',
+          line: 7
+        }
+      ]
+    },
+
+    // unused data
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+        <script>
+          export default {
+            data () {
+              return {
+                count: 2
+              };
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused data found: "count"',
+          line: 9
+        }
+      ]
+    },
+
+    // unused computed property
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>{{ cont }}</div>
+        </template>
+        <script>
+          export default {
+            computed: {
+              count() {
+                return 2;
+              }
+            }
+          };
+        </script>
+      `,
+      errors: [
+        {
+          message: 'Unused computed property found: "count"',
+          line: 8
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
Hello,

we've implemented `vue/no-unused-properties` (disallows any unused properties, data and computed properties) as our custom internal rule recently and noticed that there's an accepted rule proposition for this logic already (#631) so we're sharing what we have.

Refs: #631