### PR TITLE
README.md-VSCode ESlint Auto Fix

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -140,7 +140,7 @@ Example **.vscode/settings.json**:
   "eslint.validate": [
     "javascript",
     "javascriptreact",
-    { "language": "vue", "autoFix": true }
+    "vue"
   ]
 }
 ```


### PR DESCRIPTION
> Auto Fix is enabled by default. Use the single string form.
warning is shown due to changes in vscode-eslint.

![71537321-72b1cc80-28e8-11ea-8eaa-37edc4b13aa5](https://user-images.githubusercontent.com/53117838/72554468-b5f2d000-38d5-11ea-8552-bc93f896b00c.png)

As autoFix is set to `true` by default, object format in `eslint.validate` is now deprecated.
Check [vscode-eslint#7b5c40536131aa94eccd8a175e37104f5b785071](https://github.com/microsoft/vscode-eslint/commit/7b5c40536131aa94eccd8a175e37104f5b785071#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R223)