### PR TITLE
Add `vue/func-call-spacing` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -322,6 +322,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/dot-location](./dot-location.md) | enforce consistent newlines before and after dots | :wrench: |
 | [vue/dot-notation](./dot-notation.md) | enforce dot notation whenever possible | :wrench: |
 | [vue/eqeqeq](./eqeqeq.md) | require the use of `===` and `!==` | :wrench: |
+| [vue/func-call-spacing](./func-call-spacing.md) | require or disallow spacing between function identifiers and their invocations | :wrench: |
 | [vue/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in object literal properties | :wrench: |
 | [vue/keyword-spacing](./keyword-spacing.md) | enforce consistent spacing before and after keywords | :wrench: |
 | [vue/max-len](./max-len.md) | enforce a maximum line length |  |

--- a/docs/rules/func-call-spacing.md
+++ b/docs/rules/func-call-spacing.md
@@ -1,0 +1,25 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/func-call-spacing
+description: require or disallow spacing between function identifiers and their invocations
+---
+# vue/func-call-spacing
+> require or disallow spacing between function identifiers and their invocations
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [func-call-spacing] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [func-call-spacing]
+
+[func-call-spacing]: https://eslint.org/docs/rules/func-call-spacing
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/func-call-spacing.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/func-call-spacing.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/func-call-spacing)</sup>

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -13,6 +13,7 @@ module.exports = {
     'vue/comma-spacing': 'off',
     'vue/comma-style': 'off',
     'vue/dot-location': 'off',
+    'vue/func-call-spacing': 'off',
     'vue/html-closing-bracket-newline': 'off',
     'vue/html-closing-bracket-spacing': 'off',
     'vue/html-comment-content-newline': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ module.exports = {
     'dot-location': require('./rules/dot-location'),
     'dot-notation': require('./rules/dot-notation'),
     eqeqeq: require('./rules/eqeqeq'),
+    'func-call-spacing': require('./rules/func-call-spacing'),
     'html-closing-bracket-newline': require('./rules/html-closing-bracket-newline'),
     'html-closing-bracket-spacing': require('./rules/html-closing-bracket-spacing'),
     'html-comment-content-newline': require('./rules/html-comment-content-newline'),

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -1,0 +1,11 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(require('eslint/lib/rules/func-call-spacing'), {
+  skipDynamicArguments: true
+})

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -3,7 +3,8 @@
  */
 'use strict'
 
-const RuleTester = require('eslint').RuleTester
+const { RuleTester, CLIEngine } = require('eslint')
+const semver = require('semver')
 const rule = require('../../../lib/rules/func-call-spacing')
 
 const tester = new RuleTester({
@@ -54,7 +55,9 @@ tester.run('func-call-spacing', rule, {
       `,
       errors: [
         {
-          message: 'Unexpected whitespace between function name and paren.',
+          message: semver.lt(CLIEngine.version, '7.0.0')
+            ? 'Unexpected newline between function name and paren.'
+            : 'Unexpected whitespace between function name and paren.',
           line: 3
         }
       ]

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -1,0 +1,84 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/func-call-spacing')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020 }
+})
+
+tester.run('func-call-spacing', rule, {
+  valid: [
+    `
+    <template>
+      <div :foo="foo()" />
+    </template>
+    `,
+    {
+      code: `
+      <template>
+        <div :foo="foo ()" />
+      </template>
+      `,
+      options: ['always']
+    },
+    `
+    <template>
+      <div :[foo()]="value" />
+    </template>
+    `,
+    {
+      code: `
+      <template>
+        <div :[foo()]="value" />
+      </template>
+      `,
+      options: ['always']
+    }
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div :foo="foo ()" />
+      </template>
+      `,
+      output: `
+      <template>
+        <div :foo="foo()" />
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Unexpected whitespace between function name and paren.',
+          line: 3,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div :foo="foo()" />
+      </template>
+      `,
+      options: ['always'],
+      output: `
+      <template>
+        <div :foo="foo ()" />
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Missing space between function name and paren.',
+          line: 3,
+          column: 20
+        }
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -55,8 +55,7 @@ tester.run('func-call-spacing', rule, {
       errors: [
         {
           message: 'Unexpected whitespace between function name and paren.',
-          line: 3,
-          column: 20
+          line: 3
         }
       ]
     },
@@ -75,8 +74,7 @@ tester.run('func-call-spacing', rule, {
       errors: [
         {
           message: 'Missing space between function name and paren.',
-          line: 3,
-          column: 20
+          line: 3
         }
       ]
     }


### PR DESCRIPTION
This PR adds the wrapper rule of the [func-call-spacing](https://eslint.org/docs/rules/func-call-spacing) core rule to apply to the expressions in `<template>`.