### PR TITLE
Fix guide link on valid-v-bind-sync rule docs

### DIFF
--- a/docs/rules/valid-v-bind-sync.md
+++ b/docs/rules/valid-v-bind-sync.md
@@ -62,7 +62,7 @@ Nothing.
 
 ## :books: Further reading
 
-- [Guide - `.sync` Modifier]([https://vuejs.org/v2/guide/list.html#v-for-with-a-Component](https://vuejs.org/v2/guide/components-custom-events.html#sync-Modifier))
+- [Guide - `.sync` Modifier](https://vuejs.org/v2/guide/components-custom-events.html#sync-Modifier)
 
 ## :mag: Implementation
 


### PR DESCRIPTION
Copy-paste error on the [valid-v-bind-sync docs](https://eslint.vuejs.org/rules/valid-v-bind-sync.html): The link to the Vue.js guide for `.sync` pointed to a Markdown link syntax.