### PR TITLE
Fixed no-side-effects-in-computed-properties when el is object

### DIFF
--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -31,15 +31,9 @@ module.exports = {
   create(context) {
     /** @type {Map<ObjectExpression, ComponentComputedProperty[]>} */
     const computedPropertiesMap = new Map()
-    /**
-     * @typedef {object} ScopeStack
-     * @property {ScopeStack} upper
-     * @property {BlockStatement | Expression} body
-     */
-    /**
-     * @type {ScopeStack}
-     */
-    let scopeStack
+
+    /** @type { { upper: any, body: null | BlockStatement | Expression } } */
+    let scopeStack = { upper: null, body: null }
 
     /** @param {FunctionExpression | ArrowFunctionExpression | FunctionDeclaration} node */
     function onFunctionEnter(node) {

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -180,7 +180,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
         el: test.el
       })`,
       parserOptions
-    },
+    }
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -173,7 +173,14 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
         }
       })`,
       parserOptions
-    }
+    },
+    {
+      code: `const test = { el: '#app' }
+        Vue.component('test', {
+        el: test.el
+      })`,
+      parserOptions
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Hi, thanks for great plugin!

I'm using object property to set `el` of Vue.
However, I get a `TypeError` when I update eslint-plugin-vue to `v7.0.0-alpha.7` and run eslint.

for example:

```javascript
const dummy = { app: '#app' }

new Vue({
  el: dummy.app,
  template: '<p>test</p>',
});
```

```
TypeError: Cannot read property 'body' of undefined
```


I think the cause of this issue is that the `scopeStack` has no default value.
but, I’m not sure if this PR is the best solution.

Could you please review this PR or use another best solution to fix this issue?
Thanks.
