### PR TITLE
chore: update ESLint to v6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,11 @@ jobs:
           command: npm install
       - run:
           name: Install eslint 5
-          command: npm install eslint@5.0.0 --no-save
+          command: |
+            # We need to execute this command twice because of npm's bug.
+            # See also: https://npm.community/t/error-node-modules-staging-eslint-e7cf6846-node-modules-eslint
+            npm install eslint@5.0.0 --no-save
+            npm install eslint@5.0.0 --no-save
       - run:
           name: Test
           command: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,10 @@ workflows:
   version: 2
   node-multi-build:
     jobs:
-      - node-v6
       - node-v8
       - node-v10
-      - node-v10-minimal
+      - node-v12
+      - node-v12-minimal
 
 version: 2
 jobs:
@@ -31,10 +31,6 @@ jobs:
           name: Test
           command: npm test
 
-  node-v6:
-    <<: *node-base
-    docker:
-      - image: node:6
   node-v8:
     <<: *node-base
     docker:
@@ -43,9 +39,14 @@ jobs:
     <<: *node-base
     docker:
       - image: node:10
-  node-v10-minimal:
+  node-v12:
+    <<: *node-base
     docker:
-      - image: node:10
+      - image: node:12
+
+  node-v12-minimal:
+    docker:
+      - image: node:12
     steps:
       - run:
           name: Versions

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 'use strict'
 
 module.exports = {
-  root: true,
+  // https://github.com/eslint/eslint/issues/11888
+  root: false,
   parserOptions: {
     ecmaVersion: 6
   },

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -67,7 +67,7 @@ If you installed [@vue/cli-plugin-eslint](https://github.com/vuejs/vue-cli/tree/
 
 #### How to use custom parser?
 
-If you want to use custom parsers such as [babel-eslint](https://www.npmjs.com/package/babel-eslint) or [typescript-eslint-parser](https://www.npmjs.com/package/typescript-eslint-parser), you have to use `parserOptions.parser` option instead of `parser` option. Because this plugin requires [vue-eslint-parser](https://www.npmjs.com/package/vue-eslint-parser) to parse `.vue` files, so this plugin doesn't work if you overwrote `parser` option.
+If you want to use custom parsers such as [babel-eslint](https://www.npmjs.com/package/babel-eslint) or [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser), you have to use `parserOptions.parser` option instead of `parser` option. Because this plugin requires [vue-eslint-parser](https://www.npmjs.com/package/vue-eslint-parser) to parse `.vue` files, so this plugin doesn't work if you overwrote `parser` option.
 
 ```diff
 - "parser": "babel-eslint",

--- a/package.json
+++ b/package.json
@@ -50,18 +50,19 @@
   },
   "devDependencies": {
     "@types/node": "^4.2.16",
-    "babel-eslint": "^8.2.2",
+    "@typescript-eslint/parser": "^1.11.0",
+    "babel-eslint": "^10.0.2",
     "chai": "^4.1.0",
-    "eslint": "^5.11.1",
+    "eslint": "^6.0.0",
     "eslint-plugin-eslint-plugin": "^2.0.1",
     "eslint-plugin-vue-libs": "^3.0.0",
+    "eslint-plugin-vue": "file:.",
     "eslint4b": "^5.1.0",
     "lodash": "^4.17.4",
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
     "semver": "^5.6.0",
-    "typescript": "^3.1.3",
-    "typescript-eslint-parser": "^20.0.0",
+    "typescript": "^3.5.2",
     "vue-eslint-editor": "^0.1.4",
     "vuepress": "^0.14.5"
   }

--- a/tests/lib/autofix.js
+++ b/tests/lib/autofix.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const Linter = require('eslint').Linter
+const parser = require('vue-eslint-parser')
 const chai = require('chai')
 
 const rules = require('../..').rules
@@ -24,6 +25,7 @@ const baseConfig = {
 
 describe('Complex autofix test cases', () => {
   const linter = new Linter()
+  linter.defineParser('vue-eslint-parser', parser)
   for (const key of Object.keys(rules)) {
     const ruleId = `vue/${key}`
     linter.defineRule(ruleId, rules[key])

--- a/tests/lib/rules-without-vue-eslint-parser.js
+++ b/tests/lib/rules-without-vue-eslint-parser.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const Linter = require('eslint').Linter
+const parser = require('babel-eslint')
 const rules = require('../..').rules
 
 describe("Don't crash even if without vue-eslint-parser.", () => {
@@ -22,6 +23,7 @@ describe("Don't crash even if without vue-eslint-parser.", () => {
           [ruleId]: 'error'
         }
       }
+      linter.defineParser('babel-eslint', parser)
       linter.defineRule(ruleId, rules[key])
       linter.verifyAndFix(code, config, 'test.vue')
     })

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/array-bracket-spacing')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/arrow-spacing')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -17,7 +17,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -16,7 +16,7 @@ var RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 var tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 tester.run('attributes-order', rule, {

--- a/tests/lib/rules/block-spacing.js
+++ b/tests/lib/rules/block-spacing.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/block-spacing')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/brace-style')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/camelcase')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/comma-dangle')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2018 }
 })
 

--- a/tests/lib/rules/comment-directive.js
+++ b/tests/lib/rules/comment-directive.js
@@ -20,7 +20,7 @@ const eslint = require('eslint')
 
 // Initialize linter.
 const linter = new eslint.CLIEngine({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015
   },

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -15,7 +15,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/dot-location')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/eqeqeq')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/html-closing-bracket-newline.js
+++ b/tests/lib/rules/html-closing-bracket-newline.js
@@ -17,7 +17,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015
   }

--- a/tests/lib/rules/html-closing-bracket-spacing.js
+++ b/tests/lib/rules/html-closing-bracket-spacing.js
@@ -16,7 +16,7 @@ const rule = require('../../../lib/rules/html-closing-bracket-spacing')
 // -----------------------------------------------------------------------------
 
 var ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015
   }

--- a/tests/lib/rules/html-end-tags.js
+++ b/tests/lib/rules/html-end-tags.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/html-end-tags')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -95,7 +95,7 @@ function unIndent (strings) {
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2017,
     ecmaFeatures: {

--- a/tests/lib/rules/html-quotes.js
+++ b/tests/lib/rules/html-quotes.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/html-quotes')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/html-self-closing.js
+++ b/tests/lib/rules/html-self-closing.js
@@ -17,7 +17,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser'
+  parser: require.resolve('vue-eslint-parser')
 })
 
 const ALL_CODE = `<template>

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/key-spacing')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/keyword-spacing')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/match-component-file-name.js
+++ b/tests/lib/rules/match-component-file-name.js
@@ -128,7 +128,7 @@ ruleTester.run('match-component-file-name', rule, {
           }
         </script>
       `,
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions // options default to [['jsx']]
     },
     {
@@ -142,7 +142,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['jsx'] }], // missing jsx in options
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
     {
@@ -155,7 +155,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
     {
@@ -166,7 +166,7 @@ ruleTester.run('match-component-file-name', rule, {
         </template>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
     {
@@ -180,7 +180,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
     {
@@ -194,7 +194,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
     {
@@ -208,7 +208,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
     {
@@ -222,7 +222,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
     {
@@ -236,7 +236,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions
     },
 
@@ -590,7 +590,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions,
       errors: [{
         message: 'Component name `MComponent` should match file name `MyComponent`.'
@@ -607,7 +607,7 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `,
       options: [{ extensions: ['vue'] }],
-      parser: 'vue-eslint-parser',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions,
       errors: [{
         message: 'Component name `MComponent` should match file name `MyComponent`.'

--- a/tests/lib/rules/max-attributes-per-line.js
+++ b/tests/lib/rules/max-attributes-per-line.js
@@ -16,7 +16,7 @@ const rule = require('../../../lib/rules/max-attributes-per-line')
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/multiline-html-element-content-newline.js
+++ b/tests/lib/rules/multiline-html-element-content-newline.js
@@ -15,7 +15,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015
   }

--- a/tests/lib/rules/mustache-interpolation-spacing.js
+++ b/tests/lib/rules/mustache-interpolation-spacing.js
@@ -16,7 +16,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-confusing-v-for-v-if.js
+++ b/tests/lib/rules/no-confusing-v-for-v-if.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/no-confusing-v-for-v-if')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-deprecated-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-scope-attribute.js
@@ -4,7 +4,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/no-deprecated-scope-attribute')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015
   }

--- a/tests/lib/rules/no-duplicate-attributes.js
+++ b/tests/lib/rules/no-duplicate-attributes.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/no-duplicate-attributes')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-empty-pattern.js
+++ b/tests/lib/rules/no-empty-pattern.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/no-empty-pattern')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2018 }
 })
 

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -16,7 +16,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015, sourceType: 'module' }
 })
 

