### PR TITLE
Support module.exports in addition to export default

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -88,7 +88,7 @@ All component-related rules are applied to code that passes any of the following
 * `app.component()` expression
 * `app.mixin()` expression
 * `createApp()` expression
-* `export default {}` in `.vue` or `.jsx` file
+* `export default {}` or `module.exports = {}` in `.vue` or `.jsx` file
 
 However, if you want to take advantage of the rules in any of your custom objects that are Vue components, you might need to use the special comment `// @vue/component` that marks an object in the next line as a Vue component in any file, e.g.:
 

--- a/lib/rules/require-direct-export.js
+++ b/lib/rules/require-direct-export.js
@@ -40,6 +40,16 @@ module.exports = {
             message: `Expected the component literal to be directly exported.`
           })
         }
+      },
+      'AssignmentExpression:exit' (node) {
+        if (!utils.isVueFile(filePath)) return
+
+        if (utils.isModuleExports(node) && node.right.type !== 'ObjectExpression') {
+          context.report({
+            node,
+            message: `Expected the component literal to be directly exported.`
+          })
+        }
       }
     }
   }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -489,17 +489,40 @@ module.exports = {
   },
 
   /**
+   * Chcek whether the given node is a module.exports assignment
+   * @param {ASTNode} node Node to check
+   * @returns {boolean}
+   */
+  isModuleExports (node) {
+    return node.type === 'AssignmentExpression' &&
+      node.operator === '=' &&
+      node.left.type === 'MemberExpression' &&
+      node.left.object.type === 'Identifier' &&
+      node.left.object.name === 'module' &&
+      node.left.property.type === 'Identifier' &&
+      node.left.property.name === 'exports'
+  },
+
+  /**
    * Check whether the given node is a Vue component based
    * on the filename and default export type
-   * export default {} in .vue || .jsx
+   * export default {} || module.exports = {} in .vue || .jsx
    * @param {ASTNode} node Node to check
    * @param {string} path File name with extension
    * @returns {boolean}
    */
   isVueComponentFile (node, path) {
-    return this.isVueFile(path) &&
-      node.type === 'ExportDefaultDeclaration' &&
-      node.declaration.type === 'ObjectExpression'
+    return this.isVueFile(path) && (
+      (
+        // export default {}
+        node.type === 'ExportDefaultDeclaration' &&
+        node.declaration.type === 'ObjectExpression'
+      ) || (
+        // module.exports = {}
+        this.isModuleExports(node) &&
+        node.right.type === 'ObjectExpression'
+      )
+    )
   },
 
   /**
@@ -625,8 +648,14 @@ module.exports = {
 
     return {
       'ObjectExpression:exit' (node) {
+        // Comment containing @vue/component on the line above
         if (!componentComments.some(el => el.loc.end.line === node.loc.start.line - 1) || isDuplicateNode(node)) return
         cb(node)
+      },
+      'AssignmentExpression:exit' (node) {
+        // module.exports = {} in .vue || .jsx
+        if (!_this.isVueComponentFile(node, filePath) || isDuplicateNode(node.right)) return
+        cb(node.right)
       },
       'ExportDefaultDeclaration:exit' (node) {
         // export default {} in .vue || .jsx

--- a/tests/lib/rules/require-direct-export.js
+++ b/tests/lib/rules/require-direct-export.js
@@ -35,6 +35,13 @@ ruleTester.run('require-direct-export', rule, {
             export default {}
           `,
       parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+            module.exports = {}
+          `,
+      parserOptions
     }
   ],
 
@@ -49,6 +56,18 @@ ruleTester.run('require-direct-export', rule, {
       errors: [{
         message: 'Expected the component literal to be directly exported.',
         type: 'ExportDefaultDeclaration',
+        line: 3
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+          var A = {};
+          module.exports = A`,
+      parserOptions,
+      errors: [{
+        message: 'Expected the component literal to be directly exported.',
+        type: 'AssignmentExpression',
         line: 3
       }]
     }

--- a/tests/lib/utils/vue-component.js
+++ b/tests/lib/utils/vue-component.js
@@ -327,6 +327,11 @@ ruleTester.run('vue-component', rule, {
       filename: 'test.js',
       code: `export default { }`,
       parserOptions
+    },
+    {
+      filename: 'test.js',
+      code: `module.exports = { }`,
+      parserOptions
     }
   ].concat(validTests('js')).concat(validTests('jsx')).concat(validTests('vue')),
   invalid: [
@@ -337,8 +342,20 @@ ruleTester.run('vue-component', rule, {
       errors: [makeError(1)]
     },
     {
+      filename: 'test.vue',
+      code: `module.exports = { }`,
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
       filename: 'test.jsx',
       code: `export default { }`,
+      parserOptions,
+      errors: [makeError(1)]
+    },
+    {
+      filename: 'test.jsx',
+      code: `module.exports = { }`,
       parserOptions,
       errors: [makeError(1)]
     }


### PR DESCRIPTION
Recognize exported objects in .vue files as Vue components, even if
they're exported using module.exports rather than export default.

Also recognize module.exports for the purposes of require-direct-export:
let A = { /* stuff */ }; module.exports = A;
is now a violation of this rule.