### PR TITLE
Add `vue/no-deprecated-dollar-scopedslots-api` rule.

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -43,6 +43,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 | [vue/no-async-in-computed-properties](./no-async-in-computed-properties.md) | disallow asynchronous actions in computed properties |  |
 | [vue/no-deprecated-data-object-declaration](./no-deprecated-data-object-declaration.md) | disallow using deprecated object declaration on data (in Vue.js 3.0.0+) | :wrench: |
 | [vue/no-deprecated-dollar-listeners-api](./no-deprecated-dollar-listeners-api.md) | disallow using deprecated `$listeners` (in Vue.js 3.0.0+) |  |
+| [vue/no-deprecated-dollar-scopedslots-api](./no-deprecated-dollar-scopedslots-api.md) | disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+) | :wrench: |
 | [vue/no-deprecated-events-api](./no-deprecated-events-api.md) | disallow using deprecated events api (in Vue.js 3.0.0+) |  |
 | [vue/no-deprecated-filter](./no-deprecated-filter.md) | disallow using deprecated filters syntax (in Vue.js 3.0.0+) |  |
 | [vue/no-deprecated-functional-template](./no-deprecated-functional-template.md) | disallow using deprecated the `functional` template (in Vue.js 3.0.0+) |  |

--- a/docs/rules/no-deprecated-dollar-scopedslots-api.md
+++ b/docs/rules/no-deprecated-dollar-scopedslots-api.md
@@ -1,0 +1,47 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-deprecated-dollar-scopedslots-api
+description: disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+)
+---
+# vue/no-deprecated-dollar-scopedslots-api
+> disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+)
+
+- :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/vue3-strongly-recommended"` and `"plugin:vue/vue3-recommended"`.
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports use of deprecated `$scopedSlots`. (in Vue.js 3.0.0+).
+
+<eslint-code-block fix :rules="{'vue/no-deprecated-dollar-scopedslots-api': ['error']}">
+
+```vue
+<template>
+  <!-- ✗ BAD -->
+  <div v-if="$scopedSlots.default"><slot /></div>
+</template>
+<script>
+export default {
+  render() {
+    /* ✗ BAD */
+    return this.$scopedSlots.default()
+  }
+}
+</script>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :books: Further reading
+
+- [Vue RFCs - 0006-slots-unification](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0006-slots-unification.md)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-deprecated-dollar-scopedslots-api.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-deprecated-dollar-scopedslots-api.js)

--- a/lib/configs/vue3-essential.js
+++ b/lib/configs/vue3-essential.js
@@ -11,6 +11,7 @@ module.exports = {
     'vue/no-async-in-computed-properties': 'error',
     'vue/no-deprecated-data-object-declaration': 'error',
     'vue/no-deprecated-dollar-listeners-api': 'error',
+    'vue/no-deprecated-dollar-scopedslots-api': 'error',
     'vue/no-deprecated-events-api': 'error',
     'vue/no-deprecated-filter': 'error',
     'vue/no-deprecated-functional-template': 'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,7 @@ module.exports = {
     'no-custom-modifiers-on-v-model': require('./rules/no-custom-modifiers-on-v-model'),
     'no-deprecated-data-object-declaration': require('./rules/no-deprecated-data-object-declaration'),
     'no-deprecated-dollar-listeners-api': require('./rules/no-deprecated-dollar-listeners-api'),
+    'no-deprecated-dollar-scopedslots-api': require('./rules/no-deprecated-dollar-scopedslots-api'),
     'no-deprecated-events-api': require('./rules/no-deprecated-events-api'),
     'no-deprecated-filter': require('./rules/no-deprecated-filter'),
     'no-deprecated-functional-template': require('./rules/no-deprecated-functional-template'),

--- a/lib/rules/no-deprecated-dollar-scopedslots-api.js
+++ b/lib/rules/no-deprecated-dollar-scopedslots-api.js
@@ -1,0 +1,79 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+)',
+      categories: ['vue3-essential'],
+      url:
+        'https://eslint.vuejs.org/rules/no-deprecated-dollar-scopedslots-api.html'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      deprecated: 'The `$scopedSlots` is deprecated.'
+    }
+  },
+
+  create(context) {
+    return utils.defineTemplateBodyVisitor(
+      context,
+      {
+        VExpressionContainer(node) {
+          for (const reference of node.references) {
+            if (reference.variable != null) {
+              // Not vm reference
+              continue
+            }
+            if (reference.id.name === '$scopedSlots') {
+              context.report({
+                node: reference.id,
+                messageId: 'deprecated',
+                fix(fixer) {
+                  return fixer.replaceText(reference.id, '$slots')
+                }
+              })
+            }
+          }
+        }
+      },
+      utils.defineVueVisitor(context, {
+        MemberExpression(node) {
+          if (
+            node.property.type !== 'Identifier' ||
+            node.property.name !== '$scopedSlots'
+          ) {
+            return
+          }
+          if (!utils.isThis(node.object, context)) {
+            return
+          }
+
+          context.report({
+            node: node.property,
+            messageId: 'deprecated',
+            fix(fixer) {
+              return fixer.replaceText(node.property, '$slots')
+            }
+          })
+        }
+      })
+    )
+  }
+}

--- a/tests/lib/rules/no-deprecated-dollar-scopedslots-api.js
+++ b/tests/lib/rules/no-deprecated-dollar-scopedslots-api.js
@@ -1,0 +1,288 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-deprecated-dollar-scopedslots-api')
+
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+})
+ruleTester.run('no-deprecated-dollar-scopedslots-api', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-bind="$attrs"/>
+        </template>
+        <script>
+        export default {
+          mounted () {
+            this.$emit('start')
+          }
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+          methods: {
+            click () {
+              this.$emit('click')
+            }
+          }
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+        }
+        const another = function () {
+          console.log(this.$scopedSlots)
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div foo="$scopedSlots"/>
+        </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-on="() => {
+            function click ($scopedSlots) {
+              fn(foo.$scopedSlots)
+              fn($scopedSlots)
+            }
+          }"/>
+          <div v-for="$scopedSlots in list">
+            <div v-on="$scopedSlots">
+          </div>
+          <VueComp>
+            <template v-slot="{$scopedSlots}">
+              <div v-on="$scopedSlots">
+            </template>
+          </VueComp>
+        </template>
+        <script>
+        export default {
+          methods: {
+            click ($scopedSlots) {
+              foo.$scopedSlots
+            }
+          }
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+          computed: {
+            foo () {
+              const {vm} = this
+              return vm.$scopedSlots
+            }
+          }
+        }
+        </script>
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="$scopedSlots.default"/>
+        </template>
+        <script>
+        export default {
+          render() {
+            return this.$scopedSlots.foo('bar')
+          }
+        }
+        </script>
+      `,
+      output: `
+        <template>
+          <div v-if="$slots.default"/>
+        </template>
+        <script>
+        export default {
+          render() {
+            return this.$slots.foo('bar')
+          }
+        }
+        </script>
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 22,
+          messageId: 'deprecated',
+          endLine: 3,
+          endColumn: 34
+        },
+        {
+          line: 8,
+          column: 25,
+          messageId: 'deprecated',
+          endLine: 8,
+          endColumn: 37
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-for="slot in $scopedSlots"/>
+          <div :foo="$scopedSlots"/>
+        </template>
+        <script>
+        export default {
+          computed: {
+            foo () {
+              fn(this.$scopedSlots)
+            }
+          }
+        }
+        </script>
+      `,
+      output: `
+        <template>
+          <div v-for="slot in $slots"/>
+          <div :foo="$slots"/>
+        </template>
+        <script>
+        export default {
+          computed: {
+            foo () {
+              fn(this.$slots)
+            }
+          }
+        }
+        </script>
+      `,
+      errors: [
+        {
+          line: 3,
+          column: 31,
+          messageId: 'deprecated',
+          endLine: 3,
+          endColumn: 43
+        },
+        {
+          line: 4,
+          column: 22,
+          messageId: 'deprecated',
+          endLine: 4,
+          endColumn: 34
+        },
+        {
+          line: 10,
+          column: 23,
+          messageId: 'deprecated',
+          endLine: 10,
+          endColumn: 35
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+          render() {
+            const vm = this
+            return vm.$scopedSlots.foo('bar')
+          }
+        }
+        </script>
+      `,
+      output: `
+        <script>
+        export default {
+          render() {
+            const vm = this
+            return vm.$slots.foo('bar')
+          }
+        }
+        </script>
+      `,
+      errors: [
+        {
+          line: 6,
+          column: 23,
+          messageId: 'deprecated'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+          render() {
+            const vm = this
+            function fn() {
+              return vm.$scopedSlots
+            }
+            return fn().foo('bar')
+          }
+        }
+        </script>
+      `,
+      output: `
+        <script>
+        export default {
+          render() {
+            const vm = this
+            function fn() {
+              return vm.$slots
+            }
+            return fn().foo('bar')
+          }
+        }
+        </script>
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 25,
+          messageId: 'deprecated'
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds `vue/no-deprecated-dollar-scopedslots-api` rule.

`vue/no-deprecated-dollar-scopedslots-api` rule reports use of deprecated `$scopedSlots`.

- [0006-slots-unification](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0006-slots-unification.md)