### PR TITLE
Update eslint peer dependency to 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">=6.5"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "^6.0.0"
   },
   "dependencies": {
     "vue-eslint-parser": "^6.0.2"


### PR DESCRIPTION
The plugin has been updated to eslint 6, but the peer dependency still requires 5.