### PR TITLE
Updated to detect Vue3 components.

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -85,6 +85,9 @@ All component-related rules are applied to code that passes any of the following
 * `Vue.component()` expression
 * `Vue.extend()` expression
 * `Vue.mixin()` expression
+* `app.component()` expression
+* `app.mixin()` expression
+* `createApp()` expression
 * `export default {}` in `.vue` or `.jsx` file
 
 However, if you want to take advantage of the rules in any of your custom objects that are Vue components, you might need to use the special comment `// @vue/component` that marks an object in the next line as a Vue component in any file, e.g.:

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -264,7 +264,7 @@ module.exports = {
     return componentsNode.value.properties
       .filter(p => p.type === 'Property')
       .map(node => {
-        const name = this.getStaticPropertyName(node)
+        const name = getStaticPropertyName(node)
         return name ? { node, name } : null
       })
       .filter(comp => comp != null)
@@ -402,42 +402,7 @@ module.exports = {
    * @param {Property|MethodDefinition|MemberExpression|Literal|TemplateLiteral|Identifier} node - The node to get.
    * @return {string|null} The property name if static. Otherwise, null.
    */
-  getStaticPropertyName (node) {
-    let prop
-    switch (node && node.type) {
-      case 'Property':
-      case 'MethodDefinition':
-        prop = node.key
-        break
-      case 'MemberExpression':
-        prop = node.property
-        break
-      case 'Literal':
-      case 'TemplateLiteral':
-      case 'Identifier':
-        prop = node
-        break
-      // no default
-    }
-
-    switch (prop && prop.type) {
-      case 'Literal':
-        return String(prop.value)
-      case 'TemplateLiteral':
-        if (prop.expressions.length === 0 && prop.quasis.length === 1) {
-          return prop.quasis[0].value.cooked
-        }
-        break
-      case 'Identifier':
-        if (!node.computed) {
-          return prop.name
-        }
-        break
-      // no default
-    }
-
-    return null
-  },
+  getStaticPropertyName,
 
   /**
    * Get all props by looking at all component's properties
@@ -464,8 +429,8 @@ module.exports = {
         .filter(prop => prop.type === 'Property')
         .map(prop => {
           return {
-            key: prop.key, value: this.unwrapTypes(prop.value), node: prop,
-            propName: this.getStaticPropertyName(prop)
+            key: prop.key, value: unwrapTypes(prop.value), node: prop,
+            propName: getStaticPropertyName(prop)
           }
         })
     } else {
@@ -548,28 +513,52 @@ module.exports = {
       const callee = node.callee
 
       if (callee.type === 'MemberExpression') {
-        const calleeObject = this.unwrapTypes(callee.object)
+        const calleeObject = unwrapTypes(callee.object)
 
-        const isFullVueComponent = calleeObject.type === 'Identifier' &&
-          calleeObject.name === 'Vue' &&
-          callee.property.type === 'Identifier' &&
-          ['component', 'mixin', 'extend'].indexOf(callee.property.name) > -1 &&
-          node.arguments.length >= 1 &&
-          node.arguments.slice(-1)[0].type === 'ObjectExpression'
+        if (calleeObject.type === 'Identifier') {
+          const propName = getStaticPropertyName(callee.property)
+          if (calleeObject.name === 'Vue') {
+            // for Vue.js 2.x
+            // Vue.component('xxx', {}) || Vue.mixin({}) || Vue.extend('xxx', {})
+            const isFullVueComponentForVue2 =
+              ['component', 'mixin', 'extend'].includes(propName) &&
+              isObjectArgument(node)
 
-        return isFullVueComponent
+            return isFullVueComponentForVue2
+          }
+
+          // for Vue.js 3.x
+          // app.component('xxx', {}) || app.mixin({})
+          const isFullVueComponent =
+            ['component', 'mixin'].includes(propName) &&
+            isObjectArgument(node)
+
+          return isFullVueComponent
+        }
       }
 
       if (callee.type === 'Identifier') {
-        const isDestructedVueComponent = callee.name === 'component' &&
-          node.arguments.length >= 1 &&
-          node.arguments.slice(-1)[0].type === 'ObjectExpression'
-
-        return isDestructedVueComponent
+        if (callee.name === 'component') {
+          // for Vue.js 2.x
+          // component('xxx', {})
+          const isDestructedVueComponent = isObjectArgument(node)
+          return isDestructedVueComponent
+        }
+        if (callee.name === 'createApp') {
+          // for Vue.js 3.x
+          // createApp({})
+          const isAppVueComponent = isObjectArgument(node)
+          return isAppVueComponent
+        }
       }
     }
 
     return false
+
+    function isObjectArgument (node) {
+      return node.arguments.length > 0 &&
+        unwrapTypes(node.arguments.slice(-1)[0]).type === 'ObjectExpression'
+    }
   },
 
   /**
@@ -584,7 +573,7 @@ module.exports = {
       callee.type === 'Identifier' &&
       callee.name === 'Vue' &&
       node.arguments.length &&
-      node.arguments[0].type === 'ObjectExpression'
+      unwrapTypes(node.arguments[0]).type === 'ObjectExpression'
   },
 
   /**
@@ -647,7 +636,7 @@ module.exports = {
       'CallExpression:exit' (node) {
         // Vue.component('xxx', {}) || component('xxx', {})
         if (!_this.isVueComponent(node) || isDuplicateNode(node.arguments.slice(-1)[0])) return
-        cb(node.arguments.slice(-1)[0])
+        cb(unwrapTypes(node.arguments.slice(-1)[0]))
       }
     }
   },
@@ -664,10 +653,10 @@ module.exports = {
         const callee = callExpr.callee
 
         if (callee.type === 'MemberExpression') {
-          const calleeObject = this.unwrapTypes(callee.object)
+          const calleeObject = unwrapTypes(callee.object)
 
           if (calleeObject.type === 'Identifier' &&
-            calleeObject.name === 'Vue' &&
+            // calleeObject.name === 'Vue' && // Any names can be used in Vue.js 3.x. e.g. app.component()
             callee.property === node &&
             callExpr.arguments.length >= 1) {
             cb(callExpr)
@@ -682,9 +671,9 @@ module.exports = {
    * @param {Set} groups Name of parent group
    */
   * iterateProperties (node, groups) {
-    const nodes = node.properties.filter(p => p.type === 'Property' && groups.has(this.getStaticPropertyName(p.key)))
+    const nodes = node.properties.filter(p => p.type === 'Property' && groups.has(getStaticPropertyName(p.key)))
     for (const item of nodes) {
-      const name = this.getStaticPropertyName(item.key)
+      const name = getStaticPropertyName(item.key)
       if (!name) continue
 
       if (item.value.type === 'ArrayExpression') {
@@ -705,7 +694,7 @@ module.exports = {
   * iterateArrayExpression (node, groupName) {
     assert(node.type === 'ArrayExpression')
     for (const item of node.elements) {
-      const name = this.getStaticPropertyName(item)
+      const name = getStaticPropertyName(item)
       if (name) {
         const obj = { name, groupName, node: item }
         yield obj
@@ -721,7 +710,7 @@ module.exports = {
   * iterateObjectExpression (node, groupName) {
     assert(node.type === 'ObjectExpression')
     for (const item of node.properties) {
-      const name = this.getStaticPropertyName(item)
+      const name = getStaticPropertyName(item)
       if (name) {
         const obj = { name, groupName, node: item.key }
         yield obj
@@ -865,7 +854,56 @@ module.exports = {
    * @param {T} node
    * @return {T}
    */
-  unwrapTypes (node) {
-    return node.type === 'TSAsExpression' ? node.expression : node
+  unwrapTypes
+}
+/**
+* Unwrap typescript types like "X as F"
+* @template T
+* @param {T} node
+* @return {T}
+*/
+function unwrapTypes (node) {
+  return node.type === 'TSAsExpression' ? node.expression : node
+}
+
+/**
+ * Gets the property name of a given node.
+ * @param {Property|MethodDefinition|MemberExpression|Literal|TemplateLiteral|Identifier} node - The node to get.
+ * @return {string|null} The property name if static. Otherwise, null.
+ */
+function getStaticPropertyName (node) {
+  let prop
+  switch (node && node.type) {
+    case 'Property':
+    case 'MethodDefinition':
+      prop = node.key
+      break
+    case 'MemberExpression':
+      prop = node.property
+      break
+    case 'Literal':
+    case 'TemplateLiteral':
+    case 'Identifier':
+      prop = node
+      break
+      // no default
   }
+
+  switch (prop && prop.type) {
+    case 'Literal':
+      return String(prop.value)
+    case 'TemplateLiteral':
+      if (prop.expressions.length === 0 && prop.quasis.length === 1) {
+        return prop.quasis[0].value.cooked
+      }
+      break
+    case 'Identifier':
+      if (!node.computed) {
+        return prop.name
+      }
+      break
+      // no default
+  }
+
+  return null
 }

--- a/tests/lib/rules/component-definition-name-casing.js
+++ b/tests/lib/rules/component-definition-name-casing.js
@@ -118,6 +118,12 @@ ruleTester.run('component-definition-name-casing', rule, {
     },
     {
       filename: 'test.vue',
+      code: `app.component('FooBar', component)`,
+      options: ['PascalCase'],
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
       code: `Vue.mixin({})`,
       parserOptions
     },
@@ -134,6 +140,12 @@ ruleTester.run('component-definition-name-casing', rule, {
     {
       filename: 'test.vue',
       code: `Vue.component(\`fooBar\${foo}\`, component)`,
+      options: ['kebab-case'],
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `app.component(\`fooBar\${foo}\`, component)`,
       options: ['kebab-case'],
       parserOptions
     },
@@ -294,6 +306,17 @@ ruleTester.run('component-definition-name-casing', rule, {
     },
     {
       filename: 'test.vue',
+      code: `app.component('foo-bar', component)`,
+      output: `app.component('FooBar', component)`,
+      parserOptions,
+      errors: [{
+        message: 'Property name "foo-bar" is not PascalCase.',
+        type: 'Literal',
+        line: 1
+      }]
+    },
+    {
+      filename: 'test.vue',
       code: `(Vue as VueConstructor<Vue>).component('foo-bar', component)`,
       output: `(Vue as VueConstructor<Vue>).component('FooBar', component)`,
       parserOptions,
@@ -308,6 +331,17 @@ ruleTester.run('component-definition-name-casing', rule, {
       filename: 'test.vue',
       code: `Vue.component('foo-bar', {})`,
       output: `Vue.component('FooBar', {})`,
+      parserOptions,
+      errors: [{
+        message: 'Property name "foo-bar" is not PascalCase.',
+        type: 'Literal',
+        line: 1
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `app.component('foo-bar', {})`,
+      output: `app.component('FooBar', {})`,
       parserOptions,
       errors: [{
         message: 'Property name "foo-bar" is not PascalCase.',

--- a/tests/lib/rules/match-component-file-name.js
+++ b/tests/lib/rules/match-component-file-name.js
@@ -432,6 +432,16 @@ ruleTester.run('match-component-file-name', rule, {
     {
       filename: 'MyComponent.js',
       code: `
+        app.component('MyComponent', {
+          template: '<div />'
+        })
+      `,
+      options: [{ extensions: ['js'] }],
+      parserOptions
+    },
+    {
+      filename: 'MyComponent.js',
+      code: `
         Vue.component(myComponent, {
           template: '<div />'
         })
@@ -692,6 +702,19 @@ ruleTester.run('match-component-file-name', rule, {
       filename: 'MyComponent.js',
       code: `
         Vue.component(\`MComponent\`, {
+          template: '<div />'
+        })
+      `,
+      options: [{ extensions: ['js'] }],
+      parserOptions,
+      errors: [{
+        message: 'Component name `MComponent` should match file name `MyComponent`.'
+      }]
+    },
+    {
+      filename: 'MyComponent.js',
+      code: `
+        app.component(\`MComponent\`, {
           template: '<div />'
         })
       `,

--- a/tests/lib/rules/no-reserved-component-names.js
+++ b/tests/lib/rules/no-reserved-component-names.js
@@ -275,6 +275,11 @@ ruleTester.run('no-reserved-component-names', rule, {
       parserOptions
     },
     {
+      filename: 'test.vue',
+      code: `app.component('FooBar', {})`,
+      parserOptions
+    },
+    {
       filename: 'test.js',
       code: `
         new Vue({
@@ -352,7 +357,31 @@ ruleTester.run('no-reserved-component-names', rule, {
     ...invalidElements.map(name => {
       return {
         filename: 'test.vue',
+        code: `app.component('${name}', component)`,
+        parserOptions,
+        errors: [{
+          message: `Name "${name}" is reserved.`,
+          type: 'Literal',
+          line: 1
+        }]
+      }
+    }),
+    ...invalidElements.map(name => {
+      return {
+        filename: 'test.vue',
         code: `Vue.component(\`${name}\`, {})`,
+        parserOptions,
+        errors: [{
+          message: `Name "${name}" is reserved.`,
+          type: 'TemplateLiteral',
+          line: 1
+        }]
+      }
+    }),
+    ...invalidElements.map(name => {
+      return {
+        filename: 'test.vue',
+        code: `app.component(\`${name}\`, {})`,
         parserOptions,
         errors: [{
           message: `Name "${name}" is reserved.`,

--- a/tests/lib/rules/no-shared-component-data.js
+++ b/tests/lib/rules/no-shared-component-data.js
@@ -145,6 +145,30 @@ return {
       }]
     },
     {
+      filename: 'test.js',
+      code: `
+        app.component('some-comp', {
+          data: {
+            foo: 'bar'
+          }
+        })
+      `,
+      output: `
+        app.component('some-comp', {
+          data: function() {
+return {
+            foo: 'bar'
+          };
+}
+        })
+      `,
+      parserOptions,
+      errors: [{
+        message: '`data` property in component must be a function.',
+        line: 3
+      }]
+    },
+    {
       filename: 'test.vue',
       code: `
         export default {

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -296,6 +296,25 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
         message: 'Unexpected side effect in "test1" computed property.'
       }],
       parser: require.resolve('@typescript-eslint/parser')
+    },
+
+    {
+      code: `app.component('test', {
+        computed: {
+          test1() {
+            this.firstName = 'lorem'
+            asd.qwe.zxc = 'lorem'
+            return this.firstName + ' ' + this.lastName
+          },
+        }
+      })`,
+      parserOptions,
+      errors: [
+        {
+          line: 4,
+          message: 'Unexpected side effect in "test1" computed property.'
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -246,6 +246,38 @@ ruleTester.run('order-in-components', rule, {
     {
       filename: 'test.js',
       code: `
+        app.component('smart-list', {
+          name: 'app',
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          components: {},
+          template: '<div></div>'
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      output: `
+        app.component('smart-list', {
+          name: 'app',
+          components: {},
+          data () {
+            return {
+              msg: 'Welcome to Your Vue.js App'
+            }
+          },
+          template: '<div></div>'
+        })
+      `,
+      errors: [{
+        message: 'The "components" property should be above the "data" property on line 4.',
+        line: 9
+      }]
+    },
+    {
+      filename: 'test.js',
+      code: `
         const { component } = Vue;
         component('smart-list', {
           name: 'app',

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -86,7 +86,7 @@ ruleTester.run('require-render-return', rule, {
         render() {
           if (a) {
             if (b) {
-              
+
             }
             if (c) {
               return true
@@ -181,6 +181,21 @@ ruleTester.run('require-render-return', rule, {
       }]
     },
     {
+      code: `app.component('test', {
+        render: function () {
+          if (a) {
+            return
+          }
+        }
+      })`,
+      parserOptions,
+      errors: [{
+        message: 'Expected to return a value in render function.',
+        type: 'Identifier',
+        line: 2
+      }]
+    },
+    {
       code: `Vue.component('test2', {
         render: function () {
           if (a) {
@@ -199,7 +214,7 @@ ruleTester.run('require-render-return', rule, {
       code: `Vue.component('test2', {
         render: function () {
           if (a) {
-            
+
           } else {
             return h('div', 'hello')
           }

--- a/tests/lib/utils/vue-component.js
+++ b/tests/lib/utils/vue-component.js
@@ -108,6 +108,12 @@ function validTests (ext) {
       code: `export default Foo.extend({})`,
       parser: require.resolve('@typescript-eslint/parser'),
       parserOptions
+    },
+    {
+      filename: `test.${ext}`,
+      code: `export default Foo.extend({} as ComponentOptions)`,
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions
     }
   ]
 }
@@ -146,6 +152,18 @@ function invalidTests (ext) {
     },
     {
       filename: `test.${ext}`,
+      code: `app.component('name', {})`,
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
+      filename: `test.${ext}`,
+      code: `app.mixin({})`,
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
+      filename: `test.${ext}`,
       code: `export default (Vue as VueConstructor<Vue>).extend({})`,
       parser: require.resolve('@typescript-eslint/parser'),
       parserOptions,
@@ -155,6 +173,19 @@ function invalidTests (ext) {
       filename: `test.${ext}`,
       code: `export default Vue.extend({})`,
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
+      filename: `test.${ext}`,
+      code: `export default Vue.extend({} as ComponentOptions)`,
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
+      filename: `test.${ext}`,
+      code: `createApp({})`,
       parserOptions,
       errors: [makeError(1)]
     },


### PR DESCRIPTION
This PR makes that the following Vue components are validated by each rule:

- `app.component('name', {/*component*/})`
- `app.mixin({/*component*/})`
- `createApp({/*component*/})`

---

ref #1035