--- a/tests/lib/rules/no-parsing-error.js
+++ b/tests/lib/rules/no-parsing-error.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/no-parsing-error')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/no-restricted-syntax')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -265,7 +265,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
         line: 5,
         message: 'Unexpected side effect in "test1" computed property.'
       }],
-      parser: 'typescript-eslint-parser'
+      parser: require.resolve('@typescript-eslint/parser')
     }
   ]
 })

--- a/tests/lib/rules/no-spaces-around-equal-signs-in-attribute.js
+++ b/tests/lib/rules/no-spaces-around-equal-signs-in-attribute.js
@@ -15,7 +15,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser'
+  parser: require.resolve('vue-eslint-parser')
 })
 
 tester.run('no-spaces-around-equal-signs-in-attribute', rule, {

--- a/tests/lib/rules/no-template-key.js
+++ b/tests/lib/rules/no-template-key.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/no-template-key')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-template-shadow.js
+++ b/tests/lib/rules/no-template-shadow.js
@@ -16,7 +16,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/lib/rules/no-textarea-mustache.js
+++ b/tests/lib/rules/no-textarea-mustache.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/no-textarea-mustache')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-unused-components.js
+++ b/tests/lib/rules/no-unused-components.js
@@ -16,7 +16,7 @@ const rule = require('../../../lib/rules/no-unused-components')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/no-unused-vars')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-use-v-if-with-v-for.js
+++ b/tests/lib/rules/no-use-v-if-with-v-for.js
@@ -15,7 +15,7 @@ const rule = require('../../../lib/rules/no-use-v-if-with-v-for')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/no-v-html.js
+++ b/tests/lib/rules/no-v-html.js
@@ -15,7 +15,7 @@ const rule = require('../../../lib/rules/no-v-html')
 // Tests
 // ------------------------------------------------------------------------------
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/object-curly-spacing')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/require-component-is.js
+++ b/tests/lib/rules/require-component-is.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/require-component-is')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/require-default-prop.js
+++ b/tests/lib/rules/require-default-prop.js
@@ -126,7 +126,7 @@ ruleTester.run('require-default-prop', rule, {
           }
         });
       `,
-      parser: 'typescript-eslint-parser'
+      parser: require.resolve('@typescript-eslint/parser')
     },
     {
       filename: 'test.vue',
@@ -140,7 +140,7 @@ ruleTester.run('require-default-prop', rule, {
           }
         });
       `,
-      parser: 'typescript-eslint-parser'
+      parser: require.resolve('@typescript-eslint/parser')
     },
     {
       filename: 'test.vue',
@@ -209,7 +209,7 @@ ruleTester.run('require-default-prop', rule, {
           }
         });
       `,
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [{
         message: `Prop 'a' requires default value to be set.`,
         line: 4
@@ -226,7 +226,7 @@ ruleTester.run('require-default-prop', rule, {
           }
         });
       `,
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [{
         message: `Prop 'a' requires default value to be set.`,
         line: 4

--- a/tests/lib/rules/require-prop-type-constructor.js
+++ b/tests/lib/rules/require-prop-type-constructor.js
@@ -164,7 +164,7 @@ ruleTester.run('require-prop-type-constructor', rule, {
         message: 'The "a" property should be a constructor.',
         line: 5
       }],
-      parser: 'typescript-eslint-parser'
+      parser: require.resolve('@typescript-eslint/parser')
     }
   ]
 })

