### PR TITLE
Fix false positives for arrow function in `vue/return-in-emits-validator`rule

### DIFF
--- a/lib/rules/return-in-emits-validator.js
+++ b/lib/rules/return-in-emits-validator.js
@@ -74,6 +74,14 @@ module.exports = {
           },
           ':function' (node) {
             scopeStack = { upper: scopeStack, functionNode: node, hasReturnValue: false, possibleOfReturnTrue: false }
+
+            if (node.type === 'ArrowFunctionExpression' && node.expression) {
+              scopeStack.hasReturnValue = true
+
+              if (!isFalsy(node.body)) {
+                scopeStack.possibleOfReturnTrue = true
+              }
+            }
           },
           ReturnStatement (node) {
             if (node.argument) {

--- a/tests/lib/rules/return-in-emits-validator.js
+++ b/tests/lib/rules/return-in-emits-validator.js
@@ -38,6 +38,7 @@ ruleTester.run('return-in-emits-validator', rule, {
             baz: (e) => {
               return e
             },
+            baz2: (e) => e,
             qux () {
               if (foo) {
                 return true
@@ -171,6 +172,22 @@ ruleTester.run('return-in-emits-validator', rule, {
       `,
       errors: [{
         message: 'Expected to return a boolean value in "foo" emits validator.',
+        line: 5
+      }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+          emits: {
+            foo: () => false
+          }
+        }
+        </script>
+      `,
+      errors: [{
+        message: 'Expected to return a true value in "foo" emits validator.',
         line: 5
       }]
     },


### PR DESCRIPTION
close #1137