### PR TITLE
feat(attributes-order): add slot attribute

### DIFF
--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -36,6 +36,12 @@ This rule aims to enforce ordering of component attributes. The default order is
   e.g. '@click="functionCall"', 'v-on="event"'
 - `CONTENT`
   e.g. 'v-text', 'v-html'
+  
+Since 7.0.1:
+ 
+- `SLOT`
+  e.g. 'v-slot', 'slot' (separately from `UNIQUE`).
+  It will inherit `UNIQUE` position by default.
 
 ### the default order
 

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -19,7 +19,8 @@ const ATTRS = {
   OTHER_DIRECTIVES: 'OTHER_DIRECTIVES',
   OTHER_ATTR: 'OTHER_ATTR',
   EVENTS: 'EVENTS',
-  CONTENT: 'CONTENT'
+  CONTENT: 'CONTENT',
+  SLOT: 'SLOT'
 }
 
 /**
@@ -83,7 +84,7 @@ function getAttributeType(attribute, sourceCode) {
       } else if (name === 'html' || name === 'text') {
         return ATTRS.CONTENT
       } else if (name === 'slot') {
-        return ATTRS.UNIQUE
+        return ATTRS.SLOT
       } else if (name === 'is') {
         return ATTRS.DEFINITION
       } else {
@@ -100,13 +101,10 @@ function getAttributeType(attribute, sourceCode) {
     return ATTRS.DEFINITION
   } else if (propName === 'id') {
     return ATTRS.GLOBAL
-  } else if (
-    propName === 'ref' ||
-    propName === 'key' ||
-    propName === 'slot' ||
-    propName === 'slot-scope'
-  ) {
+  } else if (propName === 'ref' || propName === 'key') {
     return ATTRS.UNIQUE
+  } else if (propName === 'slot' || propName === 'slot-scope') {
+    return ATTRS.SLOT
   } else {
     return ATTRS.OTHER_ATTR
   }
@@ -185,6 +183,10 @@ function create(context) {
       })
     } else attributePosition[item] = i
   })
+
+  if (!(ATTRS.SLOT in attributePosition)) {
+    attributePosition[ATTRS.SLOT] = attributePosition[ATTRS.GLOBAL]
+  }
 
   /**
    * @typedef {object} State
@@ -271,7 +273,7 @@ module.exports = {
           items: {
             type: 'string'
           },
-          maxItems: 10,
+          maxItems: 11,
           minItems: 10
         }
       }

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -965,12 +965,14 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      code: '<template><div ref="foo" v-slot="{ qux }" bar="baz"></div></template>',
-      output: '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
+      code:
+        '<template><div ref="foo" v-slot="{ qux }" bar="baz"></div></template>',
+      output:
+        '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
       errors: [
         {
           message: 'Attribute "bar" should go before "v-slot".'
-        },
+        }
       ]
     },
 
@@ -994,13 +996,15 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      code: '<template><div bar="baz" ref="foo" v-slot="{ qux }"></div></template>',
-      output: '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
+      code:
+        '<template><div bar="baz" ref="foo" v-slot="{ qux }"></div></template>',
+      output:
+        '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
       errors: [
         {
           message: 'Attribute "ref" should go before "bar".'
-        },
+        }
       ]
-    },
+    }
   ]
 })

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -943,6 +943,64 @@ tester.run('attributes-order', rule, {
           message: 'Attribute "v-is" should go before "v-cloak".'
         }
       ]
-    }
+    },
+
+    {
+      filename: 'test.vue',
+      options: [
+        {
+          order: [
+            'UNIQUE',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT',
+            'DEFINITION',
+            'SLOT'
+          ]
+        }
+      ],
+      code: '<template><div ref="foo" v-slot="{ qux }" bar="baz"></div></template>',
+      output: '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
+      errors: [
+        {
+          message: 'Attribute "bar" should go before "v-slot".'
+        },
+      ]
+    },
+
+    {
+      filename: 'test.vue',
+      options: [
+        {
+          order: [
+            'UNIQUE',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'CONTENT',
+            'DEFINITION',
+            'SLOT'
+          ]
+        }
+      ],
+      code: '<template><div bar="baz" ref="foo" v-slot="{ qux }"></div></template>',
+      output: '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
+      errors: [
+        {
+          message: 'Attribute "ref" should go before "bar".'
+        },
+      ]
+    },
   ]
 })


### PR DESCRIPTION
First of all thanks for such a great eslint plugin for Vue! It helps my team a lot to have consistent code practices.
Secondly, I'd like to improve the tool a little bit because in our case it wasn't possible to migrate some of the codebase to support eslint without changing plugin's code.

## Motivation

There's a rule `attributes-order` that is included in the recommended ruleset which has predefined attributes set. This set is great, but in some cases might be a bit limiting. In particular, there's no separate treatment for `key`, `ref` vs `slot` and `v-slot` right now (they are mutually controlled by the `UNIQUE` option) and I would like to improve that.

The reason for controlling them separately is that `ref` and `key` respond to the outer interface of the component, so I would like to have these attributes as high as possible. On the other side, `slot` and `v-slot` respond to the inner interface of the component by controlling it's ancestors placement within the component and passing data down the render tree. I would like to have that attribute as low as possible so it's closer to the actual elements it's controlling.

Basic example of the attribute order I would like to have:

```html
<SlottedComponent
  ref="slottedComponent"
  :key="key"
  :data="data"
  v-slot="{ item }"
>
  <ItemComponent :item="item" />
</SlottedComponent>
```

With this change in place users will be able to place slots as close to the ancestors as possible without affecting `ref` and `key` order.

## Implementation

This **is not** a breaking change. Users who don't want to control slot attribute position won't have to do so, it will inherit `UNIQUE` position by default. However if you _do_ want to control it you can do it without breaking any existing rules.

I've covered this change with a few tests, also updated the docs (version number might need a change though).