### PR TITLE
Add `vue/no-useless-concat` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -302,6 +302,7 @@ For example:
 | [vue/no-unregistered-components](./no-unregistered-components.md) | disallow using components that are not registered inside templates |  |
 | [vue/no-unsupported-features](./no-unsupported-features.md) | disallow unsupported Vue.js syntax on the specified version | :wrench: |
 | [vue/no-unused-properties](./no-unused-properties.md) | disallow unused properties |  |
+| [vue/no-useless-concat](./no-useless-concat.md) | disallow unnecessary concatenation of literals or template literals |  |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |
 | [vue/padding-line-between-blocks](./padding-line-between-blocks.md) | require or disallow padding lines between blocks | :wrench: |
 | [vue/prefer-template](./prefer-template.md) | require template literals instead of string concatenation | :wrench: |

--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -1,0 +1,21 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-useless-concat
+description: disallow unnecessary concatenation of literals or template literals
+---
+# vue/no-useless-concat
+> disallow unnecessary concatenation of literals or template literals
+
+This rule is the same rule as core [no-useless-concat] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [no-useless-concat]
+
+[no-useless-concat]: https://eslint.org/docs/rules/no-useless-concat
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-useless-concat.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-useless-concat.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,6 +91,7 @@ module.exports = {
     'no-unused-properties': require('./rules/no-unused-properties'),
     'no-unused-vars': require('./rules/no-unused-vars'),
     'no-use-v-if-with-v-for': require('./rules/no-use-v-if-with-v-for'),
+    'no-useless-concat': require('./rules/no-useless-concat'),
     'no-v-html': require('./rules/no-v-html'),
     'no-v-model-argument': require('./rules/no-v-model-argument'),
     'no-watch-after-await': require('./rules/no-watch-after-await'),

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -1,0 +1,9 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(require('eslint/lib/rules/no-useless-concat'))

--- a/tests/lib/rules/no-useless-concat.js
+++ b/tests/lib/rules/no-useless-concat.js
@@ -1,0 +1,30 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-useless-concat')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('no-useless-concat', rule, {
+  valid: [
+    `<template><div :attr="'foo-bar'" /></template>`,
+    '<template><div attr="foo-bar" /></template>',
+    `<template><div :[\`foo-bar\`]="a" /></template>`
+  ],
+  invalid: [
+    {
+      code: `<template><div :attr="'foo'+'bar'" /></template>`,
+      errors: ['Unexpected string concatenation of literals.']
+    },
+    {
+      code: `<template><div :[\`foo\`+\`bar\`]="a" /></template>`,
+      errors: ['Unexpected string concatenation of literals.']
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [no-useless-concat](https://eslint.org/docs/rules/no-useless-concat) core rule to apply to the expressions in `<template>`.