### PR TITLE
Add `vue/object-curly-newline` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -328,6 +328,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/no-irregular-whitespace](./no-irregular-whitespace.md) | disallow irregular whitespace |  |
 | [vue/no-restricted-syntax](./no-restricted-syntax.md) | disallow specified syntax |  |
 | [vue/no-useless-concat](./no-useless-concat.md) | disallow unnecessary concatenation of literals or template literals |  |
+| [vue/object-curly-newline](./object-curly-newline.md) | enforce consistent line breaks inside braces | :wrench: |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |
 | [vue/prefer-template](./prefer-template.md) | require template literals instead of string concatenation | :wrench: |
 | [vue/space-in-parens](./space-in-parens.md) | enforce consistent spacing inside parentheses | :wrench: |

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -1,0 +1,25 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/object-curly-newline
+description: enforce consistent line breaks inside braces
+---
+# vue/object-curly-newline
+> enforce consistent line breaks inside braces
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [object-curly-newline] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [object-curly-newline]
+
+[object-curly-newline]: https://eslint.org/docs/rules/object-curly-newline
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/object-curly-newline.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/object-curly-newline.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/object-curly-newline)</sup>

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -30,6 +30,7 @@ module.exports = {
     'vue/no-extra-parens': 'off',
     'vue/no-multi-spaces': 'off',
     'vue/no-spaces-around-equal-signs-in-attribute': 'off',
+    'vue/object-curly-newline': 'off',
     'vue/object-curly-spacing': 'off',
     'vue/padding-line-between-blocks': 'off',
     'vue/script-indent': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,7 @@ module.exports = {
     'no-v-html': require('./rules/no-v-html'),
     'no-v-model-argument': require('./rules/no-v-model-argument'),
     'no-watch-after-await': require('./rules/no-watch-after-await'),
+    'object-curly-newline': require('./rules/object-curly-newline'),
     'object-curly-spacing': require('./rules/object-curly-spacing'),
     'one-component-per-file': require('./rules/one-component-per-file'),
     'order-in-components': require('./rules/order-in-components'),

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -1,0 +1,12 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(
+  require('eslint/lib/rules/object-curly-newline'),
+  { skipDynamicArguments: true }
+)

--- a/tests/lib/rules/object-curly-newline.js
+++ b/tests/lib/rules/object-curly-newline.js
@@ -1,0 +1,148 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/object-curly-newline')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020 }
+})
+
+tester.run('object-curly-newline', rule, {
+  valid: [
+    `
+    <template>
+      <div :foo="{a: 1}" />
+    </template>
+    `,
+    {
+      code: `
+      <template>
+        <div :foo="{a: 1}" />
+      </template>
+      `,
+      options: ['never']
+    },
+    `
+    <template>
+      <div :foo="{
+        a: 1
+      }" />
+    </template>
+    `,
+    {
+      code: `
+      <template>
+        <div :foo="{
+          a: 1
+        }" />
+      </template>
+      `,
+      options: ['always']
+    },
+    `
+    <template>
+      <div :[{a:1}]="value" />
+    </template>
+    `,
+    {
+      code: `
+      <template>
+        <div :[{a:1}]="value" />
+      </template>
+      `,
+      options: ['always']
+    },
+    {
+      code: `
+      <template>
+        <div :[{a:1}]="value" />
+      </template>
+      `,
+      options: ['never']
+    }
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div :foo="{a: 1
+        }" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :foo="{a: 1}" />
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Unexpected line break before this closing brace.',
+          line: 4,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div :foo="{
+          a: 1}" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :foo="{a: 1}" />
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Unexpected line break after this opening brace.',
+          line: 3,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div :foo="{a: 1}" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :foo="{
+a: 1
+}" />
+      </template>
+      `,
+      options: ['always'],
+      errors: [
+        'Expected a line break after this opening brace.',
+        'Expected a line break before this closing brace.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div :foo="{
+          a: 1
+        }" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :foo="{a: 1}" />
+      </template>
+      `,
+      options: ['never'],
+      errors: [
+        'Unexpected line break after this opening brace.',
+        'Unexpected line break before this closing brace.'
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [object-curly-newline](https://eslint.org/docs/rules/object-curly-newline) core rule to apply to the expressions in `<template>`.