### PR TITLE
Add `vue/template-curly-spacing` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -300,6 +300,7 @@ For example:
 | [vue/space-infix-ops](./space-infix-ops.md) | require spacing around infix operators | :wrench: |
 | [vue/space-unary-ops](./space-unary-ops.md) | enforce consistent spacing before or after unary operators | :wrench: |
 | [vue/static-class-names-order](./static-class-names-order.md) | enforce static class names order | :wrench: |
+| [vue/template-curly-spacing](./template-curly-spacing.md) | require or disallow spacing around embedded expressions of template strings | :wrench: |
 | [vue/v-on-function-call](./v-on-function-call.md) | enforce or forbid parentheses after method calls without arguments in `v-on` directives | :wrench: |
 
 ## Deprecated

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -1,0 +1,23 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/template-curly-spacing
+description: require or disallow spacing around embedded expressions of template strings
+---
+# vue/template-curly-spacing
+> require or disallow spacing around embedded expressions of template strings
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [template-curly-spacing] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [template-curly-spacing]
+
+[template-curly-spacing]: https://eslint.org/docs/rules/template-curly-spacing
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/template-curly-spacing.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/template-curly-spacing.js)

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -32,6 +32,7 @@ module.exports = {
     'vue/script-indent': 'off',
     'vue/singleline-html-element-content-newline': 'off',
     'vue/space-infix-ops': 'off',
-    'vue/space-unary-ops': 'off'
+    'vue/space-unary-ops': 'off',
+    'vue/template-curly-spacing': 'off'
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,7 @@ module.exports = {
     'space-infix-ops': require('./rules/space-infix-ops'),
     'space-unary-ops': require('./rules/space-unary-ops'),
     'static-class-names-order': require('./rules/static-class-names-order'),
+    'template-curly-spacing': require('./rules/template-curly-spacing'),
     'this-in-template': require('./rules/this-in-template'),
     'use-v-on-exact': require('./rules/use-v-on-exact'),
     'v-bind-style': require('./rules/v-bind-style'),

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -1,0 +1,12 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(
+  require('eslint/lib/rules/template-curly-spacing'),
+  { skipDynamicArguments: true }
+)

--- a/tests/lib/rules/template-curly-spacing.js
+++ b/tests/lib/rules/template-curly-spacing.js
@@ -1,0 +1,90 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/template-curly-spacing')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020 }
+})
+
+tester.run('template-curly-spacing', rule, {
+  valid: [
+    `
+    <template>
+      <div :class="[\`foo-\${bar}\`]" />
+    </template>
+    `,
+    `
+    <template>
+      <div :[\`foo\${bar}\`]="value" />
+    </template>
+    `,
+    {
+      code: `
+      <template>
+        <div :class="[\`foo-\${ bar }\`]" />
+      </template>
+      `,
+      options: ['always']
+    },
+    {
+      code: `
+      <template>
+        <div :[\`foo\${bar}\`]="value" />
+      </template>
+      `,
+      options: ['always']
+    }
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div :class="[\`foo-\${ bar }\`]" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :class="[\`foo-\${bar}\`]" />
+      </template>
+      `,
+      errors: [
+        {
+          message: "Unexpected space(s) after '${'.",
+          line: 3
+        },
+        {
+          message: "Unexpected space(s) before '}'.",
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div :class="[\`foo-\${bar}\`]" />
+      </template>
+      `,
+      options: ['always'],
+      output: `
+      <template>
+        <div :class="[\`foo-\${ bar }\`]" />
+      </template>
+      `,
+      errors: [
+        {
+          message: "Expected space(s) after '${'.",
+          line: 3
+        },
+        {
+          message: "Expected space(s) before '}'.",
+          line: 3
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [template-curly-spacing](https://eslint.org/docs/rules/template-curly-spacing) core rule to apply to the expressions in `<template>`.