### PR TITLE
Fix: register v-slot-style and valid-v-slot

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,6 +75,7 @@ module.exports = {
     'v-bind-style': require('./rules/v-bind-style'),
     'v-on-function-call': require('./rules/v-on-function-call'),
     'v-on-style': require('./rules/v-on-style'),
+    'v-slot-style': require('./rules/v-slot-style'),
     'valid-template-root': require('./rules/valid-template-root'),
     'valid-v-bind': require('./rules/valid-v-bind'),
     'valid-v-cloak': require('./rules/valid-v-cloak'),
@@ -88,6 +89,7 @@ module.exports = {
     'valid-v-once': require('./rules/valid-v-once'),
     'valid-v-pre': require('./rules/valid-v-pre'),
     'valid-v-show': require('./rules/valid-v-show'),
+    'valid-v-slot': require('./rules/valid-v-slot'),
     'valid-v-text': require('./rules/valid-v-text')
   },
   configs: {


### PR DESCRIPTION
Feel free to just close if these rules were left unregistered because they're not done or there are known issues. 🙂 I registered them because I needed to use them on a project.