### PR TITLE
Replace words

### DIFF
--- a/docs/rules/no-bare-strings-in-template.md
+++ b/docs/rules/no-bare-strings-in-template.md
@@ -57,7 +57,7 @@ If you want to report these string literals, enable the [vue/no-useless-v-bind] 
 ```js
 {
   "vue/no-bare-strings-in-template": ["error", {
-    "whitelist": [
+    "allowlist": [
       "(", ")", ",", ".", "&", "+", "-", "=", "*", "/", "#", "%", "!", "?", ":", "[", "]", "{", "}", "<", ">", "\u00b7", "\u2022", "\u2010", "\u2013", "\u2014", "\u2212", "|"
     ],
     "attributes": {
@@ -70,7 +70,7 @@ If you want to report these string literals, enable the [vue/no-useless-v-bind] 
 }
 ```
 
-- `whitelist` ... An array of whitelisted strings.
+- `allowlist` ... An array of allowed strings.
 - `attributes` ... An object whose keys are tag name or patterns and value is an array of attributes to check for that tag name.
 - `directives` ... An array of directive names to check literal value.
 

--- a/docs/rules/require-prop-type-constructor.md
+++ b/docs/rules/require-prop-type-constructor.md
@@ -14,7 +14,7 @@ description: require prop type to be a constructor
 
 This rule reports prop types that can't be presumed as constructors.
 
-It's impossible to catch every possible case and know whether the prop type is a constructor or not, hence this rule black list few types of nodes, instead of white-listing correct ones.
+It's impossible to catch every possible case and know whether the prop type is a constructor or not, hence this rule block-list few types of nodes, instead of allow-listing correct ones.
 
 The following types are forbidden and will be reported:
 

--- a/lib/rules/no-bare-strings-in-template.js
+++ b/lib/rules/no-bare-strings-in-template.js
@@ -128,7 +128,7 @@ module.exports = {
       {
         type: 'object',
         properties: {
-          whitelist: {
+          allowlist: {
             type: 'array',
             items: { type: 'string' },
             uniqueItems: true
@@ -164,12 +164,12 @@ module.exports = {
      */
     const opts = context.options[0] || {}
     /** @type {string[]} */
-    const whitelist = opts.whitelist || DEFAULT_WHITELIST
+    const allowlist = opts.allowlist || DEFAULT_WHITELIST
     const attributes = parseTargetAttrs(opts.attributes || DEFAULT_ATTRIBUTES)
     const directives = opts.directives || DEFAULT_DIRECTIVES
 
-    const whitelistRe = new RegExp(
-      whitelist.map((w) => regexp.escape(w)).join('|'),
+    const allowlistRe = new RegExp(
+      allowlist.map((w) => regexp.escape(w)).join('|'),
       'gu'
     )
 
@@ -180,7 +180,7 @@ module.exports = {
      * @param {string} str
      */
     function getBareString(str) {
-      return str.trim().replace(whitelistRe, '').trim()
+      return str.trim().replace(allowlistRe, '').trim()
     }
 
     /**

--- a/tests/lib/rules/no-bare-strings-in-template.js
+++ b/tests/lib/rules/no-bare-strings-in-template.js
@@ -214,7 +214,7 @@ tester.run('no-bare-strings-in-template', rule, {
         <h1>ipsum</h1>
       </template>
       `,
-      options: [{ whitelist: ['Lorem'] }],
+      options: [{ allowlist: ['Lorem'] }],
       errors: [
         {
           line: 4,


### PR DESCRIPTION
This PR replaces some words.

Also, change the option name in the `vue/no-bare-strings-in-template` rule.
This is a breaking change, but we'll change this rule as it's only released in alpha stage.