### PR TITLE
fix: list semver as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "eslint": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
-    "vue-eslint-parser": "^7.0.0"
+    "vue-eslint-parser": "^7.0.0",
+    "semver": "^5.6.0"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",
@@ -64,7 +65,6 @@
     "lodash": "^4.17.4",
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
-    "semver": "^5.6.0",
     "typescript": "^3.5.2",
     "vue-eslint-editor": "^0.1.4",
     "vuepress": "^0.14.5"


### PR DESCRIPTION
Introduced in https://github.com/vuejs/eslint-plugin-vue/pull/841

Moves `semver` from `devDependencies` to `dependencies` since it's needed by two rules.

https://github.com/vuejs/eslint-plugin-vue/blob/0c80259ac96a65695b0668adbf2a577316ff7307/lib/rules/no-unsupported-features.js#L7
https://github.com/vuejs/eslint-plugin-vue/blob/0c80259ac96a65695b0668adbf2a577316ff7307/lib/rules/syntaxes/v-bind-prop-modifier-shorthand.js#L6

Ref https://github.com/yarnpkg/berry/issues/654