### PR TITLE
Fixed crashes of `no-reserved-component-names`, `match-component-file-name` and `component-definition-name-casing` rules.

### DIFF
--- a/lib/rules/component-definition-name-casing.js
+++ b/lib/rules/component-definition-name-casing.js
@@ -73,21 +73,15 @@ module.exports = {
     }
 
     return Object.assign({},
-      {
-        "CallExpression > MemberExpression > Identifier[name='component']" (node) {
-          const parent = node.parent.parent
-          const calleeObject = utils.unwrapTypes(parent.callee.object)
+      utils.executeOnCallVueComponent(context, (node) => {
+        if (node.arguments.length === 2) {
+          const argument = node.arguments[0]
 
-          if (calleeObject.type === 'Identifier' && calleeObject.name === 'Vue') {
-            if (parent.arguments && parent.arguments.length === 2) {
-              const argument = parent.arguments[0]
-              if (canConvert(argument)) {
-                convertName(argument)
-              }
-            }
+          if (canConvert(argument)) {
+            convertName(argument)
           }
         }
-      },
+      }),
       utils.executeOnVue(context, (obj) => {
         const node = obj.properties
           .find(item => (

--- a/lib/rules/match-component-file-name.js
+++ b/lib/rules/match-component-file-name.js
@@ -101,21 +101,15 @@ module.exports = {
     }
 
     return Object.assign({},
-      {
-        "CallExpression > MemberExpression > Identifier[name='component']" (node) {
-          const parent = node.parent.parent
-          const calleeObject = utils.unwrapTypes(parent.callee.object)
+      utils.executeOnCallVueComponent(context, (node) => {
+        if (node.arguments.length === 2) {
+          const argument = node.arguments[0]
 
-          if (calleeObject.type === 'Identifier' && calleeObject.name === 'Vue') {
-            if (parent.arguments && parent.arguments.length === 2) {
-              const argument = parent.arguments[0]
-              if (canVerify(argument)) {
-                verifyName(argument)
-              }
-            }
+          if (canVerify(argument)) {
+            verifyName(argument)
           }
         }
-      },
+      }),
       utils.executeOnVue(context, (object) => {
         const node = object.properties
           .find(item => (

--- a/lib/rules/no-reserved-component-names.js
+++ b/lib/rules/no-reserved-component-names.js
@@ -86,24 +86,15 @@ module.exports = {
     }
 
     return Object.assign({},
-      {
-        "CallExpression > MemberExpression > Identifier[name='component']" (node) {
-          const parent = node.parent.parent
-          const calleeObject = utils.unwrapTypes(parent.callee.object)
+      utils.executeOnCallVueComponent(context, (node) => {
+        if (node.arguments.length === 2) {
+          const argument = node.arguments[0]
 
-          if (calleeObject.type === 'Identifier' &&
-              calleeObject.name === 'Vue' &&
-              parent.arguments &&
-              parent.arguments.length === 2
-          ) {
-            const argument = parent.arguments[0]
-
-            if (canVerify(argument)) {
-              reportIfInvalid(argument)
-            }
+          if (canVerify(argument)) {
+            reportIfInvalid(argument)
           }
         }
-      },
+      }),
       utils.executeOnVue(context, (obj) => {
         // Report if a component has been registered locally with a reserved name.
         utils.getRegisteredComponents(obj)

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -636,6 +636,30 @@ module.exports = {
   },
 
   /**
+   * Check call `Vue.component` and call callback.
+   * @param {RuleContext} _context The ESLint rule context object.
+   * @param {Function} cb Callback function
+   */
+  executeOnCallVueComponent (_context, cb) {
+    return {
+      "CallExpression > MemberExpression > Identifier[name='component']": (node) => {
+        const callExpr = node.parent.parent
+        const callee = callExpr.callee
+
+        if (callee.type === 'MemberExpression') {
+          const calleeObject = this.unwrapTypes(callee.object)
+
+          if (calleeObject.type === 'Identifier' &&
+            calleeObject.name === 'Vue' &&
+            callee.property === node &&
+            callExpr.arguments.length >= 1) {
+            cb(callExpr)
+          }
+        }
+      }
+    }
+  },
+  /**
    * Return generator with all properties
    * @param {ASTNode} node Node to check
    * @param {Set} groups Name of parent group

--- a/tests/lib/rules/component-definition-name-casing.js
+++ b/tests/lib/rules/component-definition-name-casing.js
@@ -136,6 +136,12 @@ ruleTester.run('component-definition-name-casing', rule, {
       code: `Vue.component(\`fooBar\${foo}\`, component)`,
       options: ['kebab-case'],
       parserOptions
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/1018
+    {
+      filename: 'test.js',
+      code: `fn1(component.data)`,
+      parserOptions
     }
   ],
 

--- a/tests/lib/rules/match-component-file-name.js
+++ b/tests/lib/rules/match-component-file-name.js
@@ -531,6 +531,12 @@ ruleTester.run('match-component-file-name', rule, {
       `,
       options: [{ shouldMatchCase: true }],
       parserOptions: jsxParserOptions
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/1018
+    {
+      filename: 'test.jsx',
+      code: `fn1(component.data)`,
+      parserOptions
     }
   ],
 

--- a/tests/lib/rules/no-reserved-component-names.js
+++ b/tests/lib/rules/no-reserved-component-names.js
@@ -311,6 +311,12 @@ ruleTester.run('no-reserved-component-names', rule, {
       `,
       parser: require.resolve('vue-eslint-parser'),
       parserOptions
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/1018
+    {
+      filename: 'test.js',
+      code: `fn1(component.data)`,
+      parserOptions
     }
   ],
 


### PR DESCRIPTION
fixed #1018