### PR TITLE
Update @typescript-eslint/parser link

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -67,7 +67,7 @@ If you installed [@vue/cli-plugin-eslint](https://github.com/vuejs/vue-cli/tree/
 
 #### How to use custom parser?
 
-If you want to use custom parsers such as [babel-eslint](https://www.npmjs.com/package/babel-eslint) or [typescript-eslint-parser](https://www.npmjs.com/package/typescript-eslint-parser), you have to use `parserOptions.parser` option instead of `parser` option. Because this plugin requires [vue-eslint-parser](https://www.npmjs.com/package/vue-eslint-parser) to parse `.vue` files, so this plugin doesn't work if you overwrote `parser` option.
+If you want to use custom parsers such as [babel-eslint](https://www.npmjs.com/package/babel-eslint) or [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser), you have to use `parserOptions.parser` option instead of `parser` option. Because this plugin requires [vue-eslint-parser](https://www.npmjs.com/package/vue-eslint-parser) to parse `.vue` files, so this plugin doesn't work if you overwrote `parser` option.
 
 ```diff
 - "parser": "babel-eslint",


### PR DESCRIPTION
typescript-eslint-parser is deprecated and to be replaced by @typescript-eslint/parser
As stated on https://www.npmjs.com/package/typescript-eslint-parser