### PR TITLE
Fixed false negatives when using ignorePattern for `vue/no-unused-var` rule.

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -35,31 +35,31 @@ module.exports = {
 
   create(context) {
     const option = context.options[0] || {}
-    const pattern = option.ignorePattern
-    let regExp = null
-    if (pattern) {
-      regExp = new RegExp(pattern, 'u')
+    const ignorePattern = option.ignorePattern
+    let ignoreRegEx = null
+    if (ignorePattern) {
+      ignoreRegEx = new RegExp(ignorePattern, 'u')
     }
     return utils.defineTemplateBodyVisitor(context, {
       VElement(node) {
         const variables = node.variables
-
-        for (
-          let i = variables.length - 1;
-          i >= 0 &&
-          !variables[i].references.length &&
-          // eslint-disable-next-line no-unmodified-loop-condition
-          (regExp === null || !regExp.test(variables[i].id.name));
-          i--
-        ) {
+        for (let i = variables.length - 1; i >= 0; i--) {
           const variable = variables[i]
+
+          if (variable.references.length) {
+            break
+          }
+
+          if (ignoreRegEx != null && ignoreRegEx.test(variable.id.name)) {
+            continue
+          }
           context.report({
             node: variable.id,
             loc: variable.id.loc,
             message: `'{{name}}' is defined but never used.`,
             data: variable.id,
             suggest:
-              pattern === '^_'
+              ignorePattern === '^_'
                 ? [
                     {
                       desc: `Replace the ${variable.id.name} with _${variable.id.name}`,

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -157,6 +157,11 @@ tester.run('no-unused-vars', rule, {
     {
       code: '<template><div v-for="_i in foo" ></div></template>',
       errors: ["'_i' is defined but never used."]
+    },
+    {
+      code: '<template><div v-for="(a, _i) in foo" ></div></template>',
+      options: [{ ignorePattern: '^_' }],
+      errors: ["'a' is defined but never used."]
     }
   ]
 })


### PR DESCRIPTION
Fixed an issue where variables before the one matching `ignorePattern` were not checked.