### PR TITLE
Turn off require-v-for-key by default.

### DIFF
--- a/lib/configs/essential.js
+++ b/lib/configs/essential.js
@@ -21,7 +21,7 @@ module.exports = {
     'vue/require-component-is': 'error',
     'vue/require-prop-type-constructor': 'error',
     'vue/require-render-return': 'error',
-    'vue/require-v-for-key': 'error',
+    'vue/require-v-for-key': 'off',
     'vue/require-valid-default-prop': 'error',
     'vue/return-in-computed-property': 'error',
     'vue/use-v-on-exact': 'error',


### PR DESCRIPTION
This lint is too restrictive, and isn't able to detect the cases when it is wrong.

See https://github.com/vuejs/vetur/issues/261