### PR TITLE
New: Add `vue/require-shorthand-boolean-prop` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -277,6 +277,7 @@ For example:
 | [vue/padding-line-between-blocks](./padding-line-between-blocks.md) | require or disallow padding lines between blocks | :wrench: |
 | [vue/require-direct-export](./require-direct-export.md) | require the component to be directly exported |  |
 | [vue/require-name-property](./require-name-property.md) | require a name property in Vue components |  |
+| [vue/require-shorthand-boolean-prop](./require-shorthand-boolean-prop.md) | enforce or forbid passing `true` value to a prop |  |
 | [vue/script-indent](./script-indent.md) | enforce consistent indentation in `<script>` | :wrench: |
 | [vue/sort-keys](./sort-keys.md) | enforce sort-keys in a manner that is compatible with order-in-components |  |
 | [vue/space-infix-ops](./space-infix-ops.md) | require spacing around infix operators | :wrench: |

--- a/docs/rules/require-shorthand-boolean-prop.md
+++ b/docs/rules/require-shorthand-boolean-prop.md
@@ -1,0 +1,66 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/require-shorthand-boolean-prop
+description: enforce or forbid passing `true` value to a prop
+---
+# vue/require-shorthand-boolean-prop
+> enforce or forbid passing `true` value to a prop
+
+## :book: Rule Details
+
+This rule aims at enforcing usage of shorthand properties for `true` values in Vue templates.
+
+<eslint-code-block :rules="{'vue/require-shorthand-boolean-prop': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <component
+    isValid
+  />
+  
+  <!-- ✗ BAD -->
+  <component
+    :isValid="true"
+  />
+</template>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+```json
+{
+  "vue/require-shorthand-boolean-prop": ["error", "always" | "never"]
+}
+```
+- `"always"` (default) ... Always use shorthand prop.
+- `"never"` ... Never use shorthand prop. Instead pass `true` explicitly.
+
+### `"never"`
+
+<eslint-code-block :rules="{'vue/require-shorthand-boolean-prop': ['error', 'never']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <component
+    :isValid="true"
+    isValid
+  />
+  
+  <!-- ✗ BAD -->
+  <component
+    isValid
+  />
+</template>
+```
+
+</eslint-code-block>
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/require-shorthand-boolean-prop.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/require-shorthand-boolean-prop.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,6 +82,7 @@ module.exports = {
     'require-prop-type-constructor': require('./rules/require-prop-type-constructor'),
     'require-prop-types': require('./rules/require-prop-types'),
     'require-render-return': require('./rules/require-render-return'),
+    'require-shorthand-boolean-prop': require('./rules/require-shorthand-boolean-prop'),
     'require-v-for-key': require('./rules/require-v-for-key'),
     'require-valid-default-prop': require('./rules/require-valid-default-prop'),
     'return-in-computed-property': require('./rules/return-in-computed-property'),

--- a/lib/rules/require-shorthand-boolean-prop.js
+++ b/lib/rules/require-shorthand-boolean-prop.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Enforce or forbid passing `true` value to a prop
+ * @author Anton Veselev
+ */
+'use strict'
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'enforce or forbid passing `true` value to a prop',
+      categories: ['vue3-uncategorized', 'uncategorized'],
+      recommended: false,
+      url: 'https://eslint.vuejs.org/rules/require-shorthand-boolean-prop.html'
+    },
+    fixable: 'code',
+    schema: [
+      {
+        enum: ['always', 'never']
+      }
+    ]
+  },
+
+  create (context) {
+    const isAlways = context.options[0] !== 'never'
+
+    return utils.defineTemplateBodyVisitor(context, {
+      VStartTag (node) {
+        for (const attr of node.attributes) {
+          if (attr.value === null) {
+            if (!isAlways) {
+              context.report({
+                node,
+                loc: attr.loc,
+                message: 'Unexpected shorthand prop.',
+                fix (fixer) {
+                  const { rawName } = attr.key || {}
+                  return rawName
+                    ? fixer.replaceTextRange(attr.range, `:${rawName}="true"`)
+                    : null
+                }
+              })
+            }
+            continue
+          }
+          const { expression } = attr.value
+          if (expression && expression.value === true) {
+            if (isAlways) {
+              context.report({
+                node,
+                loc: attr.loc,
+                message: "Unexpected 'true' value.",
+                fix (fixer) {
+                  const { rawName } = (attr.key || {}).argument || {}
+                  return rawName
+                    ? fixer.replaceTextRange(attr.range, rawName)
+                    : null
+                }
+              })
+            }
+            continue
+          }
+        }
+      }
+    })
+  }
+}

--- a/tests/lib/rules/require-shorthand-boolean-prop.js
+++ b/tests/lib/rules/require-shorthand-boolean-prop.js
@@ -1,0 +1,157 @@
+/**
+ * @fileoverview Enforce or forbid passing `true` value to a prop
+ * @author Anton Veselev
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/require-shorthand-boolean-prop')
+
+const { RuleTester } = require('eslint')
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+ruleTester.run('require-shorthand-boolean-prop', rule, {
+
+  valid: [
+    {
+      code: `
+        <template>
+          <component />
+        </template>
+      `
+    },
+    {
+      code: `
+        <template>
+          <component
+            isValid
+          />
+        </template>
+      `
+    },
+    {
+      code: `
+        <template>
+          <component
+            isValid
+          />
+        </template>
+      `,
+      options: ['always']
+    },
+    {
+      code: `
+        <template>
+          <component
+            :isValid="false"
+          />
+        </template>
+      `,
+      options: ['always']
+    },
+    {
+      code: `
+        <template>
+          <component
+            :isValid="true"
+          />
+        </template>
+      `,
+      options: ['never']
+    },
+    {
+      code: `
+        <template>
+          <component
+            :isValid="false"
+          />
+        </template>
+      `,
+      options: ['never']
+    },
+    {
+      code: `
+        <template>
+          <component
+            str="true"
+          />
+        </template>
+      `
+    },
+    {
+      code: `
+        <template>
+          <component
+            str="true"
+          />
+        </template>
+      `,
+      options: ['always']
+    },
+    {
+      code: `
+        <template>
+          <component
+            str="true"
+          />
+        </template>
+      `,
+      options: ['never']
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        <template>
+          <component
+            :isValid="true"
+          />
+        </template>
+      `,
+      errors: [{
+        message: "Unexpected 'true' value.",
+        type: 'VStartTag'
+      }]
+    },
+    {
+      code: `
+        <template>
+          <component
+            isValid
+          />
+        </template>
+      `,
+      options: ['never'],
+      errors: [{
+        message: 'Unexpected shorthand prop.',
+        type: 'VStartTag'
+      }]
+    },
+    {
+      code: `
+        <template>
+          <component
+            :isValid="true"
+          />
+        </template>
+      `,
+      options: ['always'],
+      errors: [{
+        message: "Unexpected 'true' value.",
+        type: 'VStartTag'
+      }]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the `vue/require-shorthand-boolean-prop` rule.

ref https://github.com/vuejs/eslint-plugin-vue/issues/775