### PR TITLE
Fix iterateProperties to support arrow functions

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -693,6 +693,8 @@ module.exports = {
         yield * this.iterateObjectExpression(item.value, name)
       } else if (item.value.type === 'FunctionExpression') {
         yield * this.iterateFunctionExpression(item.value, name)
+      } else if (item.value.type === 'ArrowFunctionExpression') {
+        yield * this.iterateArrowFunctionExpression(item.value, name)
       }
     }
   },
@@ -742,6 +744,24 @@ module.exports = {
           yield * this.iterateObjectExpression(item.argument, groupName)
         }
       }
+    }
+  },
+
+  /**
+   * Return generator with all elements inside ArrowFunctionExpression
+   * @param {ASTNode} node Node to check
+   * @param {string} groupName Name of parent group
+   */
+    * iterateArrowFunctionExpression (node, groupName) {
+    assert(node.type === 'ArrowFunctionExpression')
+    if (node.body.type === 'BlockStatement') {
+      for (const item of node.body.body) {
+        if (item.type === 'ReturnStatement' && item.argument && item.argument.type === 'ObjectExpression') {
+          yield * this.iterateObjectExpression(item.argument, groupName)
+        }
+      }
+    } else if (node.body.type === 'ObjectExpression') {
+      yield * this.iterateObjectExpression(node.body, groupName)
     }
   },
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -752,7 +752,7 @@ module.exports = {
    * @param {ASTNode} node Node to check
    * @param {string} groupName Name of parent group
    */
-    * iterateArrowFunctionExpression (node, groupName) {
+  * iterateArrowFunctionExpression (node, groupName) {
     assert(node.type === 'ArrowFunctionExpression')
     if (node.body.type === 'BlockStatement') {
       for (const item of node.body.body) {

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -49,6 +49,58 @@ ruleTester.run('no-dupe-keys', rule, {
       filename: 'test.vue',
       code: `
         export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data: () => {
+            return {
+              dat: null
+            }
+          },
+          data: () => {
+            return
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data: () => ({
+            dat: null
+          }),
+          data: () => {
+            return
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
           ...foo(),
           props: {
             ...foo(),
@@ -77,6 +129,78 @@ ruleTester.run('no-dupe-keys', rule, {
               ...dat
             }
           },
+        }
+      `,
+      parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          ...foo(),
+          props: {
+            ...foo(),
+            foo: String
+          },
+          computed: {
+            ...mapGetters({
+              test: 'getTest'
+            }),
+            bar: {
+              get () {
+              }
+            }
+          },
+          data: {
+            ...foo(),
+            dat: null
+          },
+          methods: {
+            ...foo(),
+            test () {
+            }
+          },
+          data: () => {
+            return {
+              ...dat
+            }
+          },
+        }
+      `,
+      parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          ...foo(),
+          props: {
+            ...foo(),
+            foo: String
+          },
+          computed: {
+            ...mapGetters({
+              test: 'getTest'
+            }),
+            bar: {
+              get () {
+              }
+            }
+          },
+          data: {
+            ...foo(),
+            dat: null
+          },
+          methods: {
+            ...foo(),
+            test () {
+            }
+          },
+          data: () => ({
+            ...dat
+          }),
         }
       `,
       parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
@@ -134,6 +258,68 @@ ruleTester.run('no-dupe-keys', rule, {
       }, {
         message: 'Duplicated key \'foo\'.',
         line: 14
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['foo'],
+          computed: {
+            foo () {
+            }
+          },
+          data: () => {
+            return {
+              foo: null
+            }
+          },
+          methods: {
+            foo () {
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 5
+      }, {
+        message: 'Duplicated key \'foo\'.',
+        line: 10
+      }, {
+        message: 'Duplicated key \'foo\'.',
+        line: 14
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['foo'],
+          computed: {
+            foo () {
+            }
+          },
+          data: () => ({
+            foo: null
+          }),
+          methods: {
+            foo () {
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 5
+      }, {
+        message: 'Duplicated key \'foo\'.',
+        line: 9
+      }, {
+        message: 'Duplicated key \'foo\'.',
+        line: 12
       }]
     },
     {

--- a/tests/lib/rules/no-reserved-keys.js
+++ b/tests/lib/rules/no-reserved-keys.js
@@ -45,6 +45,50 @@ ruleTester.run('no-reserved-keys', rule, {
         }
       `,
       parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data: () => {
+            return {
+              dat: null
+            }
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          }
+        }
+      `,
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data: () => ({
+            dat: null
+          }),
+          methods: {
+            _foo () {},
+            test () {
+            }
+          }
+        }
+      `,
+      parserOptions
     }
   ],
 
@@ -71,6 +115,38 @@ ruleTester.run('no-reserved-keys', rule, {
           data: {
             _foo: String
           }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: "Keys starting with with '_' are reserved in '_foo' group.",
+        line: 4
+      }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        new Vue({
+          data: () => {
+            return {
+              _foo: String
+            }
+          }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: "Keys starting with with '_' are reserved in '_foo' group.",
+        line: 5
+      }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        new Vue({
+          data: () => ({
+            _foo: String
+          })
         })
       `,
       parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/no-template-shadow.js
+++ b/tests/lib/rules/no-template-shadow.js
@@ -70,6 +70,52 @@ ruleTester.run('no-template-shadow', rule, {
           }
         }
       </script>`
+    },
+    {
+      filename: 'test.vue',
+      code: `<template>
+        <div v-for="i in b" />
+        <div v-for="b in c" />
+        <div v-for="d in f" />
+      </template>
+      <script>
+        export default {
+          ...a,
+          data: () => {
+            return {
+              ...b,
+              c: [1, 2, 3]
+            }
+          },
+          computed: {
+            ...d,
+            e,
+            ['f']: [1, 2],
+          }
+        }
+      </script>`
+    },
+    {
+      filename: 'test.vue',
+      code: `<template>
+        <div v-for="i in b" />
+        <div v-for="b in c" />
+        <div v-for="d in f" />
+      </template>
+      <script>
+        export default {
+          ...a,
+          data: () => ({
+            ...b,
+            c: [1, 2, 3]
+          }),
+          computed: {
+            ...d,
+            e,
+            ['f']: [1, 2],
+          }
+        }
+      </script>`
     }
   ],
 
@@ -192,6 +238,76 @@ ruleTester.run('no-template-shadow', rule, {
               c: [1, 2, 3]
             }
           },
+          computed: {
+            ...d,
+            e,
+            ['f']: [1, 2],
+          }
+        }
+      </script>`,
+      errors: [{
+        message: "Variable 'e' is already declared in the upper scope.",
+        type: 'Identifier',
+        line: 6
+      }, {
+        message: "Variable 'f' is already declared in the upper scope.",
+        type: 'Identifier',
+        line: 7
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `<template>
+        <div v-for="i in c" />
+        <div v-for="a in c" />
+        <div v-for="b in c" />
+        <div v-for="d in c" />
+        <div v-for="e in f" />
+        <div v-for="f in c" />
+      </template>
+      <script>
+        export default {
+          ...a,
+          data: () => {
+            return {
+              ...b,
+              c: [1, 2, 3]
+            }
+          },
+          computed: {
+            ...d,
+            e,
+            ['f']: [1, 2],
+          }
+        }
+      </script>`,
+      errors: [{
+        message: "Variable 'e' is already declared in the upper scope.",
+        type: 'Identifier',
+        line: 6
+      }, {
+        message: "Variable 'f' is already declared in the upper scope.",
+        type: 'Identifier',
+        line: 7
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `<template>
+        <div v-for="i in c" />
+        <div v-for="a in c" />
+        <div v-for="b in c" />
+        <div v-for="d in c" />
+        <div v-for="e in f" />
+        <div v-for="f in c" />
+      </template>
+      <script>
+        export default {
+          ...a,
+          data: () => ({
+              ...b,
+              c: [1, 2, 3]
+          }),
           computed: {
             ...d,
             e,


### PR DESCRIPTION
current iterateProperties doesn't support arrow function properties. However it supports functions and iterate their returned objects. 

So we can't treat properties from arrow functions same way:

default way works:
```
data: function () {
  return {
   property: 'value'
  }
},
```

But following examples won't work:
```
data: () => {
  return {
   property: 'value'
  }
},
```

or like this:

```
data: () => ({
  property: 'value'
}),
```

Pull request adds support for `ArrowFunctionExpression` in `iterateProperties`.