### PR TITLE
Add `vue/object-property-newline` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -329,6 +329,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/no-restricted-syntax](./no-restricted-syntax.md) | disallow specified syntax |  |
 | [vue/no-useless-concat](./no-useless-concat.md) | disallow unnecessary concatenation of literals or template literals |  |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |
+| [vue/object-property-newline](./object-property-newline.md) | enforce placing object properties on separate lines | :wrench: |
 | [vue/prefer-template](./prefer-template.md) | require template literals instead of string concatenation | :wrench: |
 | [vue/space-in-parens](./space-in-parens.md) | enforce consistent spacing inside parentheses | :wrench: |
 | [vue/space-infix-ops](./space-infix-ops.md) | require spacing around infix operators | :wrench: |

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -1,0 +1,25 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/object-property-newline
+description: enforce placing object properties on separate lines
+---
+# vue/object-property-newline
+> enforce placing object properties on separate lines
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [object-property-newline] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [object-property-newline]
+
+[object-property-newline]: https://eslint.org/docs/rules/object-property-newline
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/object-property-newline.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/object-property-newline.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/object-property-newline)</sup>

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -31,6 +31,7 @@ module.exports = {
     'vue/no-multi-spaces': 'off',
     'vue/no-spaces-around-equal-signs-in-attribute': 'off',
     'vue/object-curly-spacing': 'off',
+    'vue/object-property-newline': 'off',
     'vue/padding-line-between-blocks': 'off',
     'vue/script-indent': 'off',
     'vue/singleline-html-element-content-newline': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,7 @@ module.exports = {
     'no-v-model-argument': require('./rules/no-v-model-argument'),
     'no-watch-after-await': require('./rules/no-watch-after-await'),
     'object-curly-spacing': require('./rules/object-curly-spacing'),
+    'object-property-newline': require('./rules/object-property-newline'),
     'one-component-per-file': require('./rules/one-component-per-file'),
     'order-in-components': require('./rules/order-in-components'),
     'padding-line-between-blocks': require('./rules/padding-line-between-blocks'),

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -1,0 +1,12 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(
+  require('eslint/lib/rules/object-property-newline'),
+  { skipDynamicArguments: true }
+)

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -1,0 +1,90 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/object-property-newline')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020 }
+})
+
+tester.run('object-property-newline', rule, {
+  valid: [
+    `
+    <template>
+      <div :foo="{a: 1,
+        b: [2, {a: 3,
+          b: 4}]}" />
+    </template>
+    `,
+    `
+    <template>
+      <div :foo="{a: 1,
+        b: 2}" />
+    </template>
+    `,
+    `
+    <template>
+      <div :[{a:1,b:2}]="value" />
+    </template>
+    `,
+    {
+      code: `
+      <template>
+        <div :foo="{a: 1, b: [2, {a: 3, b: 4}]}" />
+      </template>
+      `,
+      options: [{ allowAllPropertiesOnSameLine: true }]
+    }
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div :foo="{a: 1, b: [2, {a: 3, b: 4}]}" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :foo="{a: 1,
+b: [2, {a: 3,
+b: 4}]}" />
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Object properties must go on a new line.',
+          line: 3,
+          column: 27
+        },
+        {
+          message: 'Object properties must go on a new line.',
+          line: 3,
+          column: 41
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div :foo="{a: 1, b: 2,
+          c: 3}" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :foo="{a: 1,
+b: 2,
+          c: 3}" />
+      </template>
+      `,
+      options: [{ allowAllPropertiesOnSameLine: true }],
+      errors: [
+        "Object properties must go on a new line if they aren't all on the same line."
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [object-property-newline](https://eslint.org/docs/rules/object-property-newline) core rule to apply to the expressions in `<template>`.