### PR TITLE
Fixed crash when using `vue/no-empty-component-block` and `vue/padding-line-between-blocks` rules in `.js` file

### DIFF
--- a/lib/rules/no-empty-component-block.js
+++ b/lib/rules/no-empty-component-block.js
@@ -69,10 +69,12 @@ module.exports = {
     if (!context.parserServices.getDocumentFragment) {
       return {}
     }
+    const documentFragment = context.parserServices.getDocumentFragment()
+    if (!documentFragment) {
+      return {}
+    }
 
-    const componentBlocks = context.parserServices
-      .getDocumentFragment()
-      .children.filter(isVElement)
+    const componentBlocks = documentFragment.children.filter(isVElement)
 
     return {
       Program() {

--- a/lib/rules/padding-line-between-blocks.js
+++ b/lib/rules/padding-line-between-blocks.js
@@ -139,11 +139,15 @@ module.exports = {
     if (!context.parserServices.getDocumentFragment) {
       return {}
     }
+    const df = context.parserServices.getDocumentFragment()
+    if (!df) {
+      return {}
+    }
+    const documentFragment = df
+
     /** @type {'always' | 'never'} */
     const option = context.options[0] || 'always'
     const paddingType = PaddingTypes[option]
-
-    const documentFragment = context.parserServices.getDocumentFragment()
 
     /** @type {Token[]} */
     let tokens

--- a/tests/lib/rules-without-vue-sfc.js
+++ b/tests/lib/rules-without-vue-sfc.js
@@ -1,0 +1,31 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const Linter = require('eslint').Linter
+const parser = require('vue-eslint-parser')
+const rules = require('../..').rules
+
+describe("Don't crash even if without vue SFC.", () => {
+  const code = 'var a = 1'
+
+  for (const key of Object.keys(rules)) {
+    const ruleId = `vue/${key}`
+
+    it(ruleId, () => {
+      const linter = new Linter()
+      const config = {
+        parser: 'vue-eslint-parser',
+        parserOptions: { ecmaVersion: 2015 },
+        rules: {
+          [ruleId]: 'error'
+        }
+      }
+      linter.defineParser('vue-eslint-parser', parser)
+      linter.defineRule(ruleId, rules[key])
+      linter.verifyAndFix(code, config, 'test.js')
+    })
+  }
+})

--- a/tests/lib/rules/no-empty-component-block.js
+++ b/tests/lib/rules/no-empty-component-block.js
@@ -22,7 +22,8 @@ tester.run('no-empty-component-block', rule, {
     `<template src="./template.html"></template><script src="./script.js"></script>`,
     `<template src="./template.html" /><script src="./script.js" />`,
     `<template src="./template.html"></template><script src="./script.js"></script><style src="./style.css"></style>`,
-    `<template src="./template.html" /><script src="./script.js" /><style src="./style.css" />`
+    `<template src="./template.html" /><script src="./script.js" /><style src="./style.css" />`,
+    `var a = 1`
   ],
   invalid: [
     {

--- a/tests/lib/rules/padding-line-between-blocks.js
+++ b/tests/lib/rules/padding-line-between-blocks.js
@@ -83,7 +83,8 @@ tester.run('padding-line-between-blocks', rule, {
       <style></style>
       `,
       options: ['never']
-    }
+    },
+    `var a = 1`
   ],
   invalid: [
     {

--- a/typings/eslint-plugin-vue/util-types/parser-services.ts
+++ b/typings/eslint-plugin-vue/util-types/parser-services.ts
@@ -17,7 +17,7 @@ export interface ParserServices {
     templateBodyVisitor: TemplateListener,
     scriptVisitor?: eslint.Rule.RuleListener
   ) => eslint.Rule.RuleListener
-  getDocumentFragment?: () => VAST.VDocumentFragment
+  getDocumentFragment?: () => VAST.VDocumentFragment | null
 }
 export namespace ParserServices {
   export interface TokenStore {


### PR DESCRIPTION


Fixed #1230