### PR TITLE
Add `vue/no-deprecated-destroyed-lifecycle` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -42,6 +42,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 | [vue/no-arrow-functions-in-watch](./no-arrow-functions-in-watch.md) | disallow using arrow functions to define watcher |  |
 | [vue/no-async-in-computed-properties](./no-async-in-computed-properties.md) | disallow asynchronous actions in computed properties |  |
 | [vue/no-deprecated-data-object-declaration](./no-deprecated-data-object-declaration.md) | disallow using deprecated object declaration on data (in Vue.js 3.0.0+) | :wrench: |
+| [vue/no-deprecated-destroyed-lifecycle](./no-deprecated-destroyed-lifecycle.md) | disallow using deprecated `destroyed` and `beforeDestroy` lifecycle hooks (in Vue.js 3.0.0+) |  |
 | [vue/no-deprecated-dollar-listeners-api](./no-deprecated-dollar-listeners-api.md) | disallow using deprecated `$listeners` (in Vue.js 3.0.0+) |  |
 | [vue/no-deprecated-dollar-scopedslots-api](./no-deprecated-dollar-scopedslots-api.md) | disallow using deprecated `$scopedSlots` (in Vue.js 3.0.0+) | :wrench: |
 | [vue/no-deprecated-events-api](./no-deprecated-events-api.md) | disallow using deprecated events api (in Vue.js 3.0.0+) |  |

