### PR TITLE
Improved to not report that a value is required when parsing error

### DIFF
--- a/lib/rules/valid-v-bind-sync.js
+++ b/lib/rules/valid-v-bind-sync.js
@@ -37,10 +37,7 @@ function isValidElement(node) {
  * @returns {boolean} `true` if the node can be LHS.
  */
 function isLhs(node) {
-  return (
-    Boolean(node) &&
-    (node.type === 'Identifier' || node.type === 'MemberExpression')
-  )
+  return node.type === 'Identifier' || node.type === 'MemberExpression'
 }
 
 // ------------------------------------------------------------------------------
@@ -85,29 +82,31 @@ module.exports = {
           })
         }
 
-        if (node.value) {
-          if (!isLhs(node.value.expression)) {
+        if (!node.value || !node.value.expression) {
+          return
+        }
+
+        if (!isLhs(node.value.expression)) {
+          context.report({
+            node,
+            loc: node.loc,
+            messageId: 'unexpectedNonLhsExpression'
+          })
+        }
+
+        for (const reference of node.value.references) {
+          const id = reference.id
+          if (id.parent.type !== 'VExpressionContainer') {
+            continue
+          }
+          const variable = reference.variable
+          if (variable) {
             context.report({
               node,
               loc: node.loc,
-              messageId: 'unexpectedNonLhsExpression'
+              messageId: 'unexpectedUpdateIterationVariable',
+              data: { varName: id.name }
             })
-          }
-
-          for (const reference of node.value.references) {
-            const id = reference.id
-            if (id.parent.type !== 'VExpressionContainer') {
-              continue
-            }
-            const variable = reference.variable
-            if (variable) {
-              context.report({
-                node,
-                loc: node.loc,
-                messageId: 'unexpectedUpdateIterationVariable',
-                data: { varName: id.name }
-              })
-            }
           }
         }
       }

--- a/lib/rules/valid-v-bind.js
+++ b/lib/rules/valid-v-bind.js
@@ -48,7 +48,7 @@ module.exports = {
           }
         }
 
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/rules/valid-v-else-if.js
+++ b/lib/rules/valid-v-else-if.js
@@ -70,7 +70,7 @@ module.exports = {
             message: "'v-else-if' directives require no modifier."
           })
         }
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/rules/valid-v-else.js
+++ b/lib/rules/valid-v-else.js
@@ -70,7 +70,7 @@ module.exports = {
             message: "'v-else' directives require no modifier."
           })
         }
