### PR TITLE
Add `vue/prefer-template` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -292,6 +292,7 @@ For example:
 | [vue/no-unsupported-features](./no-unsupported-features.md) | disallow unsupported Vue.js syntax on the specified version | :wrench: |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |
 | [vue/padding-line-between-blocks](./padding-line-between-blocks.md) | require or disallow padding lines between blocks | :wrench: |
+| [vue/prefer-template](./prefer-template.md) | require template literals instead of string concatenation | :wrench: |
 | [vue/require-direct-export](./require-direct-export.md) | require the component to be directly exported |  |
 | [vue/require-explicit-emits](./require-explicit-emits.md) | require `emits` option with name triggered by `$emit()` |  |
 | [vue/require-name-property](./require-name-property.md) | require a name property in Vue components |  |

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -1,0 +1,23 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/prefer-template
+description: require template literals instead of string concatenation
+---
+# vue/prefer-template
+> require template literals instead of string concatenation
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [prefer-template] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [prefer-template]
+
+[prefer-template]: https://eslint.org/docs/rules/prefer-template
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/prefer-template.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/prefer-template.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,7 @@ module.exports = {
     'object-curly-spacing': require('./rules/object-curly-spacing'),
     'order-in-components': require('./rules/order-in-components'),
     'padding-line-between-blocks': require('./rules/padding-line-between-blocks'),
+    'prefer-template': require('./rules/prefer-template'),
     'prop-name-casing': require('./rules/prop-name-casing'),
     'require-component-is': require('./rules/require-component-is'),
     'require-default-prop': require('./rules/require-default-prop'),

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -1,0 +1,11 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(
+  require('eslint/lib/rules/prefer-template')
+)

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -1,0 +1,63 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/prefer-template')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020 }
+})
+
+tester.run('prefer-template', rule, {
+  valid: [
+    `
+    <template>
+      <div :class="[\`foo-\${bar}\`]" />
+    </template>
+    `,
+    `
+    <template>
+      <div :[\`foo\${bar}\`]="value" />
+    </template>
+    `
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div :class="['foo-' + bar]" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :class="[\`foo-\${  bar}\`]" />
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Unexpected string concatenation.',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div :['foo'+bar]="value" />
+      </template>`,
+      output: `
+      <template>
+        <div :[\`foo\${bar}\`]="value" />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected string concatenation.',
+          line: 3
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [prefer-template](https://eslint.org/docs/rules/prefer-template) core rule to apply to the expressions in `<template>`.