### PR TITLE
Upgrade vue-eslint-parser@^6.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
-    "vue-eslint-parser": "^6.0.4"
+    "vue-eslint-parser": "^6.0.5"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",


### PR DESCRIPTION
This change removes the peerDependencies warning.

close #981
