### PR TITLE
fix(use-v-on-exact): Don't flag events with different key codes

### DIFF
--- a/lib/rules/use-v-on-exact.js
+++ b/lib/rules/use-v-on-exact.js
@@ -11,6 +11,7 @@
 const utils = require('../utils')
 
 const SYSTEM_MODIFIERS = new Set(['ctrl', 'shift', 'alt', 'meta'])
+const GLOBAL_MODIFIERS = new Set(['stop', 'prevent', 'capture', 'self', 'once', 'passive', 'native'])
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -34,6 +35,16 @@ function getEventDirectives (attributes, sourceCode) {
       node: attribute.key,
       modifiers: attribute.key.modifiers.map(modifier => modifier.name)
     }))
+}
+
+/**
+ * Checks whether given modifier is key modifier
+ *
+ * @param {string} modifier
+ * @returns {boolean}
+ */
+function isKeyModifier (modifier) {
+  return !GLOBAL_MODIFIERS.has(modifier) && !SYSTEM_MODIFIERS.has(modifier)
 }
 
 /**
@@ -87,6 +98,16 @@ function getSystemModifiersString (modifiers) {
 }
 
 /**
+ * Creates alphabetically sorted string with key modifiers
+ *
+ * @param {array[string]} modifiers
+ * @returns {string} e.g. "enter,tab"
+ */
+function getKeyModifiersString (modifiers) {
+  return modifiers.filter(isKeyModifier).sort().join(',')
+}
+
+/**
  * Compares two events based on their modifiers
  * to detect possible event leakeage
  *
@@ -100,13 +121,21 @@ function hasConflictedModifiers (baseEvent, event) {
     event.modifiers.includes('exact')
   ) return false
 
-  const eventModifiers = getSystemModifiersString(event.modifiers)
-  const baseEventModifiers = getSystemModifiersString(baseEvent.modifiers)
+  const eventKeyModifiers = getKeyModifiersString(event.modifiers)
+  const baseEventKeyModifiers = getKeyModifiersString(baseEvent.modifiers)
+
+  if (
+    eventKeyModifiers && baseEventKeyModifiers &&
+    eventKeyModifiers !== baseEventKeyModifiers
+  ) return false
+
+  const eventSystemModifiers = getSystemModifiersString(event.modifiers)
+  const baseEventSystemModifiers = getSystemModifiersString(baseEvent.modifiers)
 
   return (
     baseEvent.modifiers.length >= 1 &&
-    baseEventModifiers !== eventModifiers &&
-    baseEventModifiers.indexOf(eventModifiers) > -1
+    baseEventSystemModifiers !== eventSystemModifiers &&
+    baseEventSystemModifiers.indexOf(eventSystemModifiers) > -1
   )
 }
 

--- a/tests/lib/rules/use-v-on-exact.js
+++ b/tests/lib/rules/use-v-on-exact.js
@@ -158,6 +158,27 @@ ruleTester.run('use-v-on-exact', rule, {
     },
     {
       code: `<template><button @[foo]="foo" @[bar].ctrl="bar"/></template>`
+    },
+    {
+      code: `<template>
+        <input
+          @keydown.enter="foo"
+          @keydown.shift.tab="bar"/>
+      </template>`
+    },
+    {
+      code: `<template>
+        <input
+          @keydown.enter="foo"
+          @keydown.shift.tab.prevent="bar"/>
+      </template>`
+    },
+    {
+      code: `<template>
+        <input-component
+          @keydown.enter.native="foo"
+          @keydown.shift.tab.native="bar"/>
+      </template>`
     }
   ],
 


### PR DESCRIPTION
This change modifies the use-v-on-exact rule so that it doesn't flag key handlers that are for different keys. For example, this should still cause a warning:

```
<input
          @keydown.tab="foo"
          @keydown.shift.tab="bar"/>
``` 
While code like this is fine:
```
<input
          @keydown.enter="foo"
          @keydown.shift.tab="bar"/>
```

I have a few instances of this in my code, and I don't believe it can cause any issues, but I may be mistaken. Please let me know what you think.