### PR TITLE
fix attributes-order rule when some types are ommited

### DIFF
--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -97,8 +97,12 @@ function create (context) {
       previousNode = null
     },
     'VAttribute' (node) {
-      if ((currentPosition === -1) || (currentPosition <= getPosition(node, attributePosition, sourceCode))) {
-        currentPosition = getPosition(node, attributePosition, sourceCode)
+      const newPosition = getPosition(node, attributePosition, sourceCode)
+      if (newPosition === -1) {
+        return
+      }
+      if ((currentPosition === -1) || (currentPosition <= newPosition)) {
+        currentPosition = newPosition
         previousNode = node
       } else {
         reportIssue(node, previousNode)

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -293,6 +293,27 @@ tester.run('attributes-order', rule, {
             v-text="textContent">
           </div>
         </template>`
+    },
+    {
+      // omit OTHER_ATTR and allow any place for such attrs
+      filename: 'test.vue',
+      code:
+        `<template>
+          <div
+            class="content"
+            v-if="!visible"
+            :class="className"
+            v-text="textContent"
+            >
+          </div>
+        </template>`,
+      options: [
+        { order:
+          [
+            'CONDITIONALS',
+            'CONTENT'
+          ]
+        }]
     }
   ],
 


### PR DESCRIPTION
Omitting type from order list should allow using attributes of such type everywhere regardless of their order.

But for now it has a bug, which I have fixed.

E.g. omitting `OTHER_ATTR` from the order list should allow `class` attr to be used everywhere.