### PR TITLE
refactor: remove eslint internal `traverser`

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -5,7 +5,12 @@
 'use strict'
 
 const utils = require('../utils')
-const Traverser = require('eslint/lib/util/traverser')
+let Traverser
+try {
+  Traverser = require('eslint/lib/shared/traverser')
+} catch (_) {
+  Traverser = require('eslint/lib/util/traverser')
+}
 
 const defaultOrder = [
   'el',

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -5,14 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
-let Traverser
-try {
-  // eslint 6
-  Traverser = require('eslint/lib/shared/traverser')
-} catch (_) {
-  // eslint < 6
-  Traverser = require('eslint/lib/util/traverser')
-}
+const traverseNodes = require('vue-eslint-parser').AST.traverseNodes
 
 const defaultOrder = [
   'el',
@@ -100,9 +93,10 @@ const LOGICAL_OPERATORS = ['&&', '||']
  */
 function isNotSideEffectsNode (node, visitorKeys) {
   let result = true
-  new Traverser().traverse(node, {
+  const notSideEffectsNodes = []
+  traverseNodes(node, {
     visitorKeys,
-    enter (node, parent) {
+    enterNode (node, parent) {
       if (
         node.type === 'FunctionExpression' ||
         node.type === 'Identifier' ||
@@ -112,7 +106,7 @@ function isNotSideEffectsNode (node, visitorKeys) {
         node.type === 'TemplateElement'
       ) {
         // no side effects node
-        this.skip()
+        notSideEffectsNodes.push(node)
       } else if (
         node.type !== 'Property' &&
         node.type !== 'ObjectExpression' &&
@@ -127,10 +121,12 @@ function isNotSideEffectsNode (node, visitorKeys) {
         node.type !== 'TemplateLiteral'
       ) {
         // Can not be sure that a node has no side effects
-        result = false
-        this.break()
+        if (!parent || notSideEffectsNodes.includes(parent)) {
+          result = false
+        }
       }
-    }
+    },
+    leaveNode () {}
   })
   return result
 }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -93,10 +93,14 @@ const LOGICAL_OPERATORS = ['&&', '||']
  */
 function isNotSideEffectsNode (node, visitorKeys) {
   let result = true
-  const notSideEffectsNodes = []
+  const noSideEffectsNodes = new Set()
   traverseNodes(node, {
     visitorKeys,
     enterNode (node, parent) {
+      if (!result || noSideEffectsNodes.has(node)) {
+        return
+      }
+
       if (
         node.type === 'FunctionExpression' ||
         node.type === 'Identifier' ||
@@ -106,7 +110,14 @@ function isNotSideEffectsNode (node, visitorKeys) {
         node.type === 'TemplateElement'
       ) {
         // no side effects node
-        notSideEffectsNodes.push(node)
+        noSideEffectsNodes.add(node)
+        traverseNodes(node, {
+          visitorKeys,
+          enterNode (node) {
+            noSideEffectsNodes.add(node)
+          },
+          leaveNode () {}
+        })
       } else if (
         node.type !== 'Property' &&
         node.type !== 'ObjectExpression' &&
@@ -121,9 +132,7 @@ function isNotSideEffectsNode (node, visitorKeys) {
         node.type !== 'TemplateLiteral'
       ) {
         // Can not be sure that a node has no side effects
-        if (!parent || notSideEffectsNodes.includes(parent)) {
-          result = false
-        }
+        result = false
       }
     },
     leaveNode () {}

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -7,8 +7,10 @@
 const utils = require('../utils')
 let Traverser
 try {
+  // eslint 6
   Traverser = require('eslint/lib/shared/traverser')
 } catch (_) {
+  // eslint < 6
   Traverser = require('eslint/lib/util/traverser')
 }
 


### PR DESCRIPTION
eslin@6 has moved `traverser.js` to `lib/shared`

https://github.com/eslint/eslint/pull/11555