### PR TITLE
Fixed: "ignores" option of `html-indent` does not work

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -278,7 +278,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   const options = parseOptions(context.options[0], context.options[1] || {}, defaultOptions)
   const sourceCode = context.getSourceCode()
   const offsets = new Map()
-  const preformattedTokens = new Set()
+  const ignoreTokens = new Set()
 
   /**
    * Set offset to the given tokens.
@@ -341,9 +341,9 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
       )
     }
     for (const token of tokenStore.getTokensBetween(node.startTag, endToken, option)) {
-      preformattedTokens.add(token)
+      ignoreTokens.add(token)
     }
-    preformattedTokens.add(endToken)
+    ignoreTokens.add(endToken)
   }
 
   /**
@@ -587,6 +587,7 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
   function ignore (node) {
     for (const token of tokenStore.getTokens(node)) {
       offsets.delete(token)
+      ignoreTokens.add(token)
     }
   }
 
@@ -848,8 +849,8 @@ module.exports.defineVisitor = function create (context, tokenStore, defaultOpti
       }
     }
 
-    // It does not validate preformatted tokens.
-    if (preformattedTokens.has(firstToken)) {
+    // It does not validate ignore tokens.
+    if (ignoreTokens.has(firstToken)) {
       return
     }
 

--- a/tests/fixtures/html-indent/opts-ignores-vattribute-01.vue
+++ b/tests/fixtures/html-indent/opts-ignores-vattribute-01.vue
@@ -1,0 +1,19 @@
+<!--{"options":[2,{"ignores": ["VAttribute"]}]}-->
+<template>
+  <div>
+    <div
+attr1="a">
+    </div>
+    <div
+attr2>
+    </div>
+    <div
+:attr3="a">
+    </div>
+    <div
+:attr4="
+a
+">
+    </div>
+  </div>
+</template>

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -756,6 +756,25 @@ tester.run('html-indent', rule, loadPatterns(
         { message: 'Expected indentation of 4 spaces but found 0 spaces.', line: 7 },
         { message: 'Expected indentation of 2 spaces but found 0 spaces.', line: 8 }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: unIndent`
+        <template>
+        \t <div attr1
+        \t\t attr2/>
+        </template>
+      `,
+      output: unIndent`
+        <template>
+        \t<div attr1
+        \t\t attr2/>
+        </template>
+      `,
+      options: ['tab', { 'ignores': ['VAttribute'] }],
+      errors: [
+        { message: 'Expected "\\t" character, but found " " character.', line: 2 }
+      ]
     }
   ]
 ))


### PR DESCRIPTION
fixed #975 