### PR TITLE
Drop autofix of prop-name-casing.

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -98,7 +98,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 | [vue/no-multi-spaces](./no-multi-spaces.md) | disallow multiple spaces | :wrench: |
 | [vue/no-spaces-around-equal-signs-in-attribute](./no-spaces-around-equal-signs-in-attribute.md) | disallow spaces around equal signs in attribute | :wrench: |
 | [vue/no-template-shadow](./no-template-shadow.md) | disallow variable declarations from shadowing variables declared in the outer scope |  |
-| [vue/prop-name-casing](./prop-name-casing.md) | enforce specific casing for the Prop name in Vue components | :wrench: |
+| [vue/prop-name-casing](./prop-name-casing.md) | enforce specific casing for the Prop name in Vue components |  |
 | [vue/require-default-prop](./require-default-prop.md) | require default value for props |  |
 | [vue/require-prop-types](./require-prop-types.md) | require type definitions in props |  |
 | [vue/singleline-html-element-content-newline](./singleline-html-element-content-newline.md) | require a line break before and after the contents of a singleline element | :wrench: |

--- a/docs/rules/prop-name-casing.md
+++ b/docs/rules/prop-name-casing.md
@@ -8,13 +8,12 @@ description: enforce specific casing for the Prop name in Vue components
 > enforce specific casing for the Prop name in Vue components
 
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
-- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details
 
 This rule enforce proper casing of props in vue components(camelCase).
 
-<eslint-code-block fix :rules="{'vue/prop-name-casing': ['error']}">
+<eslint-code-block :rules="{'vue/prop-name-casing': ['error']}">
 
 ```vue
 <script>
@@ -46,7 +45,7 @@ export default {
 
 ### `"snake_case"`
 
-<eslint-code-block fix :rules="{'vue/prop-name-casing': ['error', 'snake_case']}">
+<eslint-code-block :rules="{'vue/prop-name-casing': ['error', 'snake_case']}">
 
 ```vue
 <script>

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -8,20 +8,6 @@ const utils = require('../utils')
 const casing = require('../utils/casing')
 const allowedCaseOptions = ['camelCase', 'snake_case']
 
-function canFixPropertyName (node, key, originalName) {
-  // Can not fix of computed property names & shorthand
-  if (node.computed || node.shorthand) {
-    return false
-  }
-
-  // Can not fix of unknown types
-  if (key.type !== 'Literal' && key.type !== 'Identifier') {
-    return false
-  }
-  // Can fix of ASCII printable characters
-  return originalName.match(/[ -~]+/)
-}
-
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -53,12 +53,7 @@ function create (context) {
           data: {
             name: propName,
             caseType: caseType
-          },
-          fix: canFixPropertyName(item.node, item.key, propName) ? fixer => {
-            return item.key.type === 'Literal'
-              ? fixer.replaceText(item.key, item.key.raw.replace(item.key.value, convertedName))
-              : fixer.replaceText(item.key, convertedName)
-          } : undefined
+          }
         })
       }
     }
@@ -77,7 +72,7 @@ module.exports = {
       category: 'strongly-recommended',
       url: 'https://eslint.vuejs.org/rules/prop-name-casing.html'
     },
-    fixable: 'code',  // null or "code" or "whitespace"
+    fixable: null,  // null or "code" or "whitespace"
     schema: [
       {
         enum: allowedCaseOptions

--- a/tests/lib/rules/prop-name-casing.js
+++ b/tests/lib/rules/prop-name-casing.js
@@ -300,13 +300,6 @@ ruleTester.run('prop-name-casing', rule, {
           }
         }
       `,
-      output: `
-        export default {
-          props: {
-            greetingText: String
-          }
-        }
-      `,
       parserOptions,
       errors: [{
         message: 'Prop "greeting_text" is not in camelCase.',
@@ -324,13 +317,6 @@ ruleTester.run('prop-name-casing', rule, {
         }
       `,
       options: ['camelCase'],
-      output: `
-        export default {
-          props: {
-            greetingText: String
-          }
-        }
-      `,
       parserOptions,
       errors: [{
         message: 'Prop "greeting_text" is not in camelCase.',
@@ -346,11 +332,6 @@ ruleTester.run('prop-name-casing', rule, {
         }
       `,
       options: ['camelCase'],
-      output: `
-        export default {
-          props: ['greetingText']
-        }
-      `,
       parserOptions,
       errors: [{
         message: 'Prop "greeting_text" is not in camelCase.',
@@ -368,13 +349,6 @@ ruleTester.run('prop-name-casing', rule, {
         }
       `,
       options: ['snake_case'],
-      output: `
-        export default {
-          props: {
-            greeting_text: String
-          }
-        }
-      `,
       parserOptions,
       errors: [{
         message: 'Prop "greetingText" is not in snake_case.',
@@ -392,13 +366,6 @@ ruleTester.run('prop-name-casing', rule, {
         }
       `,
       options: ['camelCase'],
-      output: `
-        export default {
-          props: {
-            'greetingText': String
-          }
-        }
-      `,
       parserOptions,
       errors: [{
         message: 'Prop "greeting-text" is not in camelCase.',
@@ -416,13 +383,6 @@ ruleTester.run('prop-name-casing', rule, {
         }
       `,
       options: ['snake_case'],
-      output: `
-        export default {
-          props: {
-            'greeting_text': String
-          }
-        }
-      `,
       parserOptions,
       errors: [{
         message: 'Prop "greeting-text" is not in snake_case.',
@@ -436,13 +396,6 @@ ruleTester.run('prop-name-casing', rule, {
         export default {
           props: {
             'greeting_text': String
-          }
-        }
-      `,
-      output: `
-        export default {
-          props: {
-            'greetingText': String
           }
         }
       `,
@@ -463,7 +416,6 @@ ruleTester.run('prop-name-casing', rule, {
           }
         }
       `,
-      output: null,
       parserOptions,
       errors: [{
         message: 'Prop "greeting-text" is not in camelCase.',
@@ -481,7 +433,6 @@ ruleTester.run('prop-name-casing', rule, {
           }
         }
       `,
-      output: null,
       parserOptions,
       errors: [{
         message: 'Prop "greeting_text" is not in camelCase.',
@@ -499,7 +450,6 @@ ruleTester.run('prop-name-casing', rule, {
           }
         }
       `,
-      output: null,
       parserOptions,
       errors: [{
         message: 'Prop "\u{1F37B}" is not in camelCase.',
@@ -517,7 +467,6 @@ ruleTester.run('prop-name-casing', rule, {
           }
         }
       `,
-      output: null,
       parserOptions,
       errors: [{
         message: 'Prop "漢字" is not in camelCase.',
@@ -531,13 +480,6 @@ ruleTester.run('prop-name-casing', rule, {
         export default {
           props: {
             'abc-123-def': String
-          }
-        }
-      `,
-      output: `
-        export default {
-          props: {
-            'abc123Def': String
           }
         }
       `,
@@ -558,7 +500,6 @@ ruleTester.run('prop-name-casing', rule, {
           }
         }
       `,
-      output: null,
       parserOptions,
       errors: [{
         message: 'Prop "greeting-text" is not in camelCase.',


### PR DESCRIPTION
This PR removes the `prop-name-casing` autofix.

The autofix of `prop-name-casing` breaks the program as pointed out in the following comment.

https://github.com/vuejs/eslint-plugin-vue/pull/402#issuecomment-445428304