### PR TITLE
refactor: use Array.includes() to check for existence

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -118,9 +118,9 @@ function isNotSideEffectsNode (node, visitorKeys) {
         node.type !== 'Property' &&
         node.type !== 'ObjectExpression' &&
         node.type !== 'ArrayExpression' &&
-        (node.type !== 'UnaryExpression' || ['!', '~', '+', '-', 'typeof'].indexOf(node.operator) < 0) &&
-        (node.type !== 'BinaryExpression' || ALL_BINARY_OPERATORS.indexOf(node.operator) < 0) &&
-        (node.type !== 'LogicalExpression' || LOGICAL_OPERATORS.indexOf(node.operator) < 0) &&
+        (node.type !== 'UnaryExpression' || !['!', '~', '+', '-', 'typeof'].includes(node.operator)) &&
+        (node.type !== 'BinaryExpression' || !ALL_BINARY_OPERATORS.includes(node.operator)) &&
+        (node.type !== 'LogicalExpression' || !LOGICAL_OPERATORS.indexOf(node.operator)) &&
         node.type !== 'MemberExpression' &&
         node.type !== 'ConditionalExpression' &&
         // es2015

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -120,7 +120,7 @@ function isNotSideEffectsNode (node, visitorKeys) {
         node.type !== 'ArrayExpression' &&
         (node.type !== 'UnaryExpression' || !['!', '~', '+', '-', 'typeof'].includes(node.operator)) &&
         (node.type !== 'BinaryExpression' || !ALL_BINARY_OPERATORS.includes(node.operator)) &&
-        (node.type !== 'LogicalExpression' || !LOGICAL_OPERATORS.indexOf(node.operator)) &&
+        (node.type !== 'LogicalExpression' || !LOGICAL_OPERATORS.includes(node.operator)) &&
         node.type !== 'MemberExpression' &&
         node.type !== 'ConditionalExpression' &&
         // es2015


### PR DESCRIPTION
Leverage the `Array.includes()` method to check for existence over `indexOf` which is kinda obsolete. 