### PR TITLE
New: Add `vue/no-deprecated-inline-template` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -40,6 +40,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 |:--------|:------------|:---|
 | [vue/no-async-in-computed-properties](./no-async-in-computed-properties.md) | disallow asynchronous actions in computed properties |  |
 | [vue/no-deprecated-filter](./no-deprecated-filter.md) | disallow using deprecated filters syntax |  |
+| [vue/no-deprecated-inline-template](./no-deprecated-inline-template.md) | disallow using deprecated `inline-template` attribute |  |
 | [vue/no-deprecated-scope-attribute](./no-deprecated-scope-attribute.md) | disallow deprecated `scope` attribute (in Vue.js 2.5.0+) | :wrench: |
 | [vue/no-deprecated-slot-attribute](./no-deprecated-slot-attribute.md) | disallow deprecated `slot` attribute (in Vue.js 2.6.0+) | :wrench: |
 | [vue/no-deprecated-slot-scope-attribute](./no-deprecated-slot-scope-attribute.md) | disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+) | :wrench: |

--- a/docs/rules/no-deprecated-inline-template.md
+++ b/docs/rules/no-deprecated-inline-template.md
@@ -1,0 +1,46 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-deprecated-inline-template
+description: disallow using deprecated `inline-template` attribute
+---
+# vue/no-deprecated-inline-template
+> disallow using deprecated `inline-template` attribute
+
+- :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/vue3-strongly-recommended"` and `"plugin:vue/vue3-recommended"`.
+
+## :book: Rule Details
+
+This rule reports deprecated `inline-template` attributes (removed in Vue.js v3.0.0+)
+
+<eslint-code-block :rules="{'vue/no-deprecated-inline-template': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <my-comnponent />
+
+  <!-- ✗ BAD -->
+  <my-component inline-template>
+    <div>
+      <p>These are compiled as the component's own template.</p>
+      <p>Not parent's transclusion content.</p>
+    </div>
+  </my-component>
+</template>
+```
+
+</eslint-code-block>
+
+### :wrench: Options
+
+Nothing.
+
+## :books: Further Reading
+
+- [Vue RFCs - 0016-remove-inline-templates](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0016-remove-inline-templates.md)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-deprecated-inline-template.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-deprecated-inline-template.js)

--- a/lib/configs/vue3-essential.js
+++ b/lib/configs/vue3-essential.js
@@ -8,6 +8,7 @@ module.exports = {
   rules: {
     'vue/no-async-in-computed-properties': 'error',
     'vue/no-deprecated-filter': 'error',
+    'vue/no-deprecated-inline-template': 'error',
     'vue/no-deprecated-scope-attribute': 'error',
     'vue/no-deprecated-slot-attribute': 'error',
     'vue/no-deprecated-slot-scope-attribute': 'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ module.exports = {
     'no-confusing-v-for-v-if': require('./rules/no-confusing-v-for-v-if'),
     'no-custom-modifiers-on-v-model': require('./rules/no-custom-modifiers-on-v-model'),
     'no-deprecated-filter': require('./rules/no-deprecated-filter'),
+    'no-deprecated-inline-template': require('./rules/no-deprecated-inline-template'),
     'no-deprecated-scope-attribute': require('./rules/no-deprecated-scope-attribute'),
     'no-deprecated-slot-attribute': require('./rules/no-deprecated-slot-attribute'),
     'no-deprecated-slot-scope-attribute': require('./rules/no-deprecated-slot-scope-attribute'),

--- a/lib/rules/no-deprecated-inline-template.js
+++ b/lib/rules/no-deprecated-inline-template.js
@@ -1,0 +1,43 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow using deprecated `inline-template` attribute',
+      categories: ['vue3-essential'],
+      url: 'https://eslint.vuejs.org/rules/no-deprecated-inline-template.html'
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      unexpected: '`inline-template` are deprecated.'
+    }
+  },
+
+  create: function (context) {
+    return utils.defineTemplateBodyVisitor(context, {
+      "VAttribute[directive=false] > VIdentifier[rawName='inline-template']" (node) {
+        context.report({
+          node,
+          loc: node.loc,
+          messageId: 'unexpected'
+        })
+      }
+    })
+  }
+}

--- a/tests/lib/rules/no-deprecated-inline-template.js
+++ b/tests/lib/rules/no-deprecated-inline-template.js
@@ -1,0 +1,68 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-deprecated-inline-template')
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2019 }
+})
+
+ruleTester.run('no-deprecated-inline-template', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: '<template><my-component><div /></my-component></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div /></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><my-component :inline-template="foo"><div /></my-component></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><my-component Inline-Template="foo"><div /></my-component></template>'
+    }
+  ],
+
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: '<template><my-component inline-template><div /></my-component></template>',
+      errors: [
+        {
+          line: 1,
+          column: 25,
+          messageId: 'unexpected',
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><my-component inline-template=""><div /></my-component></template>',
+      errors: [{ messageId: 'unexpected' }]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><my-component inline-template="foo"><div /></my-component></template>',
+      errors: [{ messageId: 'unexpected' }]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the `vue/no-deprecated-inline-template` rule.

This rule reports deprecated `inline-template` attributes (removed in Vue.js v3.0.0+)

ref #1035