### PR TITLE
Add `vue/no-sparse-arrays` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -338,6 +338,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/no-extra-parens](./no-extra-parens.md) | disallow unnecessary parentheses | :wrench: |
 | [vue/no-irregular-whitespace](./no-irregular-whitespace.md) | disallow irregular whitespace |  |
 | [vue/no-restricted-syntax](./no-restricted-syntax.md) | disallow specified syntax |  |
+| [vue/no-sparse-arrays](./no-sparse-arrays.md) | disallow sparse arrays |  |
 | [vue/no-useless-concat](./no-useless-concat.md) | disallow unnecessary concatenation of literals or template literals |  |
 | [vue/object-curly-newline](./object-curly-newline.md) | enforce consistent line breaks inside braces | :wrench: |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |

--- a/docs/rules/no-sparse-arrays.md
+++ b/docs/rules/no-sparse-arrays.md
@@ -1,0 +1,23 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-sparse-arrays
+description: disallow sparse arrays
+---
+# vue/no-sparse-arrays
+> disallow sparse arrays
+
+This rule is the same rule as core [no-sparse-arrays] rule but it applies to the expressions in `<template>`.
+
+## :books: Further reading
+
+- [no-sparse-arrays]
+
+[no-sparse-arrays]: https://eslint.org/docs/rules/no-sparse-arrays
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-sparse-arrays.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-sparse-arrays.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/no-sparse-arrays)</sup>

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,7 @@ module.exports = {
     'no-shared-component-data': require('./rules/no-shared-component-data'),
     'no-side-effects-in-computed-properties': require('./rules/no-side-effects-in-computed-properties'),
     'no-spaces-around-equal-signs-in-attribute': require('./rules/no-spaces-around-equal-signs-in-attribute'),
+    'no-sparse-arrays': require('./rules/no-sparse-arrays'),
     'no-static-inline-styles': require('./rules/no-static-inline-styles'),
     'no-template-key': require('./rules/no-template-key'),
     'no-template-shadow': require('./rules/no-template-shadow'),

--- a/lib/rules/no-sparse-arrays.js
+++ b/lib/rules/no-sparse-arrays.js
@@ -1,0 +1,9 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(require('eslint/lib/rules/no-sparse-arrays'))

--- a/tests/lib/rules/no-sparse-arrays.js
+++ b/tests/lib/rules/no-sparse-arrays.js
@@ -1,0 +1,55 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-sparse-arrays')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('no-sparse-arrays', rule, {
+  valid: [
+    `<template>
+      <div :class="['foo', 'bar']" />
+    </template>`,
+    `<template>
+      <div v-bind:[['foo'][0]]="bar" />
+    </template>`
+  ],
+  invalid: [
+    {
+      code: `
+      <template>
+        <div :class="[, 'foo', 'bar']" />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected comma in middle of array.',
+          line: 3,
+          column: 22,
+          endLine: 3,
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <div v-bind:[[,'foo'][1]]="bar" />
+      </template>`,
+      errors: [
+        {
+          message: 'Unexpected comma in middle of array.',
+          line: 3,
+          column: 22,
+          endLine: 3,
+          endColumn: 30
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds the wrapper rule of the [no-sparse-arrays](https://eslint.org/docs/rules/no-sparse-arrays) core rule to apply to the expressions in `<template>`.