### PR TITLE
New: Add `vue/no-mustache` rule

### DIFF
--- a/docs/rules/no-mustache.md
+++ b/docs/rules/no-mustache.md
@@ -1,0 +1,42 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-mustache
+description: disallow usage of mustache interpolations
+---
+# vue/no-mustache
+> disallow usage of mustache interpolations
+
+## :book: Rule Details
+
+This rule disallows the usage of mustache (`{{` and `}}`) interpolation.
+The benefit of this is to provide a consistent way to write out strings (using `v-{text,html}`) or if you are using another server-side template language that uses braces as well.
+
+<eslint-code-block fix :rules="{'vue/no-mustache': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <div v-text="text"></div>
+  <div v-html="text"></div>
+  <div v-bind:data-label="text"></div>
+  <div v-bind:data-label="'text'"></div>
+
+  <!-- ✗ BAD -->
+  <div>{{ text }}</div>
+  <div data-label="{{ text }}"></div>
+  <div data-label="{{ 'text' }}"></div>
+</template>
+```
+
+</eslint-code-block>
+
+## :couple: Related Rules
+
+- [vue/no-bare-strings-in-template](./no-bare-strings-in-template.md)
+- [vue/no-useless-mustaches](./no-useless-mustaches.md)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-mustache.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-mustache.js)

--- a/docs/rules/no-useless-mustaches.md
+++ b/docs/rules/no-useless-mustaches.md
@@ -11,7 +11,7 @@ description: disallow unnecessary mustache interpolations
 
 ## :book: Rule Details
 
-This rule reports mustache interpolation with a string literal value.  
+This rule reports mustache interpolation with a string literal value.
 The mustache interpolation with a string literal value can be changed to a static contents.
 
 <eslint-code-block fix :rules="{'vue/no-useless-mustaches': ['error']}">
@@ -78,9 +78,11 @@ The mustache interpolation with a string literal value can be changed to a stati
 
 - [vue/no-useless-v-bind]
 - [vue/no-useless-concat]
+- [vue/no-mustache]
 
 [vue/no-useless-v-bind]: ./no-useless-v-bind.md
 [vue/no-useless-concat]: ./no-useless-concat.md
+[vue/vue/no-mustache]: ./vue/no-mustache.md
 
 ## :mag: Implementation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,7 @@ module.exports = {
     'no-multiple-objects-in-class': require('./rules/no-multiple-objects-in-class'),
     'no-multiple-slot-args': require('./rules/no-multiple-slot-args'),
     'no-multiple-template-root': require('./rules/no-multiple-template-root'),
+    'no-mustache': require('./rules/no-mustache'),
     'no-mutating-props': require('./rules/no-mutating-props'),
     'no-parsing-error': require('./rules/no-parsing-error'),
     'no-potential-component-option-typo': require('./rules/no-potential-component-option-typo'),

--- a/lib/rules/no-mustache.js
+++ b/lib/rules/no-mustache.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview disallow usage of mustache interpolations.
+ * @author james2doyle
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const utils = require('../utils')
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'disallow usage of mustache interpolations',
+      categories: undefined,
+      url: 'https://eslint.vuejs.org/rules/no-mustache.html'
+    },
+    fixable: null,
+    schema: []
+  },
+  /** @param {RuleContext} context */
+  create(context) {
+    const template =
+      context.parserServices.getTemplateBodyTokenStore &&
+      context.parserServices.getTemplateBodyTokenStore()
+
+    // ----------------------------------------------------------------------
+    // Public
+    // ----------------------------------------------------------------------
+
+    return utils.defineTemplateBodyVisitor(context, {
+      /** @param {VLiteral} node */
+      VLiteral(node) {
+        const openBrace = template.getFirstToken(node)
+        const closeBrace = template.getLastToken(node)
+        const invalidBrace =
+          !openBrace ||
+          !closeBrace ||
+          openBrace.type !== 'HTMLLiteral' ||
+          closeBrace.type !== 'HTMLLiteral'
+
+        if (invalidBrace) {
+          return
+        }
+
+        context.report({
+          loc: {
+            start: node.loc.start,
+            end: node.loc.end
+          },
+          message:
+            'Expected attribute be a binding but found mustache template.'
+        })
+      },
+      /** @param {VExpressionContainer} node */
+      VExpressionContainer(node) {
+        const openBrace = template.getFirstToken(node)
+        const closeBrace = template.getLastToken(node)
+
+        const invalidBrace =
+          !openBrace ||
+          !closeBrace ||
+          openBrace.type !== 'VExpressionStart' ||
+          closeBrace.type !== 'VExpressionEnd'
+
+        if (invalidBrace) {
+          return
+        }
+
+        context.report({
+          loc: {
+            start: node.loc.start,
+            end: node.loc.end
+          },
+          message:
+            "Expected text content to be in 'v-text' or 'v-html' but found mustache template."
+        })
+      }
+    })
+  }
+}

--- a/tests/lib/rules/no-mustache.js
+++ b/tests/lib/rules/no-mustache.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview disallow usage of mustache interpolations.
+ * @author james2doyle
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-mustache')
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+ruleTester.run('no-mustache', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: '<template></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div v-text="text"></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div v-html="text"></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div :data-label="text"></div></template>'
+    }
+  ],
+
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: '<template><div>{{ text }}</div></template>',
+      output: '<template><div>{{ text }}</div></template>',
+      errors: [
+        "Expected text content to be in 'v-text' or 'v-html' but found mustache template."
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div data-label="{{ text }}"></div></template>',
+      output: '<template><div data-label="{{ text }}"></div></template>',
+      errors: ['Expected attribute be a binding but found mustache template.']
+    }
+  ]
+})


### PR DESCRIPTION
This rule disallows the usage of mustache interpolation.

There are a couple reasons to do this:

- you prefer directives (`v-{text,html,t}`)
- you want to make sure each piece of text is attached to a DOM node
- you already use a template language in your project that uses braces