### PR TITLE
Improved `vue/no-ref-as-operand` rule.

### DIFF
--- a/docs/rules/no-ref-as-operand.md
+++ b/docs/rules/no-ref-as-operand.md
@@ -11,7 +11,8 @@ description: disallow use of value wrapped by `ref()` (Composition API) as an op
 
 ## :book: Rule Details
 
-This rule reports cases where a ref is used incorrectly as an operand.
+This rule reports cases where a ref is used incorrectly as an operand.  
+You must use `.value` to access the `Ref` value.
 
 <eslint-code-block :rules="{'vue/no-ref-as-operand': ['error']}">
 

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -4,6 +4,7 @@
  */
 'use strict'
 const { ReferenceTracker, findVariable } = require('eslint-utils')
+const utils = require('../utils')
 
 module.exports = {
   meta: {
@@ -18,19 +19,23 @@ module.exports = {
     schema: [],
     messages: {
       requireDotValue:
-        'Must use `.value` to read or write the value wrapped by `ref()`.'
+        'Must use `.value` to read or write the value wrapped by `{{method}}()`.'
     }
   },
   create(context) {
     const refReferenceIds = new Map()
 
     function reportIfRefWrapped(node) {
-      if (!refReferenceIds.has(node)) {
+      const data = refReferenceIds.get(node)
+      if (!data) {
         return
       }
       context.report({
         node,
-        messageId: 'requireDotValue'
+        messageId: 'requireDotValue',
+        data: {
+          method: data.method
+        }
       })
     }
     return {
@@ -41,11 +46,23 @@ module.exports = {
             [ReferenceTracker.ESM]: true,
             ref: {
               [ReferenceTracker.CALL]: true
+            },
+            computed: {
+              [ReferenceTracker.CALL]: true
+            },
+            toRef: {
+              [ReferenceTracker.CALL]: true
+            },
+            customRef: {
+              [ReferenceTracker.CALL]: true
+            },
+            shallowRef: {
+              [ReferenceTracker.CALL]: true
             }
           }
         }
 
-        for (const { node } of tracker.iterateEsmReferences(traceMap)) {
+        for (const { node, path } of tracker.iterateEsmReferences(traceMap)) {
           const variableDeclarator = node.parent
           if (
             !variableDeclarator ||
@@ -73,7 +90,8 @@ module.exports = {
 
             refReferenceIds.set(reference.identifier, {
               variableDeclarator,
-              variableDeclaration
+              variableDeclaration,
+              method: path[1]
             })
           }
         }
@@ -108,13 +126,13 @@ module.exports = {
           return
         }
         // Report only constants.
-        const info = refReferenceIds.get(node)
-        if (!info) {
+        const data = refReferenceIds.get(node)
+        if (!data) {
           return
         }
         if (
-          !info.variableDeclaration ||
-          info.variableDeclaration.kind !== 'const'
+          !data.variableDeclaration ||
+          data.variableDeclaration.kind !== 'const'
         ) {
           return
         }
@@ -123,6 +141,26 @@ module.exports = {
       // refValue ? x : y
       'ConditionalExpression>Identifier'(node) {
         if (node.parent.test !== node) {
+          return
+        }
+        reportIfRefWrapped(node)
+      },
+      // `${refValue}`
+      'TemplateLiteral>Identifier'(node) {
+        reportIfRefWrapped(node)
+      },
+      // refValue.x
+      'MemberExpression>Identifier'(node) {
+        if (node.parent.object !== node) {
+          return
+        }
+        const name = utils.getStaticPropertyName(node.parent)
+        if (
+          name === 'value' ||
+          name == null ||
+          // WritableComputedRef
+          name === 'effect'
+        ) {
           return
         }
         reportIfRefWrapped(node)


### PR DESCRIPTION
- Changed `vue/no-ref-as-operand` rule to additionally track variables generated by `computed`, `toRef`, `customRef` and `shallowRef`.
- Changed `vue/no-ref-as-operand` rule to report incorrect use of TemplateLiteral and MemberExpression.