### PR TITLE
fix: remove vue/valid-template-root rule from vue3 essentials

### DIFF
--- a/lib/configs/vue3-essential.js
+++ b/lib/configs/vue3-essential.js
@@ -48,7 +48,6 @@ module.exports = {
     'vue/return-in-computed-property': 'error',
     'vue/return-in-emits-validator': 'error',
     'vue/use-v-on-exact': 'error',
-    'vue/valid-template-root': 'error',
     'vue/valid-v-bind': 'error',
     'vue/valid-v-cloak': 'error',
     'vue/valid-v-else-if': 'error',


### PR DESCRIPTION
Since Vue 3 support fragment, I don't think we need that here. 
Guessing an oversight