--- a/tests/lib/rules/require-prop-types.js
+++ b/tests/lib/rules/require-prop-types.js
@@ -144,7 +144,7 @@ ruleTester.run('require-prop-types', rule, {
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: 'typescript-eslint-parser'
+      parser: require.resolve('@typescript-eslint/parser')
     },
     {
       filename: 'test.vue',
@@ -158,7 +158,7 @@ ruleTester.run('require-prop-types', rule, {
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: 'typescript-eslint-parser'
+      parser: require.resolve('@typescript-eslint/parser')
     }
   ],
 
@@ -265,7 +265,7 @@ ruleTester.run('require-prop-types', rule, {
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [{
         message: 'Prop "foo" should define at least its type.',
         line: 4
@@ -281,7 +281,7 @@ ruleTester.run('require-prop-types', rule, {
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [{
         message: 'Prop "foo" should define at least its type.',
         line: 4

--- a/tests/lib/rules/require-v-for-key.js
+++ b/tests/lib/rules/require-v-for-key.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/require-v-for-key')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -114,7 +114,7 @@ ruleTester.run('require-valid-default-prop', rule, {
         });
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: 'typescript-eslint-parser'
+      parser: require.resolve('@typescript-eslint/parser')
     }
   ],
 
@@ -442,7 +442,7 @@ ruleTester.run('require-valid-default-prop', rule, {
         }
       });`,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: errorMessage('function or number')
     },
 

--- a/tests/lib/rules/script-indent.js
+++ b/tests/lib/rules/script-indent.js
@@ -96,7 +96,7 @@ function unIndent (strings) {
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2017,
     sourceType: 'module'

--- a/tests/lib/rules/singleline-html-element-content-newline.js
+++ b/tests/lib/rules/singleline-html-element-content-newline.js
@@ -15,7 +15,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2015
   }

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -8,7 +8,7 @@ const semver = require('semver')
 const rule = require('../../../lib/rules/space-infix-ops')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -7,7 +7,7 @@ const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/space-unary-ops')
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/this-in-template.js
+++ b/tests/lib/rules/this-in-template.js
@@ -17,7 +17,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/use-v-on-exact.js
+++ b/tests/lib/rules/use-v-on-exact.js
@@ -17,7 +17,7 @@ const RuleTester = require('eslint').RuleTester
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/v-bind-style.js
+++ b/tests/lib/rules/v-bind-style.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/v-bind-style')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/v-on-function-call.js
+++ b/tests/lib/rules/v-on-function-call.js
@@ -15,7 +15,7 @@ const rule = require('../../../lib/rules/v-on-function-call')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/v-on-style.js
+++ b/tests/lib/rules/v-on-style.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/v-on-style')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/v-slot-style.js
+++ b/tests/lib/rules/v-slot-style.js
@@ -16,7 +16,7 @@ const rule = require('../../../lib/rules/v-slot-style')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-template-root.js
+++ b/tests/lib/rules/valid-template-root.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-template-root')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-bind.js
+++ b/tests/lib/rules/valid-v-bind.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-bind')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-cloak.js
+++ b/tests/lib/rules/valid-v-cloak.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-cloak')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-else-if.js
+++ b/tests/lib/rules/valid-v-else-if.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-else-if')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-else.js
+++ b/tests/lib/rules/valid-v-else.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-else')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-for.js
+++ b/tests/lib/rules/valid-v-for.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-for')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-html.js
+++ b/tests/lib/rules/valid-v-html.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-html')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-if.js
+++ b/tests/lib/rules/valid-v-if.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-if')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-model.js
+++ b/tests/lib/rules/valid-v-model.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-model')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-on.js
+++ b/tests/lib/rules/valid-v-on.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-on')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-once.js
+++ b/tests/lib/rules/valid-v-once.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-once')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-pre.js
+++ b/tests/lib/rules/valid-v-pre.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-pre')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-show.js
+++ b/tests/lib/rules/valid-v-show.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-show')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-slot.js
+++ b/tests/lib/rules/valid-v-slot.js
@@ -16,7 +16,7 @@ const rule = require('../../../lib/rules/valid-v-slot')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/rules/valid-v-text.js
+++ b/tests/lib/rules/valid-v-text.js
@@ -17,7 +17,7 @@ const rule = require('../../../lib/rules/valid-v-text')
 // ------------------------------------------------------------------------------
 
 const tester = new RuleTester({
-  parser: 'vue-eslint-parser',
+  parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
 })
 

--- a/tests/lib/utils/vue-component.js
+++ b/tests/lib/utils/vue-component.js
@@ -100,13 +100,13 @@ function validTests (ext) {
     {
       filename: `test.${ext}`,
       code: `export default (Foo as FooConstructor<Foo>).extend({})`,
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions
     },
     {
       filename: `test.${ext}`,
       code: `export default Foo.extend({})`,
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions
     }
   ]
@@ -147,14 +147,14 @@ function invalidTests (ext) {
     {
       filename: `test.${ext}`,
       code: `export default (Vue as VueConstructor<Vue>).extend({})`,
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions,
       errors: [makeError(1)]
     },
     {
       filename: `test.${ext}`,
       code: `export default Vue.extend({})`,
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions,
       errors: [makeError(1)]
     },


### PR DESCRIPTION
This PR updates ESLint to 6 and fixes our tests to follow the breaking changes.

- https://eslint.org/docs/user-guide/migrating-to-6.0.0