### PR TITLE
New: Add `vue/no-ref-as-operand` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -160,6 +160,7 @@ For example:
 | [vue/no-deprecated-slot-scope-attribute](./no-deprecated-slot-scope-attribute.md) | disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+) | :wrench: |
 | [vue/no-empty-pattern](./no-empty-pattern.md) | disallow empty destructuring patterns |  |
 | [vue/no-irregular-whitespace](./no-irregular-whitespace.md) | disallow irregular whitespace |  |
+| [vue/no-ref-as-operand](./no-ref-as-operand.md) | disallow use of value wrapped by `ref()` (Composition API) as an operand |  |
 | [vue/no-reserved-component-names](./no-reserved-component-names.md) | disallow the use of reserved names in component definitions |  |
 | [vue/no-restricted-syntax](./no-restricted-syntax.md) | disallow specified syntax |  |
 | [vue/no-static-inline-styles](./no-static-inline-styles.md) | disallow static inline `style` attributes |  |

--- a/docs/rules/no-ref-as-operand.md
+++ b/docs/rules/no-ref-as-operand.md
@@ -44,6 +44,10 @@ export default {
 
 </eslint-code-block>
 
+## :wrench: Options
+
+Nothing.
+
 ## :books: Further reading
 
 - [Vue RFCs - 0013-composition-api](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0013-composition-api.md)

--- a/docs/rules/no-ref-as-operand.md
+++ b/docs/rules/no-ref-as-operand.md
@@ -1,0 +1,54 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-ref-as-operand
+description: disallow use of value wrapped by `ref()` (Composition API) as an operand
+---
+# vue/no-ref-as-operand
+> disallow use of value wrapped by `ref()` (Composition API) as an operand
+
+## :book: Rule Details
+
+This rule reports cases where a ref is used incorrectly as an operand.
+
+<eslint-code-block :rules="{'vue/no-ref-as-operand': ['error']}">
+
+```vue
+<script>
+import { ref } from 'vue'
+
+export default {
+  setup () {
+    const count = ref(0)
+    const ok = ref(true)
+
+    /* ✓ GOOD */
+    count.value++
+    count.value + 1
+    1 + count.value
+    var msg = ok.value ? 'yes' : 'no'
+
+    /* ✗ BAD */
+    count++
+    count + 1
+    1 + count
+    var msg = ok ? 'yes' : 'no'
+
+    return {
+      count
+    }
+  }
+}
+</script>
+```
+
+</eslint-code-block>
+
+## :books: Further reading
+
+- [Vue RFCs - 0013-composition-api](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0013-composition-api.md)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-ref-as-operand.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-ref-as-operand.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,7 @@ module.exports = {
     'no-irregular-whitespace': require('./rules/no-irregular-whitespace'),
     'no-multi-spaces': require('./rules/no-multi-spaces'),
     'no-parsing-error': require('./rules/no-parsing-error'),
+    'no-ref-as-operand': require('./rules/no-ref-as-operand'),
     'no-reserved-component-names': require('./rules/no-reserved-component-names'),
     'no-reserved-keys': require('./rules/no-reserved-keys'),
     'no-restricted-syntax': require('./rules/no-restricted-syntax'),

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -13,7 +13,7 @@ module.exports = {
       category: undefined,
       url: 'https://eslint.vuejs.org/rules/no-ref-as-operand.html'
     },
-    fixable: 'code',
+    fixable: null,
     schema: [],
     messages: {
       requireDotValue: 'Must use `.value` to read or write the value wrapped with `ref()`.'
@@ -98,11 +98,14 @@ module.exports = {
       },
       // refValue+1, refValue-1
       'BinaryExpression>Identifier' (node) {
+        if (node.parent.left !== node && node.parent.right !== node) {
+          return
+        }
         reportIfRefWrapped(node)
       },
-      // refValue+=1, refValue-=1
+      // refValue+=1, refValue-=1, foo+=refValue, foo-=refValue
       'AssignmentExpression>Identifier' (node) {
-        if (node.parent.left !== node) {
+        if (node.parent.left !== node && node.parent.right !== node) {
           return
         }
         reportIfRefWrapped(node)

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -1,0 +1,126 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+const { ReferenceTracker, findVariable } = require('eslint-utils')
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow use of value wrapped by `ref()` (Composition API) as an operand',
+      category: undefined,
+      url: 'https://eslint.vuejs.org/rules/no-ref-as-operand.html'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      requireDotValue: 'Must use `.value` to read or write the value wrapped with `ref()`.'
+    }
+  },
+  create (context) {
+    const refCallNodes = new Set()
+
+    const refReferences = new Set()
+
+    function reportIfRefWrapped (node) {
+      if (!refReferences.has(node)) {
+        return
+      }
+      context.report({
+        node,
+        messageId: 'requireDotValue'
+      })
+    }
+    return {
+      'Program' () {
+        const tracker = new ReferenceTracker(context.getScope())
+        const traceMap = {
+          vue: {
+            [ReferenceTracker.ESM]: true,
+            ref: {
+              [ReferenceTracker.CALL]: true
+            }
+          }
+        }
+
+        for (const { node } of tracker.iterateEsmReferences(traceMap)) {
+          refCallNodes.add(node)
+        }
+      },
+      'VariableDeclarator>CallExpression' (node) {
+        const varDecl = node.parent
+        if (varDecl.id.type !== 'Identifier') {
+          return
+        }
+        if (!refCallNodes.has(node)) {
+          return
+        }
+        const variable = findVariable(context.getScope(), varDecl.id)
+        if (!variable) {
+          return
+        }
+        for (const reference of variable.references) {
+          if (!reference.isRead()) {
+            continue
+          }
+          refReferences.add(reference.identifier)
+        }
+      },
+      // if (refValue)
+      'IfStatement>Identifier' (node) {
+        if (node.parent.test !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      },
+      // switch (refValue)
+      'SwitchStatement>Identifier' (node) {
+        if (node.parent.discriminant !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      },
+      // -refValue, +refValue, !refValue, ~refValue, typeof refValue
+      'UnaryExpression>Identifier' (node) {
+        if (node.parent.argument !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      },
+      // refValue++, refValue--
+      'UpdateExpression>Identifier' (node) {
+        if (node.parent.argument !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      },
+      // refValue+1, refValue-1
+      'BinaryExpression>Identifier' (node) {
+        reportIfRefWrapped(node)
+      },
+      // refValue+=1, refValue-=1
+      'AssignmentExpression>Identifier' (node) {
+        if (node.parent.left !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      },
+      // refValue || other, refValue && other. ignore: other || refValue
+      'LogicalExpression>Identifier' (node) {
+        if (node.parent.left !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      },
+      // refValue ? x : y
+      'ConditionalExpression>Identifier' (node) {
+        if (node.parent.test !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      }
+    }
+  }
+}

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -20,12 +20,10 @@ module.exports = {
     }
   },
   create (context) {
-    const refCallNodes = new Set()
-
-    const refReferences = new Set()
+    const refReferenceIds = new Map()
 
     function reportIfRefWrapped (node) {
-      if (!refReferences.has(node)) {
+      if (!refReferenceIds.has(node)) {
         return
       }
       context.report({
@@ -46,73 +44,70 @@ module.exports = {
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMap)) {
-          refCallNodes.add(node)
-        }
-      },
-      'VariableDeclarator>CallExpression' (node) {
-        const varDecl = node.parent
-        if (varDecl.id.type !== 'Identifier') {
-          return
-        }
-        if (!refCallNodes.has(node)) {
-          return
-        }
-        const variable = findVariable(context.getScope(), varDecl.id)
-        if (!variable) {
-          return
-        }
-        for (const reference of variable.references) {
-          if (!reference.isRead()) {
+          const variableDeclarator = node.parent
+          if (
+            !variableDeclarator ||
+            variableDeclarator.type !== 'VariableDeclarator' ||
+            variableDeclarator.id.type !== 'Identifier'
+          ) {
             continue
           }
-          refReferences.add(reference.identifier)
+          const variable = findVariable(context.getScope(), variableDeclarator.id)
+          if (!variable) {
+            continue
+          }
+          const variableDeclaration = (
+            variableDeclarator.parent &&
+            variableDeclarator.parent.type === 'VariableDeclaration' &&
+            variableDeclarator.parent
+          ) || null
+          for (const reference of variable.references) {
+            if (!reference.isRead()) {
+              continue
+            }
+
+            refReferenceIds.set(reference.identifier, {
+              variableDeclarator,
+              variableDeclaration
+            })
+          }
         }
       },
       // if (refValue)
       'IfStatement>Identifier' (node) {
-        if (node.parent.test !== node) {
-          return
-        }
         reportIfRefWrapped(node)
       },
       // switch (refValue)
       'SwitchStatement>Identifier' (node) {
-        if (node.parent.discriminant !== node) {
-          return
-        }
         reportIfRefWrapped(node)
       },
       // -refValue, +refValue, !refValue, ~refValue, typeof refValue
       'UnaryExpression>Identifier' (node) {
-        if (node.parent.argument !== node) {
-          return
-        }
         reportIfRefWrapped(node)
       },
       // refValue++, refValue--
       'UpdateExpression>Identifier' (node) {
-        if (node.parent.argument !== node) {
-          return
-        }
         reportIfRefWrapped(node)
       },
       // refValue+1, refValue-1
       'BinaryExpression>Identifier' (node) {
-        if (node.parent.left !== node && node.parent.right !== node) {
-          return
-        }
         reportIfRefWrapped(node)
       },
       // refValue+=1, refValue-=1, foo+=refValue, foo-=refValue
       'AssignmentExpression>Identifier' (node) {
-        if (node.parent.left !== node && node.parent.right !== node) {
-          return
-        }
         reportIfRefWrapped(node)
       },
       // refValue || other, refValue && other. ignore: other || refValue
       'LogicalExpression>Identifier' (node) {
         if (node.parent.left !== node) {
+          return
+        }
+        // Report only constants.
+        const info = refReferenceIds.get(node)
+        if (!info) {
+          return
+        }
+        if (!info.variableDeclaration || info.variableDeclaration.kind !== 'const') {
           return
         }
         reportIfRefWrapped(node)

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -16,7 +16,7 @@ module.exports = {
     fixable: null,
     schema: [],
     messages: {
-      requireDotValue: 'Must use `.value` to read or write the value wrapped with `ref()`.'
+      requireDotValue: 'Must use `.value` to read or write the value wrapped by `ref()`.'
     }
   },
   create (context) {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
     "eslint": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
+    "eslint-utils": "^2.0.0",
     "natural-compare": "^1.4.0",
-    "vue-eslint-parser": "^7.0.0",
-    "semver": "^5.6.0"
+    "semver": "^5.6.0",
+    "vue-eslint-parser": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^4.2.16",

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -117,21 +117,21 @@ tester.run('no-ref-as-operand', rule, {
       `,
       errors: [
         {
-          message: 'Must use `.value` to read or write the value wrapped with `ref()`.',
+          message: 'Must use `.value` to read or write the value wrapped by `ref()`.',
           line: 5,
           column: 7,
           endLine: 5,
           endColumn: 12
         },
         {
-          message: 'Must use `.value` to read or write the value wrapped with `ref()`.',
+          message: 'Must use `.value` to read or write the value wrapped by `ref()`.',
           line: 6,
           column: 19,
           endLine: 6,
           endColumn: 24
         },
         {
-          message: 'Must use `.value` to read or write the value wrapped with `ref()`.',
+          message: 'Must use `.value` to read or write the value wrapped by `ref()`.',
           line: 7,
           column: 23,
           endLine: 7,

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -55,9 +55,30 @@ tester.run('no-ref-as-operand', rule, {
     `,
     `
     import { ref } from 'vue'
+    const foo = ref(true)
+    if (bar) foo
+    `,
+    `
+    import { ref } from 'vue'
+    const foo = ref(true)
+    var a = other || foo // ignore
+    var b = other && foo // ignore
+
+    let bar = ref(true)
+    var a = bar || other
+    var b = bar || other
+    `,
+    `
+    import { ref } from 'vue'
     let count = not_ref(0)
 
     count++
+    `,
+    `
+    import { ref } from 'vue'
+    const foo = ref(0)
+    const bar = ref(0)
+    var baz = x ? foo : bar
     `,
     `
     import { ref } from 'vue'
@@ -76,6 +97,11 @@ tester.run('no-ref-as-operand', rule, {
     `
     import { ref } from 'unknown'
     const count = ref(0)
+    count++
+    `,
+    `
+    import { ref } from 'vue'
+    const count = ref
     count++
     `
   ],
@@ -244,11 +270,9 @@ tester.run('no-ref-as-operand', rule, {
     {
       code: `
       import { ref } from 'vue'
-      let foo = ref(true)
+      const foo = ref(true)
       var a = foo || other
       var b = foo && other
-      var c = other || foo // ignore
-      var d = other && foo // ignore
       `,
       errors: [
         {

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -1,0 +1,119 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-ref-as-operand')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2019, sourceType: 'module' }
+})
+
+tester.run('no-ref-as-operand', rule, {
+  valid: [
+    `
+    import { ref } from 'vue'
+    const count = ref(0)
+    console.log(count.value) // 0
+
+    count.value++
+    console.log(count.value) // 1
+    `,
+    `
+    <script>
+      import { ref } from 'vue'
+      export default {
+        setup() {
+          const count = ref(0)
+          console.log(count.value) // 0
+
+          count.value++
+          console.log(count.value) // 1
+          return {
+            count
+          }
+        }
+      }
+    </script>
+    `
+  ],
+  invalid: [
+    {
+      code: `
+      import { ref } from 'vue'
+      let count = ref(0)
+
+      count++ // error
+      console.log(count + 1) // error
+      console.log(1 + count) // error
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 5,
+          column: 7,
+          endLine: 5,
+          endColumn: 12
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 6,
+          column: 19,
+          endLine: 6,
+          endColumn: 24
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 7,
+          column: 23,
+          endLine: 7,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      code: `
+      <script>
+        import { ref } from 'vue'
+        export default {
+          setup() {
+            let count = ref(0)
+
+            count++ // error
+            console.log(count + 1) // error
+            console.log(1 + count) // error
+            return {
+              count
+            }
+          }
+        }
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 8,
+          column: 13,
+          endLine: 8,
+          endColumn: 18
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 9,
+          column: 25,
+          endLine: 9,
+          endColumn: 30
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 10,
+          column: 29,
+          endLine: 10,
+          endColumn: 34
+        }
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -37,6 +37,46 @@ tester.run('no-ref-as-operand', rule, {
         }
       }
     </script>
+    `,
+    `
+    import { ref } from 'vue'
+    const count = ref(0)
+    if (count.value) {}
+    switch (count.value) {}
+    var foo = -count.value
+    var foo = +count.value
+    count.value++
+    count.value--
+    count.value + 1
+    1 - count.value
+    count.value || other
+    count.value && other
+    var foo = count.value ? x : y
+    `,
+    `
+    import { ref } from 'vue'
+    let count = not_ref(0)
+
+    count++
+    `,
+    `
+    import { ref } from 'vue'
+    // Probably wrong, but not checked by this rule.
+    const {value} = ref(0)
+    value++
+    `,
+    `
+    import { ref } from 'vue'
+    const count = ref(0)
+    function foo() {
+      let count = 0
+      count++
+    }
+    `,
+    `
+    import { ref } from 'unknown'
+    const count = ref(0)
+    count++
     `
   ],
   invalid: [
@@ -51,21 +91,21 @@ tester.run('no-ref-as-operand', rule, {
       `,
       errors: [
         {
-          messageId: 'requireDotValue',
+          message: 'Must use `.value` to read or write the value wrapped with `ref()`.',
           line: 5,
           column: 7,
           endLine: 5,
           endColumn: 12
         },
         {
-          messageId: 'requireDotValue',
+          message: 'Must use `.value` to read or write the value wrapped with `ref()`.',
           line: 6,
           column: 19,
           endLine: 6,
           endColumn: 24
         },
         {
-          messageId: 'requireDotValue',
+          message: 'Must use `.value` to read or write the value wrapped with `ref()`.',
           line: 7,
           column: 23,
           endLine: 7,
@@ -112,6 +152,157 @@ tester.run('no-ref-as-operand', rule, {
           column: 29,
           endLine: 10,
           endColumn: 34
+        }
+      ]
+    },
+    {
+      code: `
+      import { ref } from 'vue'
+      const foo = ref(true)
+      if (foo) {
+        //
+      }
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      import { ref } from 'vue'
+      const foo = ref(true)
+      switch (foo) {
+        //
+      }
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      import { ref } from 'vue'
+      const foo = ref(0)
+      var a = -foo
+      var b = +foo
+      var c = !foo
+      var d = ~foo
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 4
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 5
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 6
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 7
+        }
+      ]
+    },
+    {
+      code: `
+      import { ref } from 'vue'
+      let foo = ref(0)
+      foo += 1
+      foo -= 1
+      baz += foo
+      baz -= foo
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 4
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 5
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 6
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 7
+        }
+      ]
+    },
+    {
+      code: `
+      import { ref } from 'vue'
+      let foo = ref(true)
+      var a = foo || other
+      var b = foo && other
+      var c = other || foo // ignore
+      var d = other && foo // ignore
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 4
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 5
+        }
+      ]
+    },
+    {
+      code: `
+      import { ref } from 'vue'
+      let foo = ref(true)
+      var a = foo ? x : y
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 4
+        }
+      ]
+    },
+    {
+      code: `
+      <script>
+        import { ref } from 'vue'
+        let count = ref(0)
+        export default {
+          setup() {
+            count++ // error
+            console.log(count + 1) // error
+            console.log(1 + count) // error
+            return {
+              count
+            }
+          }
+        }
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue',
+          line: 7
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 8
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 9
         }
       ]
     }


### PR DESCRIPTION
This PR adds the `vue/no-ref-as-operand` rule.

The `vue/no-ref-as-operand` rule reports cases where a ref is used incorrectly as an operand.

---

ref #1035