### PR TITLE
Add vue-eslint-parser version to "Tell us about your environment"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,8 @@ about: Create a report to help us improve
 
 **Tell us about your environment**	
 * **ESLint version:**	
-* **eslint-plugin-vue version:**	
+* **eslint-plugin-vue version:** 
+* **vue-eslint-parser version:** 
 * **Node version:**	
 
 **Please show your full configuration:**


### PR DESCRIPTION
Since my last two requests were entirely dependent on `vue-eslint-parser`'s new major version breaking rules, It could help maintainers to know that.