--- a/docs/rules/no-deprecated-destroyed-lifecycle.md
+++ b/docs/rules/no-deprecated-destroyed-lifecycle.md
@@ -1,0 +1,43 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-deprecated-destroyed-lifecycle
+description: disallow using deprecated `destroyed` and `beforeDestroy` lifecycle hooks (in Vue.js 3.0.0+)
+---
+# vue/no-deprecated-destroyed-lifecycle
+> disallow using deprecated `destroyed` and `beforeDestroy` lifecycle hooks (in Vue.js 3.0.0+)
+
+- :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/vue3-strongly-recommended"` and `"plugin:vue/vue3-recommended"`.
+
+## :book: Rule Details
+
+This rule reports use of deprecated `destroyed` and `beforeDestroy` lifecycle hooks. (in Vue.js 3.0.0+).
+
+<eslint-code-block :rules="{'vue/no-deprecated-destroyed-lifecycle': ['error']}">
+
+```vue
+<script>
+export default {
+  /* ✓ GOOD */
+  beforeMount () {},
+  mounted () {},
+  beforeUnmount () {},
+  unmounted () {},
+
+  /* ✗ BAD */
+  beforeDestroy () {},
+  destroyed () {}
+}
+</script>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-deprecated-destroyed-lifecycle.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-deprecated-destroyed-lifecycle.js)

--- a/lib/configs/vue3-essential.js
+++ b/lib/configs/vue3-essential.js
@@ -10,6 +10,7 @@ module.exports = {
     'vue/no-arrow-functions-in-watch': 'error',
     'vue/no-async-in-computed-properties': 'error',
     'vue/no-deprecated-data-object-declaration': 'error',
+    'vue/no-deprecated-destroyed-lifecycle': 'error',
     'vue/no-deprecated-dollar-listeners-api': 'error',
     'vue/no-deprecated-dollar-scopedslots-api': 'error',
     'vue/no-deprecated-events-api': 'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,7 @@ module.exports = {
     'no-confusing-v-for-v-if': require('./rules/no-confusing-v-for-v-if'),
     'no-custom-modifiers-on-v-model': require('./rules/no-custom-modifiers-on-v-model'),
     'no-deprecated-data-object-declaration': require('./rules/no-deprecated-data-object-declaration'),
+    'no-deprecated-destroyed-lifecycle': require('./rules/no-deprecated-destroyed-lifecycle'),
     'no-deprecated-dollar-listeners-api': require('./rules/no-deprecated-dollar-listeners-api'),
     'no-deprecated-dollar-scopedslots-api': require('./rules/no-deprecated-dollar-scopedslots-api'),
     'no-deprecated-events-api': require('./rules/no-deprecated-events-api'),

--- a/lib/rules/no-deprecated-destroyed-lifecycle.js
+++ b/lib/rules/no-deprecated-destroyed-lifecycle.js
@@ -49,10 +49,7 @@ module.exports = {
             {
               messageId: 'insteadUnmounted',
               fix(fixer) {
-                if (destroyed.shorthand) {
-                  return fixer.insertTextBefore(destroyed.key, 'unmounted:')
-                }
-                return fixer.replaceText(destroyed.key, 'unmounted')
+                return fix(fixer, destroyed, 'unmounted')
               }
             }
           ]
@@ -69,17 +66,35 @@ module.exports = {
             {
               messageId: 'insteadBeforeUnmount',
               fix(fixer) {
-                if (beforeDestroy.shorthand) {
-                  return fixer.insertTextBefore(
-                    beforeDestroy.key,
-                    'beforeUnmount:'
-                  )
-                }
-                return fixer.replaceText(beforeDestroy.key, 'beforeUnmount')
+                return fix(fixer, beforeDestroy, 'beforeUnmount')
               }
             }
           ]
         })
+      }
+
+      /**
+       * @param {RuleFixer} fixer
+       * @param {Property} property
+       * @param {string} newName
+       */
+      function fix(fixer, property, newName) {
+        if (property.computed) {
+          if (
+            property.key.type === 'Literal' ||
+            property.key.type === 'TemplateLiteral'
+          ) {
+            return fixer.replaceTextRange(
+              [property.key.range[0] + 1, property.key.range[1] - 1],
+              newName
+            )
+          }
+          return null
+        }
+        if (property.shorthand) {
+          return fixer.insertTextBefore(property.key, `${newName}:`)
+        }
+        return fixer.replaceText(property.key, newName)
       }
     })
   }

--- a/lib/rules/no-deprecated-destroyed-lifecycle.js
+++ b/lib/rules/no-deprecated-destroyed-lifecycle.js
@@ -1,0 +1,86 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow using deprecated `destroyed` and `beforeDestroy` lifecycle hooks (in Vue.js 3.0.0+)',
+      categories: ['vue3-essential'],
+      url:
+        'https://eslint.vuejs.org/rules/no-deprecated-destroyed-lifecycle.html'
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      deprecatedDestroyed:
+        'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+      deprecatedBeforeDestroy:
+        'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+      insteadUnmounted: 'Instead, change to `unmounted`.',
+      insteadBeforeUnmount: 'Instead, change to `beforeUnmount`.'
+    }
+  },
+  /** @param {RuleContext} context */
+  create(context) {
+    return utils.executeOnVue(context, (obj) => {
+      const destroyed = utils.findProperty(obj, 'destroyed')
+
+      if (destroyed) {
+        context.report({
+          node: destroyed.key,
+          messageId: 'deprecatedDestroyed',
+          // I don't know if they have exactly the same function, so don't do autofix.
+          suggest: [
+            {
+              messageId: 'insteadUnmounted',
+              fix(fixer) {
+                if (destroyed.shorthand) {
+                  return fixer.insertTextBefore(destroyed.key, 'unmounted:')
+                }
+                return fixer.replaceText(destroyed.key, 'unmounted')
+              }
+            }
+          ]
+        })
+      }
+
+      const beforeDestroy = utils.findProperty(obj, 'beforeDestroy')
+      if (beforeDestroy) {
+        context.report({
+          node: beforeDestroy.key,
+          messageId: 'deprecatedBeforeDestroy',
+          // I don't know if they have exactly the same function, so don't do autofix.
+          suggest: [
+            {
+              messageId: 'insteadBeforeUnmount',
+              fix(fixer) {
+                if (beforeDestroy.shorthand) {
+                  return fixer.insertTextBefore(
+                    beforeDestroy.key,
+                    'beforeUnmount:'
+                  )
+                }
+                return fixer.replaceText(beforeDestroy.key, 'beforeUnmount')
+              }
+            }
+          ]
+        })
+      }
+    })
+  }
+}

--- a/tests/lib/rules/no-deprecated-destroyed-lifecycle.js
+++ b/tests/lib/rules/no-deprecated-destroyed-lifecycle.js
@@ -1,0 +1,268 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-deprecated-destroyed-lifecycle')
+
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' }
+})
+ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        unmounted () {},
+        beforeUnmount () {},
+      }
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        unmounted,
+        beforeUnmount,
+      }
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        beforeCreate,
+        created,
+        beforeMount,
+        mounted,
+        beforeUpdate,
+        updated,
+        activated,
+        deactivated,
+        beforeUnmount,
+        unmounted,
+        errorCaptured,
+        renderTracked,
+        renderTriggered,
+      }
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        beforeUnmount:beforeDestroy,
+        unmounted:destroyed,
+      }
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        ...beforeDestroy,
+        ...destroyed,
+      }
+      </script>
+      `
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        beforeDestroy () {},
+        destroyed () {},
+      }
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 4,
+          suggestions: [
+            {
+              desc: 'Instead, change to `beforeUnmount`.',
+              output: `
+      <script>
+      export default {
+        beforeUnmount () {},
+        destroyed () {},
+      }
+      </script>
+      `
+            }
+          ]
+        },
+        {
+          message:
+            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+          line: 5,
+          suggestions: [
+            {
+              desc: 'Instead, change to `unmounted`.',
+              output: `
+      <script>
+      export default {
+        beforeDestroy () {},
+        unmounted () {},
+      }
+      </script>
+      `
+            }
+          ]
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        beforeDestroy,
+        destroyed,
+      }
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 4,
+          suggestions: [
+            {
+              desc: 'Instead, change to `beforeUnmount`.',
+              output: `
+      <script>
+      export default {
+        beforeUnmount:beforeDestroy,
+        destroyed,
+      }
+      </script>
+      `
+            }
+          ]
+        },
+        {
+          message:
+            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+          line: 5,
+          suggestions: [
+            {
+              desc: 'Instead, change to `unmounted`.',
+              output: `
+      <script>
+      export default {
+        beforeDestroy,
+        unmounted:destroyed,
+      }
+      </script>
+      `
+            }
+          ]
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        beforeCreate,
+        created,
+        beforeMount,
+        mounted,
+        beforeUpdate,
+        updated,
+        activated,
+        deactivated,
+        beforeDestroy,
+        destroyed,
+        errorCaptured,
+      }
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 12,
+          suggestions: [
+            {
+              desc: 'Instead, change to `beforeUnmount`.',
+              output: `
+      <script>
+      export default {
+        beforeCreate,
+        created,
+        beforeMount,
+        mounted,
+        beforeUpdate,
+        updated,
+        activated,
+        deactivated,
+        beforeUnmount:beforeDestroy,
+        destroyed,
+        errorCaptured,
+      }
+      </script>
+      `
+            }
+          ]
+        },
+        {
+          message:
+            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+          line: 13,
+          suggestions: [
+            {
+              desc: 'Instead, change to `unmounted`.',
+              output: `
+      <script>
+      export default {
+        beforeCreate,
+        created,
+        beforeMount,
+        mounted,
+        beforeUpdate,
+        updated,
+        activated,
+        deactivated,
+        beforeDestroy,
+        unmounted:destroyed,
+        errorCaptured,
+      }
+      </script>
+      `
+            }
+          ]
+        }
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/no-deprecated-destroyed-lifecycle.js
+++ b/tests/lib/rules/no-deprecated-destroyed-lifecycle.js
@@ -87,6 +87,17 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
       }
       </script>
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        [beforeDestroy] () {},
+        [destroyed] () {},
+      }
+      </script>
+      `
     }
   ],
   invalid: [
@@ -256,6 +267,104 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
         beforeDestroy,
         unmounted:destroyed,
         errorCaptured,
+      }
+      </script>
+      `
+            }
+          ]
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        ['beforeDestroy']() {},
+        ['destroyed']() {},
+      }
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 4,
+          suggestions: [
+            {
+              desc: 'Instead, change to `beforeUnmount`.',
+              output: `
+      <script>
+      export default {
+        ['beforeUnmount']() {},
+        ['destroyed']() {},
+      }
+      </script>
+      `
+            }
+          ]
+        },
+        {
+          message:
+            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+          line: 5,
+          suggestions: [
+            {
+              desc: 'Instead, change to `unmounted`.',
+              output: `
+      <script>
+      export default {
+        ['beforeDestroy']() {},
+        ['unmounted']() {},
+      }
+      </script>
+      `
+            }
+          ]
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        [\`beforeDestroy\`]() {},
+        [\`destroyed\`]() {},
+      }
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 4,
+          suggestions: [
+            {
+              desc: 'Instead, change to `beforeUnmount`.',
+              output: `
+      <script>
+      export default {
+        [\`beforeUnmount\`]() {},
+        [\`destroyed\`]() {},
+      }
+      </script>
+      `
+            }
+          ]
+        },
+        {
+          message:
+            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+          line: 5,
+          suggestions: [
+            {
+              desc: 'Instead, change to `unmounted`.',
+              output: `
+      <script>
+      export default {
+        [\`beforeDestroy\`]() {},
+        [\`unmounted\`]() {},
       }
       </script>
       `


### PR DESCRIPTION
This PR adds `vue/no-deprecated-destroyed-lifecycle` rule.

The `vue/no-deprecated-destroyed-lifecycle` rule reports use of deprecated `destroyed` and `beforeDestroy` lifecycle hooks.