### PR TITLE
Supports Optional Chaining

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Install eslint@6
           command: |
-            npm install -D eslint@6.0.0
+            npm install -D eslint@6.2.0
       - run:
           name: Install dependencies
           command: npm install

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,7 +135,9 @@ module.exports = {
           {
             pattern: `https://eslint.vuejs.org/rules/{{name}}.html`
           }
-        ]
+        ],
+
+        'eslint-plugin/fixer-return': 'off'
       }
     }
   ]

--- a/docs/.vuepress/components/eslint-code-block.vue
+++ b/docs/.vuepress/components/eslint-code-block.vue
@@ -89,7 +89,7 @@ export default {
         rules: this.rules,
         parser: 'vue-eslint-parser',
         parserOptions: {
-          ecmaVersion: 2019,
+          ecmaVersion: 2020,
           sourceType: 'module',
           ecmaFeatures: {
             jsx: true

--- a/docs/rules/valid-v-bind-sync.md
+++ b/docs/rules/valid-v-bind-sync.md
@@ -15,7 +15,8 @@ This rule checks whether every `.sync` modifier on `v-bind` directives is valid.
 
 This rule reports `.sync` modifier on `v-bind` directives in the following cases:
 
-- The `.sync` modifier does not have the attribute value which is valid as LHS. E.g. `<MyComponent v-bind:aaa.sync="foo() + bar()" />`
+- The `.sync` modifier does not have the attribute value which is valid as LHS. E.g. `<MyComponent v-bind:aaa.sync="foo() + bar()" />`, `<MyComponent v-bind:aaa.sync="a?.b" />`
+- The `.sync` modifier has potential null object property access. E.g. `<MyComponent v-bind:aaa.sync="(a?.b).c" />`
 - The `.sync` modifier is on non Vue-components. E.g. `<input v-bind:aaa.sync="foo"></div>`
 - The `.sync` modifier's reference is iteration variables. E.g. `<div v-for="x in list"><MyComponent v-bind:aaa.sync="x" /></div>`
 
@@ -35,6 +36,9 @@ This rule reports `.sync` modifier on `v-bind` directives in the following cases
   <!-- ✗ BAD -->
   <MyComponent v-bind:aaa.sync="foo + bar" />
   <MyComponent :aaa.sync="foo + bar" />
+
+  <MyComponent :aaa.sync="a?.b.c" />
+  <MyComponent :aaa.sync="(a?.b).c" />
 
   <input v-bind:aaa.sync="foo">
   <input :aaa.sync="foo">

--- a/docs/rules/valid-v-model.md
+++ b/docs/rules/valid-v-model.md
@@ -18,7 +18,8 @@ This rule reports `v-model` directives in the following cases:
 - The directive used on HTMLElement has an argument. E.g. `<input v-model:aaa="foo">`
 - The directive used on HTMLElement has modifiers which are not supported. E.g. `<input v-model.bbb="foo">`
 - The directive does not have that attribute value. E.g. `<input v-model>`
-- The directive does not have the attribute value which is valid as LHS. E.g. `<input v-model="foo() + bar()">`
+- The directive does not have the attribute value which is valid as LHS. E.g. `<input v-model="foo() + bar()">`, `<input v-model="a?.b">`
+- The directive has potential null object property access. E.g. `<input v-model="(a?.b).c">`
 - The directive is on unsupported elements. E.g. `<div v-model="foo"></div>`
 - The directive is on `<input>` elements which their types are `file`. E.g. `<input type="file" v-model="foo">`
 - The directive's reference is iteration variables. E.g. `<div v-for="x in list"><input type="file" v-model="x"></div>`
@@ -44,6 +45,8 @@ This rule reports `v-model` directives in the following cases:
   <input v-model:aaa="foo">
   <input v-model.bbb="foo">
   <input v-model="foo + bar">
+  <input v-model="a?.b.c">
+  <input v-model="(a?.b).c">
   <div v-model="foo"/>
   <div v-for="todo in todos">
     <input v-model="todo">

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -18,7 +18,7 @@ yarn add -D eslint eslint-plugin-vue@next
 ```
 
 ::: tip Requirements
-- ESLint v6.0.0 and above
+- ESLint v6.2.0 and above
 - Node.js v8.10.0 and above
 :::
 

--- a/lib/configs/base.js
+++ b/lib/configs/base.js
@@ -6,7 +6,7 @@
 module.exports = {
   parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module'
   },
   env: {

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -135,16 +135,13 @@ module.exports = {
                 name,
                 caseType
               },
-              fix: (fixer) => {
+              *fix(fixer) {
+                yield fixer.replaceText(open, `<${casingName}`)
                 const endTag = node.endTag
-                if (!endTag) {
-                  return fixer.replaceText(open, `<${casingName}`)
+                if (endTag) {
+                  const endTagOpen = tokens.getFirstToken(endTag)
+                  yield fixer.replaceText(endTagOpen, `</${casingName}`)
                 }
-                const endTagOpen = tokens.getFirstToken(endTag)
-                return [
-                  fixer.replaceText(open, `<${casingName}`),
-                  fixer.replaceText(endTagOpen, `</${casingName}`)
-                ]
               }
             })
           }

--- a/lib/rules/custom-event-name-casing.js
+++ b/lib/rules/custom-event-name-casing.js
@@ -48,7 +48,7 @@ function getNameParamNode(node) {
  * @param {CallExpression} node CallExpression
  */
 function getCalleeMemberNode(node) {
-  const callee = node.callee
+  const callee = utils.unwrapChainExpression(node.callee)
 
   if (callee.type === 'MemberExpression') {
     const name = utils.getStaticPropertyName(callee)

--- a/lib/rules/custom-event-name-casing.js
+++ b/lib/rules/custom-event-name-casing.js
@@ -48,7 +48,7 @@ function getNameParamNode(node) {
  * @param {CallExpression} node CallExpression
  */
 function getCalleeMemberNode(node) {
-  const callee = utils.unwrapChainExpression(node.callee)
+  const callee = utils.skipChainExpression(node.callee)
 
   if (callee.type === 'MemberExpression') {
     const name = utils.getStaticPropertyName(callee)
@@ -116,7 +116,7 @@ module.exports = {
       utils.compositingVisitors(
         utils.defineVueVisitor(context, {
           onSetupFunctionEnter(node, { node: vueNode }) {
-            const contextParam = utils.unwrapAssignmentPattern(node.params[1])
+            const contextParam = utils.skipDefaultParamValue(node.params[1])
             if (!contextParam) {
               // no arguments
               return

--- a/lib/rules/html-self-closing.js
+++ b/lib/rules/html-self-closing.js
@@ -163,7 +163,7 @@ module.exports = {
                 elementType: ELEMENT_TYPE_MESSAGES[elementType],
                 name: node.rawName
               },
-              fix: (fixer) => {
+              fix(fixer) {
                 const tokens = context.parserServices.getTemplateBodyTokenStore()
                 const close = tokens.getLastToken(node.startTag)
                 if (close.type !== 'HTMLTagClose') {
@@ -187,7 +187,7 @@ module.exports = {
                 elementType: ELEMENT_TYPE_MESSAGES[elementType],
                 name: node.rawName
               },
-              fix: (fixer) => {
+              fix(fixer) {
                 const tokens = context.parserServices.getTemplateBodyTokenStore()
                 const close = tokens.getLastToken(node.startTag)
                 if (close.type !== 'HTMLSelfClosingTagClose') {

--- a/lib/rules/no-async-in-computed-properties.js
+++ b/lib/rules/no-async-in-computed-properties.js
@@ -26,7 +26,7 @@ const TIMED_FUNCTIONS = [
  * @param {CallExpression} node
  */
 function isTimedFunction(node) {
-  const callee = utils.unwrapChainExpression(node.callee)
+  const callee = utils.skipChainExpression(node.callee)
   return (
     ((node.type === 'CallExpression' &&
       callee.type === 'Identifier' &&
@@ -45,7 +45,7 @@ function isTimedFunction(node) {
  * @param {CallExpression} node
  */
 function isPromise(node) {
-  const callee = utils.unwrapChainExpression(node.callee)
+  const callee = utils.skipChainExpression(node.callee)
   if (node.type === 'CallExpression' && callee.type === 'MemberExpression') {
     return (
       // hello.PROMISE_FUNCTION()

--- a/lib/rules/no-async-in-computed-properties.js
+++ b/lib/rules/no-async-in-computed-properties.js
@@ -26,16 +26,17 @@ const TIMED_FUNCTIONS = [
  * @param {CallExpression} node
  */
 function isTimedFunction(node) {
+  const callee = utils.unwrapChainExpression(node.callee)
   return (
     ((node.type === 'CallExpression' &&
-      node.callee.type === 'Identifier' &&
-      TIMED_FUNCTIONS.indexOf(node.callee.name) !== -1) ||
+      callee.type === 'Identifier' &&
+      TIMED_FUNCTIONS.indexOf(callee.name) !== -1) ||
       (node.type === 'CallExpression' &&
-        node.callee.type === 'MemberExpression' &&
-        node.callee.object.type === 'Identifier' &&
-        node.callee.object.name === 'window' &&
-        node.callee.property.type === 'Identifier' &&
-        TIMED_FUNCTIONS.indexOf(node.callee.property.name) !== -1)) &&
+        callee.type === 'MemberExpression' &&
+        callee.object.type === 'Identifier' &&
+        callee.object.name === 'window' &&
+        callee.property.type === 'Identifier' &&
+        TIMED_FUNCTIONS.indexOf(callee.property.name) !== -1)) &&
     node.arguments.length
   )
 }
@@ -44,18 +45,16 @@ function isTimedFunction(node) {
  * @param {CallExpression} node
  */
 function isPromise(node) {
-  if (
-    node.type === 'CallExpression' &&
-    node.callee.type === 'MemberExpression'
-  ) {
+  const callee = utils.unwrapChainExpression(node.callee)
+  if (node.type === 'CallExpression' && callee.type === 'MemberExpression') {
     return (
       // hello.PROMISE_FUNCTION()
-      (node.callee.property.type === 'Identifier' &&
-        PROMISE_FUNCTIONS.indexOf(node.callee.property.name) !== -1) || // Promise.PROMISE_METHOD()
-      (node.callee.object.type === 'Identifier' &&
-        node.callee.object.name === 'Promise' &&
-        node.callee.property.type === 'Identifier' &&
-        PROMISE_METHODS.indexOf(node.callee.property.name) !== -1)
+      (callee.property.type === 'Identifier' &&
+        PROMISE_FUNCTIONS.indexOf(callee.property.name) !== -1) || // Promise.PROMISE_METHOD()
+      (callee.object.type === 'Identifier' &&
+        callee.object.name === 'Promise' &&
+        callee.property.type === 'Identifier' &&
+        PROMISE_METHODS.indexOf(callee.property.name) !== -1)
     )
   }
   return false

--- a/lib/rules/no-deprecated-events-api.js
+++ b/lib/rules/no-deprecated-events-api.js
@@ -32,13 +32,26 @@ module.exports = {
   /** @param {RuleContext} context */
   create(context) {
     return utils.defineVueVisitor(context, {
-      /** @param {MemberExpression & {parent: CallExpression}} node */
-      'CallExpression > MemberExpression'(node) {
-        const call = node.parent
+      /** @param {MemberExpression & ({parent: CallExpression} | {parent: ChainExpression & {parent: CallExpression}})} node */
+      'CallExpression > MemberExpression, CallExpression > ChainExpression > MemberExpression'(
+        node
+      ) {
+        const call =
+          node.parent.type === 'ChainExpression'
+            ? node.parent.parent
+            : node.parent
+
+        if (call.optional) {
+          // It is OK because checking whether it is deprecated.
+          // e.g. `this.$on?.()`
+          return
+        }
+
         if (
-          call.callee !== node ||
-          node.property.type !== 'Identifier' ||
-          !['$on', '$off', '$once'].includes(node.property.name)
+          utils.unwrapChainExpression(call.callee) !== node ||
+          !['$on', '$off', '$once'].includes(
+            utils.getStaticPropertyName(node) || ''
+          )
         ) {
           return
         }

--- a/lib/rules/no-deprecated-events-api.js
+++ b/lib/rules/no-deprecated-events-api.js
@@ -48,7 +48,7 @@ module.exports = {
         }
 
         if (
-          utils.unwrapChainExpression(call.callee) !== node ||
+          utils.skipChainExpression(call.callee) !== node ||
           !['$on', '$off', '$once'].includes(
             utils.getStaticPropertyName(node) || ''
           )

--- a/lib/rules/no-deprecated-v-bind-sync.js
+++ b/lib/rules/no-deprecated-v-bind-sync.js
@@ -39,7 +39,7 @@ module.exports = {
             node,
             loc: node.loc,
             messageId: 'syncModifierIsDeprecated',
-            fix: (fixer) => {
+            fix(fixer) {
               if (node.key.argument == null) {
                 // is using spread syntax
                 return null

--- a/lib/rules/no-deprecated-v-on-number-modifiers.js
+++ b/lib/rules/no-deprecated-v-on-number-modifiers.js
@@ -47,7 +47,7 @@ module.exports = {
           context.report({
             node: modifier,
             messageId: 'numberModifierIsDeprecated',
-            fix: (fixer) => {
+            fix(fixer) {
               const key = keyCodeToKey[keyCodes]
               if (!key) return null
 

--- a/lib/rules/no-deprecated-vue-config-keycodes.js
+++ b/lib/rules/no-deprecated-vue-config-keycodes.js
@@ -33,7 +33,7 @@ module.exports = {
       "MemberExpression[property.type='Identifier'][property.name='keyCodes']"(
         node
       ) {
-        const config = utils.unwrapChainExpression(node.object)
+        const config = utils.skipChainExpression(node.object)
         if (
           config.type !== 'MemberExpression' ||
           config.property.type !== 'Identifier' ||

--- a/lib/rules/no-deprecated-vue-config-keycodes.js
+++ b/lib/rules/no-deprecated-vue-config-keycodes.js
@@ -4,6 +4,8 @@
  */
 'use strict'
 
+const utils = require('../utils')
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -31,7 +33,7 @@ module.exports = {
       "MemberExpression[property.type='Identifier'][property.name='keyCodes']"(
         node
       ) {
-        const config = node.object
+        const config = utils.unwrapChainExpression(node.object)
         if (
           config.type !== 'MemberExpression' ||
           config.property.type !== 'Identifier' ||

--- a/lib/rules/no-multiple-slot-args.js
+++ b/lib/rules/no-multiple-slot-args.js
@@ -100,15 +100,12 @@ module.exports = {
     return utils.defineVueVisitor(context, {
       /** @param {MemberExpression} node */
       MemberExpression(node) {
-        const object = node.object
+        const object = utils.unwrapChainExpression(node.object)
         if (object.type !== 'MemberExpression') {
           return
         }
-        if (
-          object.property.type !== 'Identifier' ||
-          (object.property.name !== '$slots' &&
-            object.property.name !== '$scopedSlots')
-        ) {
+        const name = utils.getStaticPropertyName(object)
+        if (!name || (name !== '$slots' && name !== '$scopedSlots')) {
           return
         }
         if (!utils.isThis(object.object, context)) {

--- a/lib/rules/no-multiple-slot-args.js
+++ b/lib/rules/no-multiple-slot-args.js
@@ -100,7 +100,7 @@ module.exports = {
     return utils.defineVueVisitor(context, {
       /** @param {MemberExpression} node */
       MemberExpression(node) {
-        const object = utils.unwrapChainExpression(node.object)
+        const object = utils.skipChainExpression(node.object)
         if (object.type !== 'MemberExpression') {
           return
         }

--- a/lib/rules/no-setup-props-destructure.js
+++ b/lib/rules/no-setup-props-destructure.js
@@ -49,18 +49,18 @@ module.exports = {
         return
       }
 
+      const rightNode = utils.unwrapChainExpression(right)
       if (
         left.type !== 'ArrayPattern' &&
         left.type !== 'ObjectPattern' &&
-        right.type !== 'MemberExpression'
+        rightNode.type !== 'MemberExpression'
       ) {
         return
       }
-
       /** @type {Expression | Super} */
-      let rightId = right
+      let rightId = rightNode
       while (rightId.type === 'MemberExpression') {
-        rightId = rightId.object
+        rightId = utils.unwrapChainExpression(rightId.object)
       }
       if (rightId.type === 'Identifier' && propsReferenceIds.has(rightId)) {
         report(left, 'getProperty')

--- a/lib/rules/no-setup-props-destructure.js
+++ b/lib/rules/no-setup-props-destructure.js
@@ -49,7 +49,7 @@ module.exports = {
         return
       }
 
-      const rightNode = utils.unwrapChainExpression(right)
+      const rightNode = utils.skipChainExpression(right)
       if (
         left.type !== 'ArrayPattern' &&
         left.type !== 'ObjectPattern' &&
@@ -60,7 +60,7 @@ module.exports = {
       /** @type {Expression | Super} */
       let rightId = rightNode
       while (rightId.type === 'MemberExpression') {
-        rightId = utils.unwrapChainExpression(rightId.object)
+        rightId = utils.skipChainExpression(rightId.object)
       }
       if (rightId.type === 'Identifier' && propsReferenceIds.has(rightId)) {
         report(left, 'getProperty')
@@ -84,7 +84,7 @@ module.exports = {
         }
       },
       onSetupFunctionEnter(node) {
-        const propsParam = utils.unwrapAssignmentPattern(node.params[0])
+        const propsParam = utils.skipDefaultParamValue(node.params[0])
         if (!propsParam) {
           // no arguments
           return

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -221,7 +221,7 @@ function getObjectPatternPropertyPatternTracker(pattern) {
 }
 
 /**
- * @param {Identifier | MemberExpression | ThisExpression} node
+ * @param {Identifier | MemberExpression | ChainExpression | ThisExpression} node
  * @param {RuleContext} context
  * @returns {UsedProps}
  */
@@ -304,6 +304,14 @@ function extractPatternOrThisProperties(node, context) {
         }
       }
     }
+  } else if (parent.type === 'ChainExpression') {
+    const { usedNames, unknown, calls } = extractPatternOrThisProperties(
+      parent,
+      context
+    )
+    result.usedNames.addAll(usedNames)
+    result.unknown = result.unknown || unknown
+    result.calls.push(...calls)
   }
   return result
 }

--- a/lib/rules/no-useless-mustaches.js
+++ b/lib/rules/no-useless-mustaches.js
@@ -142,7 +142,7 @@ module.exports = {
             return null
           }
 
-          return [fixer.replaceText(node, text.replace(/\\([\s\S])/g, '$1'))]
+          return fixer.replaceText(node, text.replace(/\\([\s\S])/g, '$1'))
         }
       })
     }

--- a/lib/rules/no-useless-v-bind.js
+++ b/lib/rules/no-useless-v-bind.js
@@ -111,10 +111,10 @@ module.exports = {
       context.report({
         node,
         messageId: 'unexpected',
-        fix(fixer) {
+        *fix(fixer) {
           if (hasComment || hasEscape) {
             // cannot fix
-            return null
+            return
           }
           const text = sourceCode.getText(value)
           const quoteChar = text[0]
@@ -126,6 +126,8 @@ module.exports = {
             node.key.name.range[1] + (shorthand ? 0 : 1)
           ]
 
+          yield fixer.removeRange(keyDirectiveRange)
+
           let attrValue
           if (quoteChar === '"') {
             attrValue = strValue.replace(DOUBLE_QUOTES_RE, '&quot;')
@@ -136,10 +138,7 @@ module.exports = {
               .replace(DOUBLE_QUOTES_RE, '&quot;')
               .replace(SINGLE_QUOTES_RE, '&apos;')
           }
-          return [
-            fixer.removeRange(keyDirectiveRange),
-            fixer.replaceText(expression, attrValue)
-          ]
+          yield fixer.replaceText(expression, attrValue)
         }
       })
     }

--- a/lib/rules/no-watch-after-await.js
+++ b/lib/rules/no-watch-after-await.js
@@ -7,7 +7,8 @@ const { ReferenceTracker } = require('eslint-utils')
 const utils = require('../utils')
 
 /**
- * @param {CallExpression} node
+ * @param {CallExpression | ChainExpression} node
+ * @returns {boolean}
  */
 function isMaybeUsedStopHandle(node) {
   const parent = node.parent
@@ -31,6 +32,9 @@ function isMaybeUsedStopHandle(node) {
     if (parent.type === 'ArrayExpression') {
       // [watch()]
       return true
+    }
+    if (parent.type === 'ChainExpression') {
+      return isMaybeUsedStopHandle(parent)
     }
   }
   return false

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -185,7 +185,9 @@ function isNotSideEffectsNode(node, visitorKeys) {
         node.type !== 'ConditionalExpression' &&
         // es2015
         node.type !== 'SpreadElement' &&
-        node.type !== 'TemplateLiteral'
+        node.type !== 'TemplateLiteral' &&
+        // es2020
+        node.type !== 'ChainExpression'
       ) {
         // Can not be sure that a node has no side effects
         result = false
@@ -289,7 +291,7 @@ module.exports = {
               firstUnorderedPropertyName: firstUnorderedProperty.name,
               line
             },
-            fix(fixer) {
+            *fix(fixer) {
               const propertyNode = property.node
               const firstUnorderedPropertyNode = firstUnorderedProperty.node
               const hasSideEffectsPossibility = propertiesNodes
@@ -302,7 +304,7 @@ module.exports = {
                     !isNotSideEffectsNode(property, sourceCode.visitorKeys)
                 )
               if (hasSideEffectsPossibility) {
-                return null
+                return
               }
               const afterComma = sourceCode.getTokenAfter(propertyNode)
               const hasAfterComma = isComma(afterComma)
@@ -313,6 +315,11 @@ module.exports = {
                 ? afterComma.range[1]
                 : propertyNode.range[1]
 
+              const removeStart = hasAfterComma
+                ? codeStart
+                : beforeComma.range[0]
+              yield fixer.removeRange([removeStart, codeEnd])
+
               const propertyCode =
                 sourceCode.text.slice(codeStart, codeEnd) +
                 (hasAfterComma ? '' : ',')
@@ -320,14 +327,7 @@ module.exports = {
                 firstUnorderedPropertyNode
               )
 
-              const removeStart = hasAfterComma
-                ? codeStart
-                : beforeComma.range[0]
-
-              return [
-                fixer.removeRange([removeStart, codeEnd]),
-                fixer.insertTextAfter(insertTarget, propertyCode)
-              ]
+              yield fixer.insertTextAfter(insertTarget, propertyCode)
             }
           })
         }

--- a/lib/rules/padding-line-between-blocks.js
+++ b/lib/rules/padding-line-between-blocks.js
@@ -48,14 +48,14 @@ function verifyForNever(context, prevBlock, nextBlock, betweenTokens) {
   context.report({
     node: nextBlock,
     messageId: 'never',
-    fix(fixer) {
-      return paddingLines.map(([prevToken, nextToken]) => {
+    *fix(fixer) {
+      for (const [prevToken, nextToken] of paddingLines) {
         const start = prevToken.range[1]
         const end = nextToken.range[0]
         const paddingText = context.getSourceCode().text.slice(start, end)
         const lastSpaces = splitLines(paddingText).pop()
-        return fixer.replaceTextRange([start, end], `\n${lastSpaces}`)
-      })
+        yield fixer.replaceTextRange([start, end], `\n${lastSpaces}`)
+      }
     }
   })
 }

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -82,12 +82,18 @@ module.exports = {
     function findPropsWithoutDefaultValue(props) {
       return props.filter((prop) => {
         if (prop.value.type !== 'ObjectExpression') {
-          return (
-            (prop.value.type !== 'CallExpression' &&
-              prop.value.type !== 'Identifier') ||
-            (prop.value.type === 'Identifier' &&
-              NATIVE_TYPES.has(prop.value.name))
-          )
+          if (prop.value.type === 'Identifier') {
+            return NATIVE_TYPES.has(prop.value.name)
+          }
+          if (
+            prop.value.type === 'CallExpression' ||
+            prop.value.type === 'MemberExpression'
+          ) {
+            // OK
+            return false
+          }
+          // NG
+          return true
         }
 
         return (
@@ -99,7 +105,7 @@ module.exports = {
 
     /**
      * Detects whether given value node is a Boolean type
-     * @param {Expression | Pattern} value
+     * @param {Expression} value
      * @return {boolean}
      */
     function isValueNodeOfBooleanType(value) {

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -129,7 +129,7 @@ module.exports = {
      * @return {Boolean}
      */
     function isBooleanProp(prop) {
-      const value = utils.unwrapTypes(prop.value)
+      const value = utils.skipTSAsExpression(prop.value)
 
       return (
         isValueNodeOfBooleanType(value) ||

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -261,7 +261,7 @@ module.exports = {
          * @param {VueObjectData} data
          */
         'CallExpression[arguments.0.type=Literal]'(node, { node: vueNode }) {
-          const callee = node.callee
+          const callee = utils.unwrapChainExpression(node.callee)
           const nameLiteralNode = node.arguments[0]
           if (!nameLiteralNode || typeof nameLiteralNode.value !== 'string') {
             // cannot check
@@ -287,20 +287,22 @@ module.exports = {
             if (callee.type === 'Identifier' && emitReferenceIds.has(callee)) {
               // verify setup(props,{emit}) {emit()}
               verify(emitsDeclarations, nameLiteralNode, vueNode)
-            } else if (
-              emit &&
-              emit.name === 'emit' &&
-              emit.member.object.type === 'Identifier' &&
-              contextReferenceIds.has(emit.member.object)
-            ) {
-              // verify setup(props,context) {context.emit()}
-              verify(emitsDeclarations, nameLiteralNode, vueNode)
+            } else if (emit && emit.name === 'emit') {
+              const memObject = utils.unwrapChainExpression(emit.member.object)
+              if (
+                memObject.type === 'Identifier' &&
+                contextReferenceIds.has(memObject)
+              ) {
+                // verify setup(props,context) {context.emit()}
+                verify(emitsDeclarations, nameLiteralNode, vueNode)
+              }
             }
           }
 
           // verify $emit
           if (emit && emit.name === '$emit') {
-            if (utils.isThis(emit.member.object, context)) {
+            const memObject = utils.unwrapChainExpression(emit.member.object)
+            if (utils.isThis(memObject, context)) {
               // verify this.$emit()
               verify(emitsDeclarations, nameLiteralNode, vueNode)
             }

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -261,7 +261,7 @@ module.exports = {
          * @param {VueObjectData} data
          */
         'CallExpression[arguments.0.type=Literal]'(node, { node: vueNode }) {
-          const callee = utils.unwrapChainExpression(node.callee)
+          const callee = utils.skipChainExpression(node.callee)
           const nameLiteralNode = node.arguments[0]
           if (!nameLiteralNode || typeof nameLiteralNode.value !== 'string') {
             // cannot check
@@ -288,7 +288,7 @@ module.exports = {
               // verify setup(props,{emit}) {emit()}
               verify(emitsDeclarations, nameLiteralNode, vueNode)
             } else if (emit && emit.name === 'emit') {
-              const memObject = utils.unwrapChainExpression(emit.member.object)
+              const memObject = utils.skipChainExpression(emit.member.object)
               if (
                 memObject.type === 'Identifier' &&
                 contextReferenceIds.has(memObject)
@@ -301,7 +301,7 @@ module.exports = {
 
           // verify $emit
           if (emit && emit.name === '$emit') {
-            const memObject = utils.unwrapChainExpression(emit.member.object)
+            const memObject = utils.skipChainExpression(emit.member.object)
             if (utils.isThis(memObject, context)) {
               // verify this.$emit()
               verify(emitsDeclarations, nameLiteralNode, vueNode)

--- a/lib/rules/require-slots-as-functions.js
+++ b/lib/rules/require-slots-as-functions.js
@@ -103,7 +103,7 @@ module.exports = {
     return utils.defineVueVisitor(context, {
       /** @param {MemberExpression} node */
       MemberExpression(node) {
-        const object = utils.unwrapChainExpression(node.object)
+        const object = utils.skipChainExpression(node.object)
         if (object.type !== 'MemberExpression') {
           return
         }

--- a/lib/rules/require-slots-as-functions.js
+++ b/lib/rules/require-slots-as-functions.js
@@ -33,7 +33,7 @@ module.exports = {
   create(context) {
     /**
      * Verify the given node
-     * @param {MemberExpression | Identifier} node The node to verify
+     * @param {MemberExpression | Identifier | ChainExpression} node The node to verify
      * @param {Expression} reportNode The node to report
      */
     function verify(node, reportNode) {
@@ -55,6 +55,12 @@ module.exports = {
       ) {
         // children = this.$slots.foo
         verifyReferences(parent.left, reportNode)
+        return
+      }
+
+      if (parent.type === 'ChainExpression') {
+        // (this.$slots?.foo).x
+        verify(parent, reportNode)
         return
       }
 
@@ -97,14 +103,11 @@ module.exports = {
     return utils.defineVueVisitor(context, {
       /** @param {MemberExpression} node */
       MemberExpression(node) {
-        const object = node.object
+        const object = utils.unwrapChainExpression(node.object)
         if (object.type !== 'MemberExpression') {
           return
         }
-        if (
-          object.property.type !== 'Identifier' ||
-          object.property.name !== '$slots'
-        ) {
+        if (utils.getStaticPropertyName(object) !== '$slots') {
           return
         }
         if (!utils.isThis(object.object, context)) {

--- a/lib/rules/require-valid-default-prop.js
+++ b/lib/rules/require-valid-default-prop.js
@@ -48,7 +48,7 @@ function getPropertyNode(obj, name) {
 }
 
 /**
- * @param {Expression | Pattern} node
+ * @param {Expression} node
  * @returns {string[]}
  */
 function getTypes(node) {
@@ -122,10 +122,11 @@ module.exports = {
     }
 
     /**
-     * @param {Expression | Pattern} node
+     * @param {Expression} targetNode
      * @returns { StandardValueType | FunctionExprValueType | FunctionValueType | null }
      */
-    function getValueType(node) {
+    function getValueType(targetNode) {
+      const node = utils.unwrapChainExpression(targetNode)
       if (node.type === 'CallExpression') {
         // Symbol(), Number() ...
         if (

--- a/lib/rules/require-valid-default-prop.js
+++ b/lib/rules/require-valid-default-prop.js
@@ -126,7 +126,7 @@ module.exports = {
      * @returns { StandardValueType | FunctionExprValueType | FunctionValueType | null }
      */
     function getValueType(targetNode) {
-      const node = utils.unwrapChainExpression(targetNode)
+      const node = utils.skipChainExpression(targetNode)
       if (node.type === 'CallExpression') {
         // Symbol(), Number() ...
         if (

--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -56,9 +56,9 @@ module.exports = {
      * @param {VAttribute|VDirective} slotAttr node of `slot`
      * @param {string | null} slotName name of `slot`
      * @param {boolean} vBind `true` if `slotAttr` is `v-bind:slot`
-     * @returns {Fix[]} fix data
+     * @returns {IterableIterator<Fix>} fix data
      */
-    function fixSlotToVSlot(fixer, slotAttr, slotName, vBind) {
+    function* fixSlotToVSlot(fixer, slotAttr, slotName, vBind) {
       const element = slotAttr.parent
       const scopeAttr = element.attributes.find(
         (attr) =>
@@ -78,11 +78,10 @@ module.exports = {
           : ''
 
       const replaceText = `v-slot${nameArgument}${scopeValue}`
-      const fixers = [fixer.replaceText(slotAttr || scopeAttr, replaceText)]
+      yield fixer.replaceText(slotAttr || scopeAttr, replaceText)
       if (slotAttr && scopeAttr) {
-        fixers.push(fixer.remove(scopeAttr))
+        yield fixer.remove(scopeAttr)
       }
-      return fixers
     }
     /**
      * Reports `slot` node
@@ -94,12 +93,12 @@ module.exports = {
         node: slotAttr.key,
         messageId: 'forbiddenSlotAttribute',
         // fix to use `v-slot`
-        fix(fixer) {
+        *fix(fixer) {
           if (!canConvertFromSlotToVSlot(slotAttr)) {
-            return null
+            return
           }
           const slotName = slotAttr.value && slotAttr.value.value
-          return fixSlotToVSlot(fixer, slotAttr, slotName, false)
+          yield* fixSlotToVSlot(fixer, slotAttr, slotName, false)
         }
       })
     }
@@ -113,15 +112,15 @@ module.exports = {
         node: slotAttr.key,
         messageId: 'forbiddenSlotAttribute',
         // fix to use `v-slot`
-        fix(fixer) {
+        *fix(fixer) {
           if (!canConvertFromVBindSlotToVSlot(slotAttr)) {
-            return null
+            return
           }
           const slotName =
             slotAttr.value &&
             slotAttr.value.expression &&
             sourceCode.getText(slotAttr.value.expression).trim()
-          return fixSlotToVSlot(fixer, slotAttr, slotName, true)
+          yield* fixSlotToVSlot(fixer, slotAttr, slotName, true)
         }
       })
     }

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -74,16 +74,17 @@ module.exports = {
       context.report({
         node: scopeAttr.key,
         messageId: 'forbiddenSlotScopeAttribute',
-        fix: fixToUpgrade
-          ? // fix to use `v-slot`
-            (fixer) => {
-              const startTag = scopeAttr.parent
-              if (!canConvertToVSlot(startTag)) {
-                return null
-              }
-              return fixSlotScopeToVSlot(fixer, scopeAttr)
-            }
-          : null
+        fix(fixer) {
+          if (!fixToUpgrade) {
+            return null
+          }
+          // fix to use `v-slot`
+          const startTag = scopeAttr.parent
+          if (!canConvertToVSlot(startTag)) {
+            return null
+          }
+          return fixSlotScopeToVSlot(fixer, scopeAttr)
+        }
       })
     }
 

--- a/lib/rules/syntaxes/v-slot.js
+++ b/lib/rules/syntaxes/v-slot.js
@@ -69,7 +69,7 @@ module.exports = {
         node: vSlotAttr.key,
         messageId: 'forbiddenVSlot',
         // fix to use `slot` (downgrade)
-        fix: (fixer) => {
+        fix(fixer) {
           if (!canConvertToSlot(vSlotAttr)) {
             return null
           }

--- a/lib/rules/v-on-function-call.js
+++ b/lib/rules/v-on-function-call.js
@@ -85,6 +85,10 @@ module.exports = {
       if (expression.type !== 'CallExpression' || expression.arguments.length) {
         return null
       }
+      if (expression.optional) {
+        // Allow optional chaining
+        return null
+      }
       const callee = expression.callee
       if (callee.type !== 'Identifier') {
         return null

--- a/lib/rules/valid-v-bind-sync.js
+++ b/lib/rules/valid-v-bind-sync.js
@@ -32,12 +32,54 @@ function isValidElement(node) {
 }
 
 /**
- * Check whether the given node can be LHS.
+ * Check whether the given node is a MemberExpression containing an optional chaining.
+ * e.g.
+ * - `a?.b`
+ * - `a?.b.c`
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a MemberExpression containing an optional chaining.
+ */
+function isOptionalChainingMemberExpression(node) {
+  return (
+    node.type === 'ChainExpression' &&
+    node.expression.type === 'MemberExpression'
+  )
+}
+
+/**
+ * Check whether the given node can be LHS (left-hand side).
  * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node can be LHS.
  */
 function isLhs(node) {
   return node.type === 'Identifier' || node.type === 'MemberExpression'
+}
+
+/**
+ * Check whether the given node is a MemberExpression of a possibly null object.
+ * e.g.
+ * - `(a?.b).c`
+ * - `(null).foo`
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a MemberExpression of a possibly null object.
+ */
+function maybeNullObjectMemberExpression(node) {
+  if (node.type !== 'MemberExpression') {
+    return false
+  }
+  const { object } = node
+  if (object.type === 'ChainExpression') {
+    // `(a?.b).c`
+    return true
+  }
+  if (object.type === 'Literal' && object.value === null && !object.bigint) {
+    // `(null).foo`
+    return true
+  }
+  if (object.type === 'MemberExpression') {
+    return maybeNullObjectMemberExpression(object)
+  }
+  return false
 }
 
 // ------------------------------------------------------------------------------
@@ -57,8 +99,12 @@ module.exports = {
     messages: {
       unexpectedInvalidElement:
         "'.sync' modifiers aren't supported on <{{name}}> non Vue-components.",
+      unexpectedOptionalChaining:
+        "Optional chaining cannot appear in 'v-bind' with '.sync' modifiers.",
       unexpectedNonLhsExpression:
         "'.sync' modifiers require the attribute value which is valid as LHS.",
+      unexpectedNullObject:
+        "'.sync' modifier has potential null object property access.",
       unexpectedUpdateIterationVariable:
         "'.sync' modifiers cannot update the iteration variable '{{varName}}' itself."
     }
@@ -83,15 +129,32 @@ module.exports = {
           })
         }
 
-        if (!node.value || !node.value.expression) {
+        if (!node.value) {
           return
         }
 
-        if (!isLhs(node.value.expression)) {
+        const expression = node.value.expression
+        if (!expression) {
+          // Parsing error
+          return
+        }
+        if (isOptionalChainingMemberExpression(expression)) {
+          context.report({
+            node,
+            loc: node.loc,
+            messageId: 'unexpectedOptionalChaining'
+          })
+        } else if (!isLhs(expression)) {
           context.report({
             node,
             loc: node.loc,
             messageId: 'unexpectedNonLhsExpression'
+          })
+        } else if (maybeNullObjectMemberExpression(expression)) {
+          context.report({
+            node,
+            loc: node.loc,
+            messageId: 'unexpectedNullObject'
           })
         }
 

--- a/lib/rules/valid-v-model.js
+++ b/lib/rules/valid-v-model.js
@@ -37,12 +37,54 @@ function isValidElement(node) {
 }
 
 /**
- * Check whether the given node can be LHS.
+ * Check whether the given node is a MemberExpression containing an optional chaining.
+ * e.g.
+ * - `a?.b`
+ * - `a?.b.c`
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a MemberExpression containing an optional chaining.
+ */
+function isOptionalChainingMemberExpression(node) {
+  return (
+    node.type === 'ChainExpression' &&
+    node.expression.type === 'MemberExpression'
+  )
+}
+
+/**
+ * Check whether the given node can be LHS (left-hand side).
  * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node can be LHS.
  */
 function isLhs(node) {
   return node.type === 'Identifier' || node.type === 'MemberExpression'
+}
+
+/**
+ * Check whether the given node is a MemberExpression of a possibly null object.
+ * e.g.
+ * - `(a?.b).c`
+ * - `(null).foo`
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is a MemberExpression of a possibly null object.
+ */
+function maybeNullObjectMemberExpression(node) {
+  if (node.type !== 'MemberExpression') {
+    return false
+  }
+  const { object } = node
+  if (object.type === 'ChainExpression') {
+    // `(a?.b).c`
+    return true
+  }
+  if (object.type === 'Literal' && object.value === null && !object.bigint) {
+    // `(null).foo`
+    return true
+  }
+  if (object.type === 'MemberExpression') {
+    return maybeNullObjectMemberExpression(object)
+  }
+  return false
 }
 
 /**
@@ -76,6 +118,7 @@ function getVariable(name, leafNode) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {RuleModule}  */
 module.exports = {
   meta: {
     type: 'problem',
@@ -85,7 +128,25 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/valid-v-model.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      unexpectedInvalidElement:
+        "'v-model' directives aren't supported on <{{name}}> elements.",
+      unexpectedInputFile:
+        "'v-model' directives don't support 'file' input type.",
+      unexpectedArgument: "'v-model' directives require no argument.",
+      unexpectedModifier:
+        "'v-model' directives don't support the modifier '{{name}}'.",
+      missingValue: "'v-model' directives require that attribute value.",
+      unexpectedOptionalChaining:
+        "Optional chaining cannot appear in 'v-model' directives.",
+      unexpectedNonLhsExpression:
+        "'v-model' directives require the attribute value which is valid as LHS.",
+      unexpectedNullObject:
+        "'v-model' directive has potential null object property access.",
+      unexpectedUpdateIterationVariable:
+        "'v-model' directives cannot update the iteration variable '{{varName}}' itself."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -99,8 +160,7 @@ module.exports = {
           context.report({
             node,
             loc: node.loc,
-            message:
-              "'v-model' directives aren't supported on <{{name}}> elements.",
+            messageId: 'unexpectedInvalidElement',
             data: { name }
           })
         }
@@ -109,7 +169,7 @@ module.exports = {
           context.report({
             node,
             loc: node.loc,
-            message: "'v-model' directives don't support 'file' input type."
+            messageId: 'unexpectedInputFile'
           })
         }
 
@@ -118,7 +178,7 @@ module.exports = {
             context.report({
               node,
               loc: node.loc,
-              message: "'v-model' directives require no argument."
+              messageId: 'unexpectedArgument'
             })
           }
 
@@ -127,8 +187,7 @@ module.exports = {
               context.report({
                 node,
                 loc: node.loc,
-                message:
-                  "'v-model' directives don't support the modifier '{{name}}'.",
+                messageId: 'unexpectedModifier',
                 data: { name: modifier.name }
               })
             }
@@ -139,20 +198,32 @@ module.exports = {
           context.report({
             node,
             loc: node.loc,
-            message: "'v-model' directives require that attribute value."
+            messageId: 'missingValue'
           })
           return
         }
-        if (!node.value.expression) {
+        const expression = node.value.expression
+        if (!expression) {
           // Parsing error
           return
         }
-        if (!isLhs(node.value.expression)) {
+        if (isOptionalChainingMemberExpression(expression)) {
           context.report({
             node,
             loc: node.loc,
-            message:
-              "'v-model' directives require the attribute value which is valid as LHS."
+            messageId: 'unexpectedOptionalChaining'
+          })
+        } else if (!isLhs(expression)) {
+          context.report({
+            node,
+            loc: node.loc,
+            messageId: 'unexpectedNonLhsExpression'
+          })
+        } else if (maybeNullObjectMemberExpression(expression)) {
+          context.report({
+            node,
+            loc: node.loc,
+            messageId: 'unexpectedNullObject'
           })
         }
 
@@ -167,8 +238,8 @@ module.exports = {
             context.report({
               node,
               loc: node.loc,
-              message:
-                "'v-model' directives cannot update the iteration variable '{{varName}}' itself.",
+              messageId: 'unexpectedUpdateIterationVariable',
+
               data: { varName: id.name }
             })
           }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -315,7 +315,6 @@ module.exports = {
       })
     }
   },
-
   /**
    * Checks whether the given value is defined.
    * @template T
@@ -323,18 +322,6 @@ module.exports = {
    * @returns {v is T}
    */
   isDef,
-  /**
-   * Check whether the given node is the root element or not.
-   * @param {VElement} node The element node to check.
-   * @returns {boolean} `true` if the node is the root element.
-   */
-  isRootElement(node) {
-    return (
-      node.parent.type === 'VDocumentFragment' ||
-      node.parent.parent.type === 'VDocumentFragment'
-    )
-  },
-
   /**
    * Get the previous sibling element of the given element.
    * @param {VElement} node The element node to get the previous sibling element.
@@ -648,36 +635,6 @@ module.exports = {
   isHtmlVoidElementName(name) {
     return VOID_ELEMENT_NAMES.has(name)
   },
-
-  /**
-   * Parse member expression node to get array with all of its parts
-   * @param {ESNode} node MemberExpression
-   * @returns {string[]}
-   */
-  parseMemberExpression(node) {
-    const members = []
-
-    if (node.type === 'MemberExpression') {
-      /** @type {Expression | Super} */
-      let memberExpression = node
-
-      while (memberExpression.type === 'MemberExpression') {
-        if (memberExpression.property.type === 'Identifier') {
-          members.push(memberExpression.property.name)
-        }
-        memberExpression = memberExpression.object
-      }
-
-      if (memberExpression.type === 'ThisExpression') {
-        members.push('this')
-      } else if (memberExpression.type === 'Identifier') {
-        members.push(memberExpression.name)
-      }
-    }
-
-    return members.reverse()
-  },
-
   /**
    * Gets the property name of a given node.
    * @param {Property|AssignmentProperty|MethodDefinition|MemberExpression} node - The node to get.
@@ -1125,7 +1082,7 @@ module.exports = {
    */
   *iterateObjectExpression(node, groupName) {
     /** @type {Set<Property> | undefined} */
-    let usedGetter = new Set()
+    let usedGetter
     for (const item of node.properties) {
       if (item.type === 'Property') {
         const key = item.key
@@ -1313,52 +1270,15 @@ module.exports = {
   getMemberChaining(node) {
     /** @type {MemberExpression[]} */
     const nodes = []
-    let n = node
+    let n = unwrapChainExpression(node)
 
     while (n.type === 'MemberExpression') {
       nodes.push(n)
-      n = n.object
+      n = unwrapChainExpression(n.object)
     }
 
     return [n, ...nodes.reverse()]
   },
-  /**
-   * Parse CallExpression or MemberExpression to get simplified version without arguments
-   *
-   * @param  {ESNode} node The node to parse (MemberExpression | CallExpression)
-   * @return {String} eg. 'this.asd.qwe().map().filter().test.reduce()'
-   */
-  parseMemberOrCallExpression(node) {
-    const parsedCallee = []
-    let n = node
-    let isFunc
-
-    while (n.type === 'MemberExpression' || n.type === 'CallExpression') {
-      if (n.type === 'CallExpression') {
-        n = n.callee
-        isFunc = true
-      } else {
-        if (n.computed) {
-          parsedCallee.push(`[]${isFunc ? '()' : ''}`)
-        } else if (n.property.type === 'Identifier') {
-          parsedCallee.push(n.property.name + (isFunc ? '()' : ''))
-        }
-        isFunc = false
-        n = n.object
-      }
-    }
-
-    if (n.type === 'Identifier') {
-      parsedCallee.push(n.name)
-    }
-
-    if (n.type === 'ThisExpression') {
-      parsedCallee.push('this')
-    }
-
-    return parsedCallee.reverse().join('.').replace(/\.\[/g, '[')
-  },
-
   /**
    * return two string editdistance
    * @param {string} a string a to compare
@@ -1430,6 +1350,12 @@ module.exports = {
    * @return { RestElement | ArrayPattern | ObjectPattern | Identifier}
    */
   unwrapAssignmentPattern,
+  /**
+   * Unwrap ChainExpression like "(a?.b)"
+   * @param { Expression | Super } node
+   * @return { Expression | Super }
+   */
+  unwrapChainExpression,
 
   /**
    * Check whether the given node is `this` or variable that stores `this`.
@@ -1479,6 +1405,7 @@ module.exports = {
   findMutating(props) {
     /** @type {MemberExpression[]} */
     const pathNodes = []
+    /** @type {MemberExpression | Identifier | ChainExpression} */
     let node = props
     let target = node.parent
     while (true) {
@@ -1499,10 +1426,9 @@ module.exports = {
           pathNodes
         }
       } else if (target.type === 'CallExpression') {
-        if (node !== props && target.callee === node) {
-          const callName = getStaticPropertyName(
-            /** @type {MemberExpression} */ (node)
-          )
+        if (pathNodes.length > 0 && target.callee === node) {
+          const mem = pathNodes[pathNodes.length - 1]
+          const callName = getStaticPropertyName(mem)
           if (
             callName &&
             /^push|pop|shift|unshift|reverse|splice|sort|copyWithin|fill$/u.exec(
@@ -1525,6 +1451,10 @@ module.exports = {
           target = target.parent
           continue // loop
         }
+      } else if (target.type === 'ChainExpression') {
+        node = target
+        target = target.parent
+        continue // loop
       }
 
       return null
@@ -1660,14 +1590,12 @@ function findProperty(node, name, filter) {
        * @returns {prop is Property}
        */
       (prop) =>
-        prop.type === 'Property' &&
-        getStaticPropertyName(prop) === name &&
-        filter(prop)
+        isProperty(prop) && getStaticPropertyName(prop) === name && filter(prop)
     : /**
        * @param {Property | SpreadElement} prop
        * @returns {prop is Property}
        */
-      (prop) => prop.type === 'Property' && getStaticPropertyName(prop) === name
+      (prop) => isProperty(prop) && getStaticPropertyName(prop) === name
   return node.properties.find(predicate) || null
 }
 
@@ -1685,14 +1613,15 @@ function findAssignmentProperty(node, name, filter) {
        * @returns {prop is AssignmentProperty}
        */
       (prop) =>
-        prop.type === 'Property' &&
+        isAssignmentProperty(prop) &&
         getStaticPropertyName(prop) === name &&
         filter(prop)
     : /**
        * @param {AssignmentProperty | RestElement} prop
        * @returns {prop is AssignmentProperty}
        */
-      (prop) => prop.type === 'Property' && getStaticPropertyName(prop) === name
+      (prop) =>
+        isAssignmentProperty(prop) && getStaticPropertyName(prop) === name
   return node.properties.find(predicate) || null
 }
 
@@ -1768,7 +1697,7 @@ function isPropertyChain(prop, node) {
 /**
  * Unwrap AssignmentPattern like "(a = 1) => ret"
  * @param { AssignmentPattern | RestElement | ArrayPattern | ObjectPattern | Identifier } node
- * @return { RestElement | ArrayPattern | ObjectPattern | Identifier}
+ * @return { RestElement | ArrayPattern | ObjectPattern | Identifier }
  */
 function unwrapAssignmentPattern(node) {
   if (!node) {
@@ -1777,6 +1706,24 @@ function unwrapAssignmentPattern(node) {
   if (node.type === 'AssignmentPattern') {
     // @ts-expect-error
     return unwrapAssignmentPattern(node.left)
+  }
+  return node
+}
+
+/**
+ * Unwrap ChainExpression like "(a?.b)"
+ * @template T
+ * @param {T} node
+ * @return {T}
+ */
+function unwrapChainExpression(node) {
+  if (!node) {
+    return node
+  }
+  // @ts-expect-error
+  if (node.type === 'ChainExpression') {
+    // @ts-expect-error
+    return unwrapChainExpression(node.expression)
   }
   return node
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -681,7 +681,7 @@ module.exports = {
             type: 'object',
             key: prop.key,
             propName,
-            value: unwrapTypes(prop.value),
+            value: skipTSAsExpression(prop.value),
             node: prop
           }
         }
@@ -689,7 +689,7 @@ module.exports = {
           type: 'object',
           key: null,
           propName: null,
-          value: unwrapTypes(prop.value),
+          value: skipTSAsExpression(prop.value),
           node: prop
         }
       })
@@ -752,7 +752,7 @@ module.exports = {
             type: 'object',
             key: prop.key,
             emitName,
-            value: unwrapTypes(prop.value),
+            value: skipTSAsExpression(prop.value),
             node: prop
           }
         }
@@ -760,7 +760,7 @@ module.exports = {
           type: 'object',
           key: null,
           emitName: null,
-          value: unwrapTypes(prop.value),
+          value: skipTSAsExpression(prop.value),
           node: prop
         }
       })
@@ -819,7 +819,7 @@ module.exports = {
       .map((cp) => {
         const key = getStaticPropertyName(cp)
         /** @type {Expression} */
-        const propValue = unwrapTypes(cp.value)
+        const propValue = skipTSAsExpression(cp.value)
         /** @type {BlockStatement | null} */
         let value = null
 
@@ -1013,7 +1013,7 @@ module.exports = {
         const callee = callExpr.callee
 
         if (callee.type === 'MemberExpression') {
-          const calleeObject = unwrapTypes(callee.object)
+          const calleeObject = skipTSAsExpression(callee.object)
 
           if (
             calleeObject.type === 'Identifier' &&
@@ -1270,11 +1270,11 @@ module.exports = {
   getMemberChaining(node) {
     /** @type {MemberExpression[]} */
     const nodes = []
-    let n = unwrapChainExpression(node)
+    let n = skipChainExpression(node)
 
     while (n.type === 'MemberExpression') {
       nodes.push(n)
-      n = unwrapChainExpression(n.object)
+      n = skipChainExpression(n.object)
     }
 
     return [n, ...nodes.reverse()]
@@ -1338,24 +1338,17 @@ module.exports = {
    */
   isPropertyChain,
   /**
-   * Unwrap typescript types like "X as F"
-   * @template T
-   * @param {T} node
-   * @return {T}
+   * Retrieve `TSAsExpression#expression` value if the given node a `TSAsExpression` node. Otherwise, pass through it.
    */
-  unwrapTypes,
+  skipTSAsExpression,
   /**
-   * Unwrap AssignmentPattern like "(a = 1) => ret"
-   * @param { AssignmentPattern | RestElement | ArrayPattern | ObjectPattern | Identifier } node
-   * @return { RestElement | ArrayPattern | ObjectPattern | Identifier}
+   * Retrieve `AssignmentPattern#left` value if the given node a `AssignmentPattern` node. Otherwise, pass through it.
    */
-  unwrapAssignmentPattern,
+  skipDefaultParamValue,
   /**
-   * Unwrap ChainExpression like "(a?.b)"
-   * @param { Expression | Super } node
-   * @return { Expression | Super }
+   * Retrieve `ChainExpression#expression` value if the given node a `ChainExpression` node. Otherwise, pass through it.
    */
-  unwrapChainExpression,
+  skipChainExpression,
 
   /**
    * Check whether the given node is `this` or variable that stores `this`.
@@ -1651,20 +1644,21 @@ function isVElement(node) {
 }
 
 /**
- * Unwrap typescript types like "X as F"
- * @template T
- * @param {T} node
- * @return {T}
+ * Retrieve `TSAsExpression#expression` value if the given node a `TSAsExpression` node. Otherwise, pass through it.
+ * @template T Node type
+ * @param {T | TSAsExpression} node The node to address.
+ * @returns {T} The `TSAsExpression#expression` value if the node is a `TSAsExpression` node. Otherwise, the node.
  */
-function unwrapTypes(node) {
+function skipTSAsExpression(node) {
   if (!node) {
     return node
   }
   // @ts-expect-error
   if (node.type === 'TSAsExpression') {
     // @ts-expect-error
-    return unwrapTypes(node.expression)
+    return skipTSAsExpression(node.expression)
   }
+  // @ts-expect-error
   return node
 }
 
@@ -1695,36 +1689,40 @@ function isPropertyChain(prop, node) {
 }
 
 /**
- * Unwrap AssignmentPattern like "(a = 1) => ret"
- * @param { AssignmentPattern | RestElement | ArrayPattern | ObjectPattern | Identifier } node
- * @return { RestElement | ArrayPattern | ObjectPattern | Identifier }
+ * Retrieve `AssignmentPattern#left` value if the given node a `AssignmentPattern` node. Otherwise, pass through it.
+ * @template T Node type
+ * @param {T | AssignmentPattern} node The node to address.
+ * @return {T} The `AssignmentPattern#left` value if the node is a `AssignmentPattern` node. Otherwise, the node.
  */
-function unwrapAssignmentPattern(node) {
+function skipDefaultParamValue(node) {
   if (!node) {
     return node
   }
+  // @ts-expect-error
   if (node.type === 'AssignmentPattern') {
     // @ts-expect-error
-    return unwrapAssignmentPattern(node.left)
+    return skipDefaultParamValue(node.left)
   }
+  // @ts-expect-error
   return node
 }
 
 /**
- * Unwrap ChainExpression like "(a?.b)"
- * @template T
- * @param {T} node
- * @return {T}
+ * Retrieve `ChainExpression#expression` value if the given node a `ChainExpression` node. Otherwise, pass through it.
+ * @template T Node type
+ * @param {T | ChainExpression} node The node to address.
+ * @returns {T} The `ChainExpression#expression` value if the node is a `ChainExpression` node. Otherwise, the node.
  */
-function unwrapChainExpression(node) {
+function skipChainExpression(node) {
   if (!node) {
     return node
   }
   // @ts-expect-error
   if (node.type === 'ChainExpression') {
     // @ts-expect-error
-    return unwrapChainExpression(node.expression)
+    return skipChainExpression(node.expression)
   }
+  // @ts-expect-error
   return node
 }
 
@@ -1826,7 +1824,7 @@ function isVueComponent(node) {
     const callee = node.callee
 
     if (callee.type === 'MemberExpression') {
-      const calleeObject = unwrapTypes(callee.object)
+      const calleeObject = skipTSAsExpression(callee.object)
 
       if (calleeObject.type === 'Identifier') {
         const propName = getStaticPropertyName(callee)
@@ -1880,7 +1878,8 @@ function isVueComponent(node) {
   function isObjectArgument(node) {
     return (
       node.arguments.length > 0 &&
-      unwrapTypes(node.arguments.slice(-1)[0]).type === 'ObjectExpression'
+      skipTSAsExpression(node.arguments.slice(-1)[0]).type ===
+        'ObjectExpression'
     )
   }
 }
@@ -1898,7 +1897,7 @@ function isVueInstance(node) {
       callee.type === 'Identifier' &&
       callee.name === 'Vue' &&
       node.arguments.length &&
-      unwrapTypes(node.arguments[0]).type === 'ObjectExpression'
+      skipTSAsExpression(node.arguments[0]).type === 'ObjectExpression'
   )
 }
 
@@ -1918,7 +1917,7 @@ function getVueObjectType(context, node) {
     const filePath = context.getFilename()
     if (
       isVueComponentFile(parent, filePath) &&
-      unwrapTypes(parent.declaration) === node
+      skipTSAsExpression(parent.declaration) === node
     ) {
       return 'export'
     }
@@ -1926,13 +1925,16 @@ function getVueObjectType(context, node) {
     // Vue.component('xxx', {}) || component('xxx', {})
     if (
       isVueComponent(parent) &&
-      unwrapTypes(parent.arguments.slice(-1)[0]) === node
+      skipTSAsExpression(parent.arguments.slice(-1)[0]) === node
     ) {
       return 'definition'
     }
   } else if (parent.type === 'NewExpression') {
     // new Vue({})
-    if (isVueInstance(parent) && unwrapTypes(parent.arguments[0]) === node) {
+    if (
+      isVueInstance(parent) &&
+      skipTSAsExpression(parent.arguments[0]) === node
+    ) {
       return 'instance'
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint": "^6.0.0 || ^7.0.0"
   },
   "dependencies": {
-    "eslint-utils": "^2.0.0",
+    "eslint-utils": "^2.1.0",
     "natural-compare": "^1.4.0",
     "semver": "^7.3.2",
     "vue-eslint-parser": "^7.1.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=8.10"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0"
+    "eslint": "^6.2.0 || ^7.0.0"
   },
   "dependencies": {
     "eslint-utils": "^2.1.0",

--- a/tests/lib/rules/custom-event-name-casing.js
+++ b/tests/lib/rules/custom-event-name-casing.js
@@ -10,7 +10,7 @@ const rule = require('../../../lib/rules/custom-event-name-casing')
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2019,
+    ecmaVersion: 2020,
     sourceType: 'module'
   }
 })
@@ -215,6 +215,66 @@ tester.run('custom-event-name-casing', rule, {
           endLine: 17,
           endColumn: 32
         }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <input
+          @click="$emit?.('fooBar')">
+      </template>
+      <script>
+      export default {
+        setup(props, context) {
+          return {
+            onInput(value) {
+              context?.emit?.('barBaz')
+            }
+          }
+        },
+        methods: {
+          onClick() {
+            this?.$emit?.('bazQux')
+          }
+        }
+      }
+      </script>
+      `,
+      errors: [
+        "Custom event name 'fooBar' must be kebab-case.",
+        "Custom event name 'barBaz' must be kebab-case.",
+        "Custom event name 'bazQux' must be kebab-case."
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <input
+          @click="$emit?.('fooBar')">
+      </template>
+      <script>
+      export default {
+        setup(props, context) {
+          return {
+            onInput(value) {
+              (context?.emit)?.('barBaz')
+            }
+          }
+        },
+        methods: {
+          onClick() {
+            (this?.$emit)?.('bazQux')
+          }
+        }
+      }
+      </script>
+      `,
+      errors: [
+        "Custom event name 'fooBar' must be kebab-case.",
+        "Custom event name 'barBaz' must be kebab-case.",
+        "Custom event name 'bazQux' must be kebab-case."
       ]
     }
   ]

--- a/tests/lib/rules/no-async-in-computed-properties.js
+++ b/tests/lib/rules/no-async-in-computed-properties.js
@@ -12,7 +12,7 @@ const rule = require('../../../lib/rules/no-async-in-computed-properties')
 const RuleTester = require('eslint').RuleTester
 
 const parserOptions = {
-  ecmaVersion: 2018,
+  ecmaVersion: 2020,
   sourceType: 'module'
 }
 
@@ -308,6 +308,34 @@ ruleTester.run('no-async-in-computed-properties', rule, {
         export default {
           computed: {
             foo: function () {
+              return bar?.then?.(response => {})
+            }
+          }
+        }
+      `,
+      parserOptions,
+      errors: ['Unexpected asynchronous action in "foo" computed property.']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo: function () {
+              return (bar?.then)?.(response => {})
+            }
+          }
+        }
+      `,
+      parserOptions,
+      errors: ['Unexpected asynchronous action in "foo" computed property.']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          computed: {
+            foo: function () {
               return bar.catch(e => {})
             }
           }
@@ -550,6 +578,66 @@ ruleTester.run('no-async-in-computed-properties', rule, {
           message: 'Unexpected timed function in "foo" computed property.',
           line: 12
         }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      export default {
+        computed: {
+          foo: function () {
+            setTimeout?.(() => { }, 0)
+            window?.setTimeout?.(() => { }, 0)
+            setInterval(() => { }, 0)
+            window?.setInterval?.(() => { }, 0)
+            setImmediate?.(() => { })
+            window?.setImmediate?.(() => { })
+            requestAnimationFrame?.(() => {})
+            window?.requestAnimationFrame?.(() => {})
+          }
+        }
+      }
+      `,
+      parserOptions,
+      errors: [
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      export default {
+        computed: {
+          foo: function () {
+            setTimeout?.(() => { }, 0)
+            ;(window?.setTimeout)?.(() => { }, 0)
+            setInterval(() => { }, 0)
+            ;(window?.setInterval)?.(() => { }, 0)
+            setImmediate?.(() => { })
+            ;(window?.setImmediate)?.(() => { })
+            requestAnimationFrame?.(() => {})
+            ;(window?.requestAnimationFrame)?.(() => {})
+          }
+        }
+      }
+      `,
+      parserOptions,
+      errors: [
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.',
+        'Unexpected timed function in "foo" computed property.'
       ]
     }
   ]

--- a/tests/lib/rules/no-deprecated-dollar-listeners-api.js
+++ b/tests/lib/rules/no-deprecated-dollar-listeners-api.js
@@ -18,7 +18,7 @@ const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
   valid: [
@@ -237,6 +237,30 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
         {
           line: 8,
           column: 27,
+          messageId: 'deprecated'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+          computed: {
+            foo () {
+              const vm = this
+              const a = vm?.$listeners
+              const b = this?.$listeners
+            }
+          }
+        }
+        </script>
+      `,
+      errors: [
+        {
+          messageId: 'deprecated'
+        },
+        {
           messageId: 'deprecated'
         }
       ]

--- a/tests/lib/rules/no-deprecated-dollar-scopedslots-api.js
+++ b/tests/lib/rules/no-deprecated-dollar-scopedslots-api.js
@@ -18,7 +18,7 @@ const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 ruleTester.run('no-deprecated-dollar-scopedslots-api', rule, {
   valid: [
@@ -280,6 +280,41 @@ ruleTester.run('no-deprecated-dollar-scopedslots-api', rule, {
         {
           line: 7,
           column: 25,
+          messageId: 'deprecated'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+        export default {
+          render () {
+            const vm = this
+            const a = vm?.$scopedSlots
+            const b = this?.$scopedSlots
+            return a.foo('bar')
+          }
+        }
+        </script>
+      `,
+      output: `
+        <script>
+        export default {
+          render () {
+            const vm = this
+            const a = vm?.$slots
+            const b = this?.$slots
+            return a.foo('bar')
+          }
+        }
+        </script>
+      `,
+      errors: [
+        {
+          messageId: 'deprecated'
+        },
+        {
           messageId: 'deprecated'
         }
       ]

--- a/tests/lib/rules/no-deprecated-events-api.js
+++ b/tests/lib/rules/no-deprecated-events-api.js
@@ -13,7 +13,7 @@ const rule = require('../../../lib/rules/no-deprecated-events-api')
 const RuleTester = require('eslint').RuleTester
 
 const parserOptions = {
-  ecmaVersion: 2018,
+  ecmaVersion: 2020,
   sourceType: 'module'
 }
 
@@ -113,6 +113,20 @@ ruleTester.run('no-deprecated-events-api', rule, {
         }
       `,
       parserOptions
+    },
+    {
+      filename: 'test.js',
+      code: `
+        app.component('some-comp', {
+          mounted () {
+            // It is OK because checking whether it is deprecated.
+            this.$on?.('start', foo)
+            this.$off?.('start', foo)
+            this.$once?.('start', foo)
+          }
+        })
+      `,
+      parserOptions
     }
   ],
 
@@ -194,6 +208,42 @@ ruleTester.run('no-deprecated-events-api', rule, {
             'The Events api `$on`, `$off` `$once` is deprecated. Using external library instead, for example mitt.',
           line: 5
         }
+      ]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        app.component('some-comp', {
+          mounted () {
+            this?.$on('start')
+            this?.$off('start')
+            this?.$once('start')
+          }
+        })
+      `,
+      parserOptions,
+      errors: [
+        'The Events api `$on`, `$off` `$once` is deprecated. Using external library instead, for example mitt.',
+        'The Events api `$on`, `$off` `$once` is deprecated. Using external library instead, for example mitt.',
+        'The Events api `$on`, `$off` `$once` is deprecated. Using external library instead, for example mitt.'
+      ]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        app.component('some-comp', {
+          mounted () {
+            ;(this?.$on)('start')
+            ;(this?.$off)('start')
+            ;(this?.$once)('start')
+          }
+        })
+      `,
+      parserOptions,
+      errors: [
+        'The Events api `$on`, `$off` `$once` is deprecated. Using external library instead, for example mitt.',
+        'The Events api `$on`, `$off` `$once` is deprecated. Using external library instead, for example mitt.',
+        'The Events api `$on`, `$off` `$once` is deprecated. Using external library instead, for example mitt.'
       ]
     }
   ]

--- a/tests/lib/rules/no-deprecated-vue-config-keycodes.js
+++ b/tests/lib/rules/no-deprecated-vue-config-keycodes.js
@@ -17,7 +17,7 @@ const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2015 }
+  parserOptions: { ecmaVersion: 2020 }
 })
 
 ruleTester.run('no-deprecated-vue-config-keycodes', rule, {
@@ -51,6 +51,16 @@ ruleTester.run('no-deprecated-vue-config-keycodes', rule, {
           endColumn: 20
         }
       ]
+    },
+    {
+      filename: 'test.js',
+      code: 'Vue?.config?.keyCodes',
+      errors: ['`Vue.config.keyCodes` are deprecated.']
+    },
+    {
+      filename: 'test.js',
+      code: '(Vue?.config)?.keyCodes',
+      errors: ['`Vue.config.keyCodes` are deprecated.']
     }
   ]
 })

--- a/tests/lib/rules/no-lifecycle-after-await.js
+++ b/tests/lib/rules/no-lifecycle-after-await.js
@@ -8,7 +8,7 @@ const rule = require('../../../lib/rules/no-lifecycle-after-await')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2019, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 
 tester.run('no-lifecycle-after-await', rule, {
@@ -202,6 +202,26 @@ tester.run('no-lifecycle-after-await', rule, {
         {
           messageId: 'forbidden',
           line: 18
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      import {onMounted} from 'vue'
+      export default {
+        async setup() {
+          await doSomething()
+
+          onMounted?.(() => { /* ... */ }) // error
+        }
+      }
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'forbidden'
         }
       ]
     }

--- a/tests/lib/rules/no-multiple-slot-args.js
+++ b/tests/lib/rules/no-multiple-slot-args.js
@@ -18,7 +18,7 @@ const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 ruleTester.run('no-multiple-slot-args', rule, {
   valid: [
@@ -107,6 +107,90 @@ ruleTester.run('no-multiple-slot-args', rule, {
           endLine: 6,
           endColumn: 41
         }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        render (h) {
+          this?.$scopedSlots?.default?.(foo, bar)
+          this?.$scopedSlots?.foo?.(foo, bar)
+          const vm = this
+          vm?.$scopedSlots?.default?.(foo, bar)
+          vm?.$scopedSlots?.foo?.(foo, bar)
+        }
+      }
+      </script>
+      `,
+      errors: [
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        render (h) {
+          this.$scopedSlots.default?.(foo, bar)
+          this.$scopedSlots.foo?.(foo, bar)
+          const vm = this
+          vm.$scopedSlots.default?.(foo, bar)
+          vm.$scopedSlots.foo?.(foo, bar)
+        }
+      }
+      </script>
+      `,
+      errors: [
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        render (h) {
+          ;(this?.$scopedSlots)?.default?.(foo, bar)
+          ;(this?.$scopedSlots?.foo)?.(foo, bar)
+          const vm = this
+          ;(vm?.$scopedSlots)?.default?.(foo, bar)
+          ;(vm?.$scopedSlots?.foo)?.(foo, bar)
+        }
+      }
+      </script>
+      `,
+      errors: [
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        render (h) {
+          ;(this?.$scopedSlots).default(foo, bar)
+          ;(this?.$scopedSlots?.foo)(foo, bar)
+          const vm = this
+          ;(vm?.$scopedSlots).default(foo, bar)
+          ;(vm?.$scopedSlots?.foo)(foo, bar)
+        }
+      }
+      </script>
+      `,
+      errors: [
+        'Unexpected multiple arguments.',
+        'Unexpected multiple arguments.'
       ]
     },
     {

--- a/tests/lib/rules/no-mutating-props.js
+++ b/tests/lib/rules/no-mutating-props.js
@@ -348,6 +348,52 @@ ruleTester.run('no-mutating-props', rule, {
       code: `
         <template>
           <div>
+            <div v-text="prop1?.shift?.()"></div>
+            <div v-text="prop2?.slice?.(0)?.shift?.()"></div>
+            <div v-if="this?.prop3"></div>
+            <div v-if="this?.prop4 < 10"></div>
+            <div v-text="this?.prop5?.shift?.()"></div>
+            <div v-text="this?.prop6?.slice?.(0)?.shift?.()"></div>
+          </div>
+        </template>
+        <script>
+          export default {
+            props: ['prop1', 'prop2', 'prop3', 'prop4', 'prop5', 'prop6']
+          }
+        </script>
+      `,
+      errors: [
+        'Unexpected mutation of "prop1" prop.',
+        'Unexpected mutation of "prop5" prop.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>
+            <div v-text="(prop1?.shift)?.()"></div>
+            <div v-text="(this?.prop2)?.shift?.()"></div>
+            <div v-text="(this?.prop3?.shift)?.()"></div>
+          </div>
+        </template>
+        <script>
+          export default {
+            props: ['prop1', 'prop2', 'prop3']
+          }
+        </script>
+      `,
+      errors: [
+        'Unexpected mutation of "prop1" prop.',
+        'Unexpected mutation of "prop2" prop.',
+        'Unexpected mutation of "prop3" prop.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>
             <input v-model="prop1.text">
             <input v-model="prop2">
             <input v-model="this.prop3.text">
@@ -417,6 +463,28 @@ ruleTester.run('no-mutating-props', rule, {
           message: 'Unexpected mutation of "items" prop.',
           line: 18
         }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script>
+          export default {
+            props: ['foo', 'bar', 'baz'],
+            methods: {
+              openModal() {
+                this?.foo?.push?.('something')
+                ;(this?.bar)?.push?.('something')
+                ;(this?.baz?.push)?.('something')
+              }
+            }
+          }
+        </script>
+      `,
+      errors: [
+        'Unexpected mutation of "foo" prop.',
+        'Unexpected mutation of "bar" prop.',
+        'Unexpected mutation of "baz" prop.'
       ]
     },
     {

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -8,7 +8,7 @@ const rule = require('../../../lib/rules/no-ref-as-operand')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2019, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 
 tester.run('no-ref-as-operand', rule, {
@@ -485,6 +485,20 @@ tester.run('no-ref-as-operand', rule, {
         import { ref, computed, toRef, customRef, shallowRef } from 'vue'
         const foo = shallowRef({})
         foo.bar = 123
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'requireDotValue'
+        }
+      ]
+    },
+    {
+      code: `
+      <script>
+        import { ref } from 'vue'
+        const foo = ref(123)
+        const bar = foo?.bar
       </script>
       `,
       errors: [

--- a/tests/lib/rules/no-setup-props-destructure.js
+++ b/tests/lib/rules/no-setup-props-destructure.js
@@ -8,7 +8,7 @@ const rule = require('../../../lib/rules/no-setup-props-destructure')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2019, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 
 tester.run('no-setup-props-destructure', rule, {
@@ -339,6 +339,38 @@ tester.run('no-setup-props-destructure', rule, {
         {
           messageId: 'getProperty',
           line: 5
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        setup(p) {
+          const x = p.foo
+          const y = p?.bar
+          const z = (p?.baz).qux
+
+          const xc = p?.foo?.()
+          const yc = (p?.bar)?.()
+          const zc = (p?.baz.qux)?.()
+        }
+      }
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 5
+        },
+        {
+          messageId: 'getProperty',
+          line: 6
+        },
+        {
+          messageId: 'getProperty',
+          line: 7
         }
       ]
     },

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -12,7 +12,7 @@ const rule = require('../../../lib/rules/no-side-effects-in-computed-properties'
 const RuleTester = require('eslint').RuleTester
 
 const parserOptions = {
-  ecmaVersion: 2018,
+  ecmaVersion: 2020,
   sourceType: 'module'
 }
 
@@ -337,6 +337,27 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           line: 4,
           message: 'Unexpected side effect in "test1" computed property.'
         }
+      ]
+    },
+    {
+      code: `Vue.component('test', {
+        computed: {
+          test1() {
+            return this?.something?.reverse?.()
+          },
+          test2() {
+            return (this?.something)?.reverse?.()
+          },
+          test3() {
+            return (this?.something?.reverse)?.()
+          },
+        }
+      })`,
+      parserOptions,
+      errors: [
+        'Unexpected side effect in "test1" computed property.',
+        'Unexpected side effect in "test2" computed property.',
+        'Unexpected side effect in "test3" computed property.'
       ]
     }
   ]

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -995,6 +995,41 @@ tester.run('no-unused-properties', rule, {
             props: [, 'count']
           }
         </script>
+        `
+    },
+    // optional chaining
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        import { ref, onMounted } from 'vue'
+
+        export default {
+          props: ['foo', 'bar'],
+          methods: {
+            fn () {
+              fn(this)
+            }
+          }
+        }
+
+        function fn(a) {
+          return a?.foo + a?.bar
+        }
+      </script>`
+    },
+    {
+      filename: 'test.js',
+      code: `
+      Vue.component('MyButton', {
+        functional: true,
+        props: ['foo', 'bar'],
+        render: function (createElement, ctx) {
+          const a = ctx
+          const b = a?.props?.foo
+          const c = (a?.props)?.bar
+        }
+      })
       `
     }
   ],

--- a/tests/lib/rules/no-watch-after-await.js
+++ b/tests/lib/rules/no-watch-after-await.js
@@ -8,7 +8,7 @@ const rule = require('../../../lib/rules/no-watch-after-await')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2019, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 
 tester.run('no-watch-after-await', rule, {
@@ -97,6 +97,27 @@ tester.run('no-watch-after-await', rule, {
       Vue.component('test', {
         el: foo()
       })`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      import {watch, watchEffect} from 'vue'
+      export default {
+        async setup() {
+          await doSomething()
+          const a = watchEffect?.(() => { /* ... */ })
+          const b = watch?.(foo, () => { /* ... */ })
+          c = watch?.()
+          d(watch?.())
+          e = {
+            foo: watch?.()
+          }
+          f = [watch?.()]
+        }
+      }
+      </script>
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -879,6 +879,7 @@ ruleTester.run('order-in-components', rule, {
           testYield: function* () {},
           testTemplate: \`a:\${a},b:\${b},c:\${c}.\`,
           testNullish: a ?? b,
+          testOptionalChaining: a?.b?.c,
           name: 'burger',
         };
       `,
@@ -897,13 +898,14 @@ ruleTester.run('order-in-components', rule, {
           testYield: function* () {},
           testTemplate: \`a:\${a},b:\${b},c:\${c}.\`,
           testNullish: a ?? b,
+          testOptionalChaining: a?.b?.c,
         };
       `,
       errors: [
         {
           message:
             'The "name" property should be above the "data" property on line 3.',
-          line: 14
+          line: 15
         }
       ]
     }

--- a/tests/lib/rules/require-default-prop.js
+++ b/tests/lib/rules/require-default-prop.js
@@ -11,7 +11,7 @@
 const rule = require('../../../lib/rules/require-default-prop')
 const RuleTester = require('eslint').RuleTester
 const parserOptions = {
-  ecmaVersion: 2018,
+  ecmaVersion: 2020,
   sourceType: 'module'
 }
 
@@ -148,7 +148,8 @@ ruleTester.run('require-default-prop', rule, {
           props: {
             bar,
             baz: prop,
-            bar1: foo()
+            baz1: prop.foo,
+            bar2: foo()
           }
         }
       `
@@ -285,7 +286,7 @@ ruleTester.run('require-default-prop', rule, {
       ]
     },
 
-    // computed propertys
+    // computed properties
     {
       filename: 'test.vue',
       code: `
@@ -370,6 +371,22 @@ ruleTester.run('require-default-prop', rule, {
         }
       `,
       errors: ["Prop 'foo' requires default value to be set."]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: {
+            bar,
+            baz: prop?.foo,
+            bar1: foo?.(),
+          }
+        }
+      `,
+      errors: [
+        "Prop 'baz' requires default value to be set.",
+        "Prop 'bar1' requires default value to be set."
+      ]
     }
   ]
 })

--- a/tests/lib/rules/require-explicit-emits.js
+++ b/tests/lib/rules/require-explicit-emits.js
@@ -10,7 +10,7 @@ const rule = require('../../../lib/rules/require-explicit-emits')
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2019,
+    ecmaVersion: 2020,
     sourceType: 'module'
   }
 })
@@ -1513,6 +1513,43 @@ emits: {'foo': null}
             }
           ]
         }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        methods: {
+          click () {
+            const vm = this
+            vm?.$emit?.('foo')
+            ;(vm?.$emit)?.('bar')
+          }
+        }
+      }
+      </script>
+      `,
+      errors: [
+        'The "foo" event has been triggered but not declared on `emits` option.',
+        'The "bar" event has been triggered but not declared on `emits` option.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        setup(p, c) {
+          c?.emit?.('foo')
+          ;(c?.emit)?.('bar')
+        }
+      }
+      </script>
+      `,
+      errors: [
+        'The "foo" event has been triggered but not declared on `emits` option.',
+        'The "bar" event has been triggered but not declared on `emits` option.'
       ]
     }
   ]

--- a/tests/lib/rules/require-slots-as-functions.js
+++ b/tests/lib/rules/require-slots-as-functions.js
@@ -18,7 +18,7 @@ const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2018, sourceType: 'module' }
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
 })
 ruleTester.run('require-slots-as-functions', rule, {
   valid: [
@@ -86,29 +86,27 @@ ruleTester.run('require-slots-as-functions', rule, {
         }
       ]
     },
-
     {
       filename: 'test.vue',
       code: `
       <script>
       export default {
         render (h) {
-          let children
-
-          const [node] = this.$slots.foo
-          const bar = [this.$slots[foo]]
-
-          children = this.$slots.foo
-
-          return h('div', children.filter(test))
+          var bar = this.$slots.foo?.bar // NG
+          var bar = this.$slots.foo?.() // OK
+          var bar = (this.$slots?.foo)?.bar // NG
+          var bar = (this.$slots?.foo)?.() // OK
+          var bar = (this?.$slots)?.foo?.bar // NG
+          var bar = (this?.$slots)?.foo?.() // OK
+          return h('div', bar)
         }
       }
       </script>
       `,
       errors: [
-        'Property in `$slots` should be used as function.',
-        'Property in `$slots` should be used as function.',
-        'Property in `$slots` should be used as function.'
+        { messageId: 'unexpected', line: 5 },
+        { messageId: 'unexpected', line: 7 },
+        { messageId: 'unexpected', line: 9 }
       ]
     }
   ]

--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -195,6 +195,18 @@ ruleTester.run('require-valid-default-prop', rule, {
         }
       }`,
       parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `export default {
+        props: {
+          foo: {
+            type: Number,
+            default: Number?.()
+          }
+        }
+      }`,
+      parserOptions
     }
   ],
 
@@ -756,6 +768,19 @@ ruleTester.run('require-valid-default-prop', rule, {
           line: 11
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `export default {
+        props: {
+          foo: {
+            type: String,
+            default: Number?.()
+          }
+        }
+      }`,
+      parserOptions,
+      errors: errorMessage('string')
     }
   ]
 })

--- a/tests/lib/rules/this-in-template.js
+++ b/tests/lib/rules/this-in-template.js
@@ -18,7 +18,7 @@ const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2015 }
+  parserOptions: { ecmaVersion: 2020 }
 })
 
 function createValidTests(prefix, options) {
@@ -188,11 +188,18 @@ ruleTester.run('this-in-template', rule, {
   valid: ['', '<template></template>', '<template><div></div></template>']
     .concat(createValidTests('', []))
     .concat(createValidTests('', ['never']))
-    .concat(createValidTests('this.', ['always'])),
+    .concat(createValidTests('this.', ['always']))
+    .concat(createValidTests('this?.', ['always'])),
   invalid: []
     .concat(
       createInvalidTests(
         'this.',
+        [],
+        "Unexpected usage of 'this'.",
+        'ThisExpression'
+      ),
+      createInvalidTests(
+        'this?.',
         [],
         "Unexpected usage of 'this'.",
         'ThisExpression'
@@ -201,6 +208,12 @@ ruleTester.run('this-in-template', rule, {
     .concat(
       createInvalidTests(
         'this.',
+        ['never'],
+        "Unexpected usage of 'this'.",
+        'ThisExpression'
+      ),
+      createInvalidTests(
+        'this?.',
         ['never'],
         "Unexpected usage of 'this'.",
         'ThisExpression'

--- a/tests/lib/rules/v-on-function-call.js
+++ b/tests/lib/rules/v-on-function-call.js
@@ -16,7 +16,7 @@ const rule = require('../../../lib/rules/v-on-function-call')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2015 }
+  parserOptions: { ecmaVersion: 2020 }
 })
 
 tester.run('v-on-function-call', rule, {
@@ -106,6 +106,11 @@ tester.run('v-on-function-call', rule, {
         <div @click="fn() /* comment */"></div>
       </template>`,
       options: ['never', { ignoreIncludesComment: true }]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div @click="foo?.()"></div></template>',
+      options: ['never']
     }
   ],
   invalid: [

--- a/tests/lib/rules/valid-v-bind-sync.js
+++ b/tests/lib/rules/valid-v-bind-sync.js
@@ -16,7 +16,7 @@ const rule = require('../../../lib/rules/valid-v-bind-sync')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2015 }
+  parserOptions: { ecmaVersion: 2020 }
 })
 
 tester.run('valid-v-bind-sync', rule, {
@@ -350,6 +350,42 @@ tester.run('valid-v-bind-sync', rule, {
       errors: [
         "'.sync' modifiers require the attribute value which is valid as LHS."
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent :foo.sync="foo?.bar" /></template>',
+      errors: [
+        "Optional chaining cannot appear in 'v-bind' with '.sync' modifiers."
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent :foo.sync="foo?.bar.baz" /></template>',
+      errors: [
+        "Optional chaining cannot appear in 'v-bind' with '.sync' modifiers."
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent :foo.sync="(a?.b)?.c" /></template>',
+      errors: [
+        "Optional chaining cannot appear in 'v-bind' with '.sync' modifiers."
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent :foo.sync="(a?.b).c" /></template>',
+      errors: ["'.sync' modifier has potential null object property access."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent :foo.sync="(null).foo" /></template>',
+      errors: ["'.sync' modifier has potential null object property access."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent :foo.sync="(a?.b).c.d" /></template>',
+      errors: ["'.sync' modifier has potential null object property access."]
     }
   ]
 })

--- a/tests/lib/rules/valid-v-model.js
+++ b/tests/lib/rules/valid-v-model.js
@@ -18,7 +18,7 @@ const rule = require('../../../lib/rules/valid-v-model')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
-  parserOptions: { ecmaVersion: 2015 }
+  parserOptions: { ecmaVersion: 2020 }
 })
 
 tester.run('valid-v-model', rule, {
@@ -232,6 +232,36 @@ tester.run('valid-v-model', rule, {
       filename: 'empty-value.vue',
       code: '<template><MyComponent v-model="" /></template>',
       errors: ["'v-model' directives require that attribute value."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><input v-model="foo?.bar"></template>',
+      errors: ["Optional chaining cannot appear in 'v-model' directives."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><input v-model="foo?.bar.baz"></template>',
+      errors: ["Optional chaining cannot appear in 'v-model' directives."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><input v-model="(a?.b)?.c"></template>',
+      errors: ["Optional chaining cannot appear in 'v-model' directives."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><input v-model="(a?.b).c"></template>',
+      errors: ["'v-model' directive has potential null object property access."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><input v-model="(null).foo"></template>',
+      errors: ["'v-model' directive has potential null object property access."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><input v-model="(a?.b).c.d"></template>',
+      errors: ["'v-model' directive has potential null object property access."]
     }
   ]
 })

--- a/tools/update-lib-configs.js
+++ b/tools/update-lib-configs.js
@@ -49,7 +49,7 @@ function formatCategory(category) {
 module.exports = {
   parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module'
   },
   env: {


### PR DESCRIPTION
And change the supported version of ESLint from 6.0.0 to 6.2.0.

### Core

- Change presets configs `parserOptions.ecmaVersion` from 2018 to 2020.
- Change supported version of ESLint from 6.0.0 to 6.2.0.
- Upgrade `eslint-utils`

### Rules

- [x] custom-event-name-casing
- [x] no-async-in-computed-properties
- [x] no-deprecated-dollar-listeners-api
- [x] no-deprecated-dollar-scopedslots-api
- [x] no-deprecated-events-api
- [x] no-deprecated-vue-config-keycodes
- [x] no-lifecycle-after-await
- [x] no-multiple-slot-args
- [x] no-mutating-props
- [x] no-ref-as-operand
- [x] no-setup-props-destructure
- [x] no-side-effects-in-computed-properties
- [x] no-unused-properties
- [x] no-watch-after-await
- [x] order-in-components
- [x] require-default-prop
- [x] require-explicit-emits
- [x] require-slots-as-functions
- [x] require-valid-default-prop
- [x] this-in-template
- [x] v-on-function-call
- [x] valid-v-bind-sync
- [x] valid-v-model