### PR TITLE
repro: arrows function as emits validators fails

### DIFF
--- a/tests/lib/rules/return-in-emits-validator.js
+++ b/tests/lib/rules/return-in-emits-validator.js
@@ -35,6 +35,7 @@ ruleTester.run('return-in-emits-validator', rule, {
             bar: function (e) {
               return true
             },
+            bar: () => true,
             baz: (e) => {
               return e
             },


### PR DESCRIPTION
Using an arrow function as an emit validator fails:

```
error: Expected to return a boolean value in "selected" emits validator (vue/return-in-emits-validator) at src/chapters/tests/User.vue:17:19:
  15 |
  16 |   emits: {
> 17 |     selected: () => true
     |                   ^
  18 |   },
```

I was keen to fix it myself, but I don't know what is missing. So here is a simple repro.