-        if (utils.hasAttributeValue(node)) {
+        if (node.value) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/rules/valid-v-for.js
+++ b/lib/rules/valid-v-for.js
@@ -137,7 +137,7 @@ module.exports = {
             message: "'v-for' directives require no modifier."
           })
         }
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/rules/valid-v-html.js
+++ b/lib/rules/valid-v-html.js
@@ -44,7 +44,7 @@ module.exports = {
             message: "'v-html' directives require no modifier."
           })
         }
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/rules/valid-v-if.js
+++ b/lib/rules/valid-v-if.js
@@ -62,7 +62,7 @@ module.exports = {
             message: "'v-if' directives require no modifier."
           })
         }
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/rules/valid-v-model.js
+++ b/lib/rules/valid-v-model.js
@@ -42,10 +42,7 @@ function isValidElement(node) {
  * @returns {boolean} `true` if the node can be LHS.
  */
 function isLhs(node) {
-  return (
-    node != null &&
-    (node.type === 'Identifier' || node.type === 'MemberExpression')
-  )
+  return node.type === 'Identifier' || node.type === 'MemberExpression'
 }
 
 /**
@@ -133,39 +130,42 @@ module.exports = {
           }
         }
 
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,
             message: "'v-model' directives require that attribute value."
           })
+          return
         }
-        if (node.value) {
-          if (!isLhs(node.value.expression)) {
+        if (!node.value.expression) {
+          // Parsing error
+          return
+        }
+        if (!isLhs(node.value.expression)) {
+          context.report({
+            node,
+            loc: node.loc,
+            message:
+              "'v-model' directives require the attribute value which is valid as LHS."
+          })
+        }
+
+        for (const reference of node.value.references) {
+          const id = reference.id
+          if (id.parent.type !== 'VExpressionContainer') {
+            continue
+          }
+
+          const variable = getVariable(id.name, element)
+          if (variable != null) {
             context.report({
               node,
               loc: node.loc,
               message:
-                "'v-model' directives require the attribute value which is valid as LHS."
+                "'v-model' directives cannot update the iteration variable '{{varName}}' itself.",
+              data: { varName: id.name }
             })
-          }
-
-          for (const reference of node.value.references) {
-            const id = reference.id
-            if (id.parent.type !== 'VExpressionContainer') {
-              continue
-            }
-
-            const variable = getVariable(id.name, element)
-            if (variable != null) {
-              context.report({
-                node,
-                loc: node.loc,
-                message:
-                  "'v-model' directives cannot update the iteration variable '{{varName}}' itself.",
-                data: { varName: id.name }
-              })
-            }
           }
         }
       }

--- a/lib/rules/valid-v-on.js
+++ b/lib/rules/valid-v-on.js
@@ -108,20 +108,30 @@ module.exports = {
         }
 
         if (
-          !utils.hasAttributeValue(node) &&
+          (!node.value || !node.value.expression) &&
           !node.key.modifiers.some((modifier) =>
             VERB_MODIFIERS.has(modifier.name)
           )
         ) {
-          if (node.value && sourceCode.getText(node.value.expression)) {
-            const value = sourceCode.getText(node.value)
-            context.report({
-              node,
-              loc: node.loc,
-              message:
-                'Avoid using JavaScript keyword as "v-on" value: {{value}}.',
-              data: { value }
-            })
+          if (node.value && !utils.isEmptyValueDirective(node, context)) {
+            const valueText = sourceCode.getText(node.value)
+            let innerText = valueText
+            if (
+              (valueText[0] === '"' || valueText[0] === "'") &&
+              valueText[0] === valueText[valueText.length - 1]
+            ) {
+              // quoted
+              innerText = valueText.slice(1, -1)
+            }
+            if (/^\w+$/.test(innerText)) {
+              context.report({
+                node,
+                loc: node.loc,
+                message:
+                  'Avoid using JavaScript keyword as "v-on" value: {{value}}.',
+                data: { value: valueText }
+              })
+            }
           } else {
             context.report({
               node,

--- a/lib/rules/valid-v-show.js
+++ b/lib/rules/valid-v-show.js
@@ -44,7 +44,7 @@ module.exports = {
             message: "'v-show' directives require no modifier."
           })
         }
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/rules/valid-v-slot.js
+++ b/lib/rules/valid-v-slot.js
@@ -264,7 +264,9 @@ module.exports = {
         if (
           ownerElement === element &&
           isDefaultSlot &&
-          !utils.hasAttributeValue(node)
+          (!node.value ||
+            utils.isEmptyValueDirective(node, context) ||
+            utils.isEmptyExpressionValueDirective(node, context))
         ) {
           context.report({
             node,

--- a/lib/rules/valid-v-text.js
+++ b/lib/rules/valid-v-text.js
@@ -44,7 +44,7 @@ module.exports = {
             message: "'v-text' directives require no modifier."
           })
         }
-        if (!utils.hasAttributeValue(node)) {
+        if (!node.value || utils.isEmptyValueDirective(node, context)) {
           context.report({
             node,
             loc: node.loc,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -290,16 +290,73 @@ module.exports = {
   },
 
   /**
-   * Check whether the given attribute has their attribute value.
-   * @param {ASTNode} node The attribute node to check.
-   * @returns {boolean} `true` if the attribute has their value.
+   * Check whether the given directive attribute has their empty value (`=""`).
+   * @param {ASTNode} node The directive attribute node to check.
+   * @param {RuleContext} context The rule context to use parser services.
+   * @returns {boolean} `true` if the directive attribute has their empty value (`=""`).
    */
-  hasAttributeValue (node) {
+  isEmptyValueDirective (node, context) {
     assert(node && node.type === 'VAttribute')
-    return (
-      node.value != null &&
-      (node.value.expression != null || node.value.syntaxError != null)
-    )
+    if (node.value == null) {
+      return false
+    }
+    if (node.value.expression != null) {
+      return false
+    }
+
+    let valueText = context.getSourceCode().getText(node.value)
+    if ((valueText[0] === '"' || valueText[0] === "'") && valueText[0] === valueText[valueText.length - 1]) {
+      // quoted
+      valueText = valueText.slice(1, -1)
+    }
+    if (!valueText) {
+      // empty
+      return true
+    }
+    return false
+  },
+
+  /**
+   * Check whether the given directive attribute has their empty expression value (e.g. `=" "`, `="/* &ast;/"`).
+   * @param {ASTNode} node The directive attribute node to check.
+   * @param {RuleContext} context The rule context to use parser services.
+   * @returns {boolean} `true` if the directive attribute has their empty expression value.
+   */
+  isEmptyExpressionValueDirective (node, context) {
+    assert(node && node.type === 'VAttribute')
+    if (node.value == null) {
+      return false
+    }
+    if (node.value.expression != null) {
+      return false
+    }
+
+    const valueNode = node.value
+    const tokenStore = context.parserServices.getTemplateBodyTokenStore()
+    let quote1 = null
+    let quote2 = null
+    // `node.value` may be only comments, so cannot get the correct tokens with `tokenStore.getTokens(node.value)`.
+    for (const token of tokenStore.getTokens(node)) {
+      if (token.range[1] <= valueNode.range[0]) {
+        continue
+      }
+      if (valueNode.range[1] <= token.range[0]) {
+        // empty
+        return true
+      }
+      if (!quote1 && token.type === 'Punctuator' && (token.value === '"' || token.value === "'")) {
+        quote1 = token
+        continue
+      }
+      if (!quote2 && quote1 && token.type === 'Punctuator' && (token.value === quote1.value)) {
+        quote2 = token
+        continue
+      }
+      // not empty
+      return false
+    }
+    // empty
+    return true
   },
 
   /**

--- a/tests/lib/rules/valid-v-bind-sync.js
+++ b/tests/lib/rules/valid-v-bind-sync.js
@@ -130,6 +130,21 @@ tester.run('valid-v-bind-sync', rule, {
     {
       filename: 'test.vue',
       code: '<template><MyComponent :foo.sync.unknown="foo" /></template>'
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><MyComponent :foo.sync="." /></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent :foo.sync="/**/" /></template>'
+    },
+    // empty value (valid-v-bind)
+    {
+      filename: 'empty-value.vue',
+      code: '<template><MyComponent :foo.sync="" /></template>'
     }
   ],
   invalid: [

--- a/tests/lib/rules/valid-v-bind.js
+++ b/tests/lib/rules/valid-v-bind.js
@@ -74,6 +74,16 @@ tester.run('valid-v-bind', rule, {
     {
       filename: 'test.vue',
       code: "<template><input v-bind='$attrs' /></template>"
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><MyComponent :foo="." /></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent :foo="/**/" /></template>'
     }
   ],
   invalid: [
@@ -91,6 +101,12 @@ tester.run('valid-v-bind', rule, {
       filename: 'test.vue',
       code: "<template><div :aaa.unknown='bbb'></div></template>",
       errors: ["'v-bind' directives don't support the modifier 'unknown'."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><MyComponent :foo="" /></template>',
+      errors: ["'v-bind' directives require an attribute value."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-cloak.js
+++ b/tests/lib/rules/valid-v-cloak.js
@@ -47,6 +47,24 @@ tester.run('valid-v-cloak', rule, {
       filename: 'test.vue',
       code: '<template><div v-cloak="aaa"></div></template>',
       errors: ["'v-cloak' directives require no attribute value."]
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-cloak="."></div></template>',
+      errors: ["'v-cloak' directives require no attribute value."]
+    },
+    // comment value
+    {
+      filename: 'comment-value.vue',
+      code: '<template><div v-cloak="/**/" /></template>',
+      errors: ["'v-cloak' directives require no attribute value."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><div v-cloak="" /></template>',
+      errors: ["'v-cloak' directives require no attribute value."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-else-if.js
+++ b/tests/lib/rules/valid-v-else-if.js
@@ -40,6 +40,18 @@ tester.run('valid-v-else-if', rule, {
     {
       filename: 'test.vue',
       code: `<template>\n    <c1 v-if="1" />\n    <c2 v-else-if="1" />\n    <c3 v-else />\n</template>`
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code:
+        '<template><div v-if="foo"></div><div v-else-if="."></div></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code:
+        '<template><div v-if="foo"></div><div v-else-if="/**/"></div></template>'
     }
   ],
   invalid: [
@@ -121,6 +133,13 @@ tester.run('valid-v-else-if', rule, {
       filename: 'test.vue',
       code:
         '<template><div><div v-if="foo"></div><div v-else-if></div></div></template>',
+      errors: ["'v-else-if' directives require that attribute value."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code:
+        '<template><div v-if="foo"></div><div v-else-if=""></div></template>',
       errors: ["'v-else-if' directives require that attribute value."]
     }
   ]

--- a/tests/lib/rules/valid-v-else.js
+++ b/tests/lib/rules/valid-v-else.js
@@ -120,6 +120,25 @@ tester.run('valid-v-else', rule, {
       code:
         '<template><div><div v-if="foo"></div><div v-else="foo"></div></div></template>',
       errors: ["'v-else' directives require no attribute value."]
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-if="foo"></div><div v-else="."></div></template>',
+      errors: ["'v-else' directives require no attribute value."]
+    },
+    // comment value
+    {
+      filename: 'comment-value.vue',
+      code:
+        '<template><div v-if="foo"></div><div v-else="/**/"></div></template>',
+      errors: ["'v-else' directives require no attribute value."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><div v-if="foo"></div><div v-else=""></div></template>',
+      errors: ["'v-else' directives require no attribute value."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-for.js
+++ b/tests/lib/rules/valid-v-for.js
@@ -127,6 +127,21 @@ tester.run('valid-v-for', rule, {
           </template>
         </template>
       `
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-for="."></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code:
+        '<template><div><template v-for="xin list"><div></div></template></div></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><div v-for="/**/"></div></template>'
     }
   ],
   invalid: [
@@ -248,12 +263,6 @@ tester.run('valid-v-for', rule, {
     {
       filename: 'test.vue',
       code:
-        '<template><div><template v-for="xin list"><div></div></template></div></template>',
-      errors: ["'v-for' directives require that attribute value."]
-    },
-    {
-      filename: 'test.vue',
-      code:
         '<template><div><template v-for="x of list"><div v-for="foo of y" :key="foo"></div></template></div></template>',
       errors: [
         "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
@@ -309,6 +318,12 @@ tester.run('valid-v-for', rule, {
           </template>
         </template>
       `
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><div v-for=""></div></template>',
+      errors: ["'v-for' directives require that attribute value."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-html.js
+++ b/tests/lib/rules/valid-v-html.js
@@ -30,6 +30,16 @@ tester.run('valid-v-html', rule, {
     {
       filename: 'test.vue',
       code: '<template><div v-html="foo"></div></template>'
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-html="."></div></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><div v-html="/**/"></div></template>'
     }
   ],
   invalid: [
@@ -46,6 +56,12 @@ tester.run('valid-v-html', rule, {
     {
       filename: 'test.vue',
       code: '<template><div v-html></div></template>',
+      errors: ["'v-html' directives require that attribute value."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><div v-html=""></div></template>',
       errors: ["'v-html' directives require that attribute value."]
     }
   ]

--- a/tests/lib/rules/valid-v-if.js
+++ b/tests/lib/rules/valid-v-if.js
@@ -30,6 +30,16 @@ tester.run('valid-v-if', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><div v-if="foo"></div></div></template>'
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-if="."></div></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><div v-if="/**/"></div></template>'
     }
   ],
   invalid: [
@@ -61,6 +71,12 @@ tester.run('valid-v-if', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><div v-if></div></div></template>',
+      errors: ["'v-if' directives require that attribute value."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><div><div v-if=""></div></div></template>',
       errors: ["'v-if' directives require that attribute value."]
     }
   ]

--- a/tests/lib/rules/valid-v-model.js
+++ b/tests/lib/rules/valid-v-model.js
@@ -150,6 +150,16 @@ tester.run('valid-v-model', rule, {
       filename: 'test.vue',
       code:
         '<template><MyComponent v-model.modifier.modifierTwo="a"></MyComponent></template>'
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><MyComponent v-model="." /></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-model="/**/" /></template>'
     }
   ],
   invalid: [
@@ -216,6 +226,12 @@ tester.run('valid-v-model', rule, {
       errors: [
         "'v-model' directives cannot update the iteration variable 'e' itself."
       ]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><MyComponent v-model="" /></template>',
+      errors: ["'v-model' directives require that attribute value."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-on.js
+++ b/tests/lib/rules/valid-v-on.js
@@ -96,6 +96,33 @@ tester.run('valid-v-on', rule, {
       filename: 'test.vue',
       code: '<template><div v-on:keydown.bar.aaa="foo"></div></template>',
       options: [{ modifiers: ['bar', 'aaa'] }]
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><MyComponent v-on:keydown="." /></template>'
+    },
+    // comment value (valid)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-on:keydown="/**/" /></template>'
+    },
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-on:keydown=/**/ /></template>'
+    },
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-on:keydown.stop="/**/" /></template>'
+    },
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-on:keydown.stop=/**/ /></template>'
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><MyComponent v-on:keydown.stop="" /></template>'
     }
   ],
   invalid: [
@@ -139,6 +166,14 @@ tester.run('valid-v-on', rule, {
       filename: 'test.vue',
       code: '<template><div @click="delete"></div></template>',
       errors: ['Avoid using JavaScript keyword as "v-on" value: "delete".']
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><MyComponent v-on:keydown="" /></template>',
+      errors: [
+        "'v-on' directives require a value or verb modifier (like 'stop' or 'prevent')."
+      ]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-once.js
+++ b/tests/lib/rules/valid-v-once.js
@@ -47,6 +47,24 @@ tester.run('valid-v-once', rule, {
       filename: 'test.vue',
       code: '<template><div v-once="aaa"></div></template>',
       errors: ["'v-once' directives require no attribute value."]
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><MyComponent v-once="." /></template>',
+      errors: ["'v-once' directives require no attribute value."]
+    },
+    // comment value
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-once="/**/" /></template>',
+      errors: ["'v-once' directives require no attribute value."]
+    },
+    // empty value
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-once="" /></template>',
+      errors: ["'v-once' directives require no attribute value."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-pre.js
+++ b/tests/lib/rules/valid-v-pre.js
@@ -47,6 +47,24 @@ tester.run('valid-v-pre', rule, {
       filename: 'test.vue',
       code: '<template><div v-pre="aaa"></div></template>',
       errors: ["'v-pre' directives require no attribute value."]
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-pre="." /></template>',
+      errors: ["'v-pre' directives require no attribute value."]
+    },
+    // comment value
+    {
+      filename: 'comment-value.vue',
+      code: '<template><div v-pre="/**/" /></template>',
+      errors: ["'v-pre' directives require no attribute value."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><div v-pre="" /></template>',
+      errors: ["'v-pre' directives require no attribute value."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-show.js
+++ b/tests/lib/rules/valid-v-show.js
@@ -30,6 +30,16 @@ tester.run('valid-v-show', rule, {
     {
       filename: 'test.vue',
       code: '<template><div v-show="foo"></div></template>'
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><MyComponent v-show="." /></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'comment-value.vue',
+      code: '<template><MyComponent v-show="/**/" /></template>'
     }
   ],
   invalid: [
@@ -48,8 +58,9 @@ tester.run('valid-v-show', rule, {
       code: '<template><div v-show></div></template>',
       errors: ["'v-show' directives require that attribute value."]
     },
+    // empty value
     {
-      filename: 'test.vue',
+      filename: 'empty-value.vue',
       code: '<template><div v-show=""></div></template>',
       errors: ["'v-show' directives require that attribute value."]
     }

--- a/tests/lib/rules/valid-v-slot.js
+++ b/tests/lib/rules/valid-v-slot.js
@@ -83,7 +83,13 @@ tester.run('valid-v-slot', rule, {
       <MyComponent>
         <template v-for="(key, value) in xxxx" #[key]>{{value}}</template>
       </MyComponent>
-    </template>`
+    </template>`,
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code:
+        '<template><MyComponent v-slot="." ><div /></MyComponent></template>'
+    }
   ],
   invalid: [
     // Verify location.
@@ -293,6 +299,26 @@ tester.run('valid-v-slot', rule, {
           <MyComponent v-slot>content</MyComponent>
         </template>
       `,
+      errors: [{ messageId: 'requireAttributeValue' }]
+    },
+    // comment value
+    {
+      filename: 'comment-value1.vue',
+      code:
+        '<template><MyComponent v-slot="/**/" ><div /></MyComponent></template>',
+      errors: [{ messageId: 'requireAttributeValue' }]
+    },
+    {
+      filename: 'comment-value2.vue',
+      code:
+        '<template><MyComponent v-slot=/**/ ><div /></MyComponent></template>',
+      errors: [{ messageId: 'requireAttributeValue' }]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code:
+        '<template><MyComponent v-slot="" ><div /></MyComponent></template>',
       errors: [{ messageId: 'requireAttributeValue' }]
     }
   ]

--- a/tests/lib/rules/valid-v-text.js
+++ b/tests/lib/rules/valid-v-text.js
@@ -34,6 +34,16 @@ tester.run('valid-v-text', rule, {
     {
       filename: 'test.vue',
       code: '<template><div v-text="foo"></div></template>'
+    },
+    // parsing error
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-text="." /></template>'
+    },
+    // comment value (parsing error)
+    {
+      filename: 'parsing-error.vue',
+      code: '<template><div v-text="/**/" /></template>'
     }
   ],
   invalid: [
@@ -50,6 +60,12 @@ tester.run('valid-v-text', rule, {
     {
       filename: 'test.vue',
       code: '<template><div v-text></div></template>',
+      errors: ["'v-text' directives require that attribute value."]
+    },
+    // empty value
+    {
+      filename: 'empty-value.vue',
+      code: '<template><div v-text="" /></template>',
       errors: ["'v-text' directives require that attribute value."]
     }
   ]


### PR DESCRIPTION
- for `vue/valid-v-bind-sync`, `vue/valid-v-bind`, `vue/valid-v-else-if`, `vue/valid-v-for`, `vue/valid-v-html`, `vue/valid-v-if`, `vue/valid-v-model`, `vue/valid-v-on`, `vue/valid-v-show`, `vue/valid-v-slot` and `vue/valid-v-text` rules.

close #921