### PR TITLE
Make rule vue/no-unregistered-components ignore recursive components

### DIFF
--- a/docs/rules/no-unregistered-components.md
+++ b/docs/rules/no-unregistered-components.md
@@ -78,7 +78,8 @@ are ignored by default.
 ```json
 {
   "vue/no-unregistered-components": ["error", {
-    "ignorePatterns": []
+    "ignorePatterns": [],
+    "ignoreRecursive": false
   }]
 }
 ```
@@ -125,6 +126,56 @@ are ignored by default.
     components: {
 
     },
+  }
+</script>
+```
+
+</eslint-code-block>
+
+- `ignoreRecursive` Suppresses all errors if component name matches its parent component name.
+
+```
+Beware: recursive components can cause infinite loops, so make sure you use it with a condition.
+```
+
+### `ignoreRecursive: true`
+
+Note that you have to declare explicitly the `name` property in your component to make the recursive component work. See https://vuejs.org/v2/guide/components-edge-cases.html#Recursive-Components
+
+<eslint-code-block :rules="{'vue/no-unregistered-components': ['error', { 'ignoreRecursive': true }]}">
+
+```vue
+<!-- ✓ GOOD -->
+<template>
+  <div>
+    <h2>Lorem ipsum</h2>
+    <CustomComponent />
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'CustomComponent'
+  }
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-unregistered-components': ['error', { 'ignoreRecursive': true }]}">
+
+```vue
+<!-- ✗ BAD -->
+<template>
+  <div>
+    <h2>Lorem ipsum</h2>
+    <CustomComponent />
+  </div>
+</template>
+
+<script>
+  export default {
+    // name is not declared
   }
 </script>
 ```

--- a/docs/rules/no-unregistered-components.md
+++ b/docs/rules/no-unregistered-components.md
@@ -78,8 +78,7 @@ are ignored by default.
 ```json
 {
   "vue/no-unregistered-components": ["error", {
-    "ignorePatterns": [],
-    "ignoreRecursive": false
+    "ignorePatterns": []
   }]
 }
 ```
@@ -126,56 +125,6 @@ are ignored by default.
     components: {
 
     },
-  }
-</script>
-```
-
-</eslint-code-block>
-
-- `ignoreRecursive` Suppresses all errors if component name matches its parent component name.
-
-```
-Beware: recursive components can cause infinite loops, so make sure you use it with a condition.
-```
-
-### `ignoreRecursive: true`
-
-Note that you have to declare explicitly the `name` property in your component to make the recursive component work. See https://vuejs.org/v2/guide/components-edge-cases.html#Recursive-Components
-
-<eslint-code-block :rules="{'vue/no-unregistered-components': ['error', { 'ignoreRecursive': true }]}">
-
-```vue
-<!-- ✓ GOOD -->
-<template>
-  <div>
-    <h2>Lorem ipsum</h2>
-    <CustomComponent />
-  </div>
-</template>
-
-<script>
-  export default {
-    name: 'CustomComponent'
-  }
-</script>
-```
-
-</eslint-code-block>
-
-<eslint-code-block :rules="{'vue/no-unregistered-components': ['error', { 'ignoreRecursive': true }]}">
-
-```vue
-<!-- ✗ BAD -->
-<template>
-  <div>
-    <h2>Lorem ipsum</h2>
-    <CustomComponent />
-  </div>
-</template>
-
-<script>
-  export default {
-    // name is not declared
   }
 </script>
 ```

--- a/lib/rules/no-unregistered-components.js
+++ b/lib/rules/no-unregistered-components.js
@@ -62,6 +62,9 @@ module.exports = {
         properties: {
           ignorePatterns: {
             type: 'array'
+          },
+          ignoreRecursive: {
+            type: 'boolean'
           }
         },
         additionalProperties: false
@@ -73,14 +76,33 @@ module.exports = {
     const options = context.options[0] || {}
     /** @type {string[]} */
     const ignorePatterns = options.ignorePatterns || []
+    /** @type {boolean} */
+    const ignoreRecursive = options.ignoreRecursive || false
     /** @type { { node: VElement | VDirective | VAttribute, name: string }[] } */
     const usedComponentNodes = []
     /** @type { { node: Property, name: string }[] } */
     const registeredComponents = []
+    /** @type {string} */
+    let componentName = ''
 
-    return utils.defineTemplateBodyVisitor(
-      context,
-      {
+    return utils.compositingVisitors(
+      utils.defineVueVisitor(context, {
+        /** @param {ObjectExpression} obj */
+        onVueObjectEnter(obj) {
+          const nameProperty = obj.properties.find(
+            /**
+             * @param {ESNode} p
+             * @returns {p is (Property & { key: Identifier & {name: 'name'}, value: ObjectExpression })}
+             */
+            (p) => p.key.name === 'name'
+          )
+
+          if (nameProperty) {
+            componentName = nameProperty.value.value
+          }
+        }
+      }),
+      utils.defineTemplateBodyVisitor(context, {
         /** @param {VElement} node */
         VElement(node) {
           if (
@@ -156,6 +178,11 @@ module.exports = {
               )
                 return false
 
+              // Check recursive components if they are ignored
+              if (ignoreRecursive) {
+                return kebabCaseName !== casing.kebabCase(componentName)
+              }
+
               // Component registered as `foo-bar` cannot be used as `FooBar`
               if (
                 casing.isPascalCase(name) &&
@@ -178,7 +205,7 @@ module.exports = {
               })
             )
         }
-      },
+      }),
       utils.executeOnVue(context, (obj) => {
         registeredComponents.push(...utils.getRegisteredComponents(obj))
       })

--- a/lib/rules/no-unregistered-components.js
+++ b/lib/rules/no-unregistered-components.js
@@ -62,9 +62,6 @@ module.exports = {
         properties: {
           ignorePatterns: {
             type: 'array'
-          },
-          ignoreRecursive: {
-            type: 'boolean'
           }
         },
         additionalProperties: false
@@ -76,17 +73,14 @@ module.exports = {
     const options = context.options[0] || {}
     /** @type {string[]} */
     const ignorePatterns = options.ignorePatterns || []
-    /** @type {boolean} */
-    const ignoreRecursive = options.ignoreRecursive || false
     /** @type { { node: VElement | VDirective | VAttribute, name: string }[] } */
     const usedComponentNodes = []
     /** @type { { node: Property, name: string }[] } */
     const registeredComponents = []
-    /** @type {string} */
-    let componentName = ''
 
-    return utils.compositingVisitors(
-      utils.defineTemplateBodyVisitor(context, {
+    return utils.defineTemplateBodyVisitor(
+      context,
+      {
         /** @param {VElement} node */
         VElement(node) {
           if (
@@ -184,22 +178,18 @@ module.exports = {
               })
             )
         }
-      }),
-      utils.defineVueVisitor(context, {
-        /** @param {ObjectExpression} obj */
-        onVueObjectEnter(obj) {
-          const nameProperty = utils.findProperty(obj, 'name')
-
-          if (nameProperty && ignoreRecursive) {
-            registeredComponents.push({
-              node: nameProperty,
-              name: nameProperty.value.value
-            })
-          }
-        }
-      }),
+      },
       utils.executeOnVue(context, (obj) => {
         registeredComponents.push(...utils.getRegisteredComponents(obj))
+
+        const nameProperty = utils.findProperty(obj, 'name')
+
+        if (nameProperty) {
+          registeredComponents.push({
+            node: nameProperty,
+            name: nameProperty.value.value
+          })
+        }
       })
     )
   }

--- a/lib/rules/no-unregistered-components.js
+++ b/lib/rules/no-unregistered-components.js
@@ -86,22 +86,6 @@ module.exports = {
     let componentName = ''
 
     return utils.compositingVisitors(
-      utils.defineVueVisitor(context, {
-        /** @param {ObjectExpression} obj */
-        onVueObjectEnter(obj) {
-          const nameProperty = obj.properties.find(
-            /**
-             * @param {ESNode} p
-             * @returns {p is (Property & { key: Identifier & {name: 'name'}, value: ObjectExpression })}
-             */
-            (p) => p.key.name === 'name'
-          )
-
-          if (nameProperty) {
-            componentName = nameProperty.value.value
-          }
-        }
-      }),
       utils.defineTemplateBodyVisitor(context, {
         /** @param {VElement} node */
         VElement(node) {
@@ -178,11 +162,6 @@ module.exports = {
               )
                 return false
 
-              // Check recursive components if they are ignored
-              if (ignoreRecursive) {
-                return kebabCaseName !== casing.kebabCase(componentName)
-              }
-
               // Component registered as `foo-bar` cannot be used as `FooBar`
               if (
                 casing.isPascalCase(name) &&
@@ -204,6 +183,19 @@ module.exports = {
                 }
               })
             )
+        }
+      }),
+      utils.defineVueVisitor(context, {
+        /** @param {ObjectExpression} obj */
+        onVueObjectEnter(obj) {
+          const nameProperty = utils.findProperty(obj, 'name')
+
+          if (nameProperty && ignoreRecursive) {
+            registeredComponents.push({
+              node: nameProperty,
+              name: nameProperty.value.value
+            })
+          }
         }
       }),
       utils.executeOnVue(context, (obj) => {

--- a/tests/lib/rules/no-unregistered-components.js
+++ b/tests/lib/rules/no-unregistered-components.js
@@ -393,6 +393,71 @@ tester.run('no-unregistered-components', rule, {
         }
         </script>
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <CustomComponent />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <custom-component />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <component :is="'CustomComponent'" />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <component is="CustomComponent" />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-is="'CustomComponent'" />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-unregistered-components.js
+++ b/tests/lib/rules/no-unregistered-components.js
@@ -405,12 +405,7 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `,
-      options: [
-        {
-          ignoreRecursive: true
-        }
-      ]
+      `
     },
     {
       filename: 'test.vue',
@@ -423,12 +418,7 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `,
-      options: [
-        {
-          ignoreRecursive: true
-        }
-      ]
+      `
     },
     {
       filename: 'test.vue',
@@ -441,12 +431,7 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `,
-      options: [
-        {
-          ignoreRecursive: true
-        }
-      ]
+      `
     },
     {
       filename: 'test.vue',
@@ -459,12 +444,7 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `,
-      options: [
-        {
-          ignoreRecursive: true
-        }
-      ]
+      `
     },
     {
       filename: 'test.vue',
@@ -477,12 +457,7 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `,
-      options: [
-        {
-          ignoreRecursive: true
-        }
-      ]
+      `
     }
   ],
   invalid: [
@@ -663,106 +638,6 @@ tester.run('no-unregistered-components', rule, {
           components: {
             'custom-component': InfoPrimaryWrapper
           }
-        }
-        </script>
-      `,
-      errors: [
-        {
-          message:
-            'The "CustomComponent" component has been used but not registered.',
-          line: 3
-        }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: `
-        <template>
-          <CustomComponent />
-        </template>
-        <script>
-        export default {
-          name: 'CustomComponent'
-        }
-        </script>
-      `,
-      errors: [
-        {
-          message:
-            'The "CustomComponent" component has been used but not registered.',
-          line: 3
-        }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: `
-        <template>
-          <custom-component />
-        </template>
-        <script>
-        export default {
-          name: 'CustomComponent'
-        }
-        </script>
-      `,
-      errors: [
-        {
-          message:
-            'The "custom-component" component has been used but not registered.',
-          line: 3
-        }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: `
-        <template>
-          <component :is="'CustomComponent'" />
-        </template>
-        <script>
-        export default {
-          name: 'CustomComponent'
-        }
-        </script>
-      `,
-      errors: [
-        {
-          message:
-            'The "CustomComponent" component has been used but not registered.',
-          line: 3
-        }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: `
-        <template>
-          <component is="CustomComponent" />
-        </template>
-        <script>
-        export default {
-          name: 'CustomComponent'
-        }
-        </script>
-      `,
-      errors: [
-        {
-          message:
-            'The "CustomComponent" component has been used but not registered.',
-          line: 3
-        }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: `
-        <template>
-          <div v-is="'CustomComponent'" />
-        </template>
-        <script>
-        export default {
-          name: 'CustomComponent'
         }
         </script>
       `,

--- a/tests/lib/rules/no-unregistered-components.js
+++ b/tests/lib/rules/no-unregistered-components.js
@@ -405,7 +405,12 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `
+      `,
+      options: [
+        {
+          ignoreRecursive: true
+        }
+      ]
     },
     {
       filename: 'test.vue',
@@ -418,7 +423,12 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `
+      `,
+      options: [
+        {
+          ignoreRecursive: true
+        }
+      ]
     },
     {
       filename: 'test.vue',
@@ -431,7 +441,12 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `
+      `,
+      options: [
+        {
+          ignoreRecursive: true
+        }
+      ]
     },
     {
       filename: 'test.vue',
@@ -444,7 +459,12 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `
+      `,
+      options: [
+        {
+          ignoreRecursive: true
+        }
+      ]
     },
     {
       filename: 'test.vue',
@@ -457,7 +477,12 @@ tester.run('no-unregistered-components', rule, {
           name: 'CustomComponent'
         }
         </script>
-      `
+      `,
+      options: [
+        {
+          ignoreRecursive: true
+        }
+      ]
     }
   ],
   invalid: [
@@ -638,6 +663,106 @@ tester.run('no-unregistered-components', rule, {
           components: {
             'custom-component': InfoPrimaryWrapper
           }
+        }
+        </script>
+      `,
+      errors: [
+        {
+          message:
+            'The "CustomComponent" component has been used but not registered.',
+          line: 3
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <CustomComponent />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `,
+      errors: [
+        {
+          message:
+            'The "CustomComponent" component has been used but not registered.',
+          line: 3
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <custom-component />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `,
+      errors: [
+        {
+          message:
+            'The "custom-component" component has been used but not registered.',
+          line: 3
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <component :is="'CustomComponent'" />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `,
+      errors: [
+        {
+          message:
+            'The "CustomComponent" component has been used but not registered.',
+          line: 3
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <component is="CustomComponent" />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
+        }
+        </script>
+      `,
+      errors: [
+        {
+          message:
+            'The "CustomComponent" component has been used but not registered.',
+          line: 3
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-is="'CustomComponent'" />
+        </template>
+        <script>
+        export default {
+          name: 'CustomComponent'
         }
         </script>
       `,


### PR DESCRIPTION
Right now when we use recursive components (when we want to use the current component inside of itself - with the example of a `Note` component that can have a number of replies, that look and behave exactly like the `Note` component, and they stack inside of one another), eslint-plugin-vue complains against it, making us disable this rule every time we want to use a recursive component. 

The suggestion is to include a new argument to the rule, `ignoreRecursive`, which, if `true`, checks whether the name of the parent component is the same as the child component (making it thus a recursive component), not warning about this rule on it.

Resolves #1304 