### PR TITLE
no-xxxx-keys: change to handle setup

### DIFF
--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -10,7 +10,7 @@ const utils = require('../utils')
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-const GROUP_NAMES = ['props', 'computed', 'data', 'methods']
+const GROUP_NAMES = ['props', 'computed', 'data', 'methods', 'setup']
 
 module.exports = {
   meta: {

--- a/lib/rules/no-reserved-keys.js
+++ b/lib/rules/no-reserved-keys.js
@@ -11,7 +11,7 @@ const utils = require('../utils')
 // ------------------------------------------------------------------------------
 
 const RESERVED_KEYS = require('../utils/vue-reserved.json')
-const GROUP_NAMES = ['props', 'computed', 'data', 'methods']
+const GROUP_NAMES = ['props', 'computed', 'data', 'methods', 'setup']
 
 module.exports = {
   meta: {

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -44,6 +44,37 @@ ruleTester.run('no-dupe-keys', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['foo'],
+          data () {
+            return {
+              dat: null
+            }
+          },
+          data () {
+            return
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          },
+          setup () {
+            const _foo = () => {}
+            const dat = ref(null)
+            const bar = computed(() => 'bar')
+
+            return {
+              bar
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
 
     {
       filename: 'test.vue',
@@ -161,6 +192,51 @@ ruleTester.run('no-dupe-keys', rule, {
             test () {
             }
           },
+          data () {
+            return {
+              ...dat
+            }
+          },
+          setup () {
+            const com = computed(() => 1)
+
+            return {
+              ...foo(),
+              com
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          ...foo(),
+          props: {
+            ...foo(),
+            foo: String
+          },
+          computed: {
+            ...mapGetters({
+              test: 'getTest'
+            }),
+            bar: {
+              get () {
+              }
+            }
+          },
+          data: {
+            ...foo(),
+            dat: null
+          },
+          methods: {
+            ...foo(),
+            test () {
+            }
+          },
           data: () => {
             return {
               ...dat
@@ -224,6 +300,39 @@ ruleTester.run('no-dupe-keys', rule, {
         }
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        // @vue/component
+        export const compA = {
+          props: {
+            propA: String
+          },
+          setup (props) {
+            const com = computed(() => props.propA)
+
+            return {
+              com
+            }
+          }
+        }
+
+        // @vue/component
+        export const compB = {
+          props: {
+            propA: String
+          },
+          setup (props) {
+            const com = computed(() => props.propA)
+
+            return {
+              com
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     }
   ],
 
@@ -245,6 +354,13 @@ ruleTester.run('no-dupe-keys', rule, {
           methods: {
             foo () {
             }
+          },
+          setup () {
+            const foo = ref(1)
+
+            return {
+              foo
+            }
           }
         }
       `,
@@ -258,6 +374,9 @@ ruleTester.run('no-dupe-keys', rule, {
       }, {
         message: 'Duplicated key \'foo\'.',
         line: 14
+      }, {
+        message: 'Duplicated key \'foo\'.',
+        line: 21
       }]
     },
     {
@@ -277,6 +396,13 @@ ruleTester.run('no-dupe-keys', rule, {
           methods: {
             foo () {
             }
+          },
+          setup: () => {
+            const foo = computed(() => 0)
+
+            return {
+              foo
+            }
           }
         }
       `,
@@ -290,6 +416,9 @@ ruleTester.run('no-dupe-keys', rule, {
       }, {
         message: 'Duplicated key \'foo\'.',
         line: 14
+      }, {
+        message: 'Duplicated key \'foo\'.',
+        line: 21
       }]
     },
     {
@@ -341,6 +470,13 @@ ruleTester.run('no-dupe-keys', rule, {
           methods: {
             foo () {
             }
+          },
+          setup (props) {
+            const foo = computed(() => props.foo)
+
+            return {
+              foo
+            }
           }
         }
       `,
@@ -354,6 +490,9 @@ ruleTester.run('no-dupe-keys', rule, {
       }, {
         message: 'Duplicated key \'foo\'.',
         line: 16
+      }, {
+        message: 'Duplicated key \'foo\'.',
+        line: 23
       }]
     },
     {
@@ -373,6 +512,132 @@ ruleTester.run('no-dupe-keys', rule, {
       errors: [{
         message: 'Duplicated key \'bar\'.',
         line: 7
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          methods: {
+            foo () {
+              return 0
+            }
+          },
+          setup () {
+            const foo = () => 0
+
+            return {
+              foo
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 12
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          methods: {
+            foo () {
+              return 0
+            }
+          },
+          setup () {
+            return {
+              foo: () => 0
+            }
+          }
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 10
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          methods: {
+            foo () {
+              return 0
+            }
+          },
+          setup: () => ({
+            foo: () => 0
+          })
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 9
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo () {
+              return 0
+            }
+          },
+          setup: () => ({
+            foo: computed(() => 0)
+          })
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 9
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          data() {
+            return {
+              foo: 0
+            }
+          },
+          setup: () => ({
+            foo: ref(0)
+          })
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 9
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          data() {
+            return {
+              foo: 0
+            }
+          },
+          setup: () => ({
+            foo: 0
+          })
+        }
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{
+        message: 'Duplicated key \'foo\'.',
+        line: 9
       }]
     }
   ]

--- a/tests/lib/rules/no-reserved-keys.js
+++ b/tests/lib/rules/no-reserved-keys.js
@@ -89,6 +89,32 @@ ruleTester.run('no-reserved-keys', rule, {
         }
       `,
       parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data: () => ({
+            dat: null
+          }),
+          methods: {
+            _foo () {},
+            test () {
+            }
+          },
+          setup () {
+            return {
+              _bar: () => {}
+            }
+          }
+        }
+      `,
+      parserOptions
     }
   ],
 
@@ -106,6 +132,23 @@ ruleTester.run('no-reserved-keys', rule, {
       errors: [{
         message: "Key '$el' is reserved.",
         line: 4
+      }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        new Vue({
+          setup () {
+            return {
+              $el: ''
+            }
+          }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      errors: [{
+        message: "Key '$el' is reserved.",
+        line: 5
       }]
     },
     {


### PR DESCRIPTION
This PR change `vue/no-dupe-key`, `no-reserved-keys` rule to handle `setup`.

ref #1035