### PR TITLE
Avoid redundant global self-require of the plugin

### DIFF
--- a/lib/rules/no-unregistered-components.js
+++ b/lib/rules/no-unregistered-components.js
@@ -8,8 +8,8 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const utils = require('eslint-plugin-vue/lib/utils')
-const casing = require('eslint-plugin-vue/lib/utils/casing')
+const utils = require('../utils')
+const casing = require('../utils/casing')
 
 // ------------------------------------------------------------------------------
 // Rule helpers

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint-plugin-eslint-plugin": "^2.2.1",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-vue": "file:.",
     "eslint4b": "^7.0.0",
     "lodash": "^4.17.15",
     "mocha": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-eslint-plugin": "^2.2.1",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-vue": "file:.",
     "eslint4b": "^7.0.0",
     "lodash": "^4.17.15",
     "mocha": "^7.1.2",


### PR DESCRIPTION
In some really specific cases when the project patches `require()` to alias some modules (e.g. to fix an issue with ESLint sharable configs) this plugin may crash. This happens because it requires itself globally using its name which is redundant. 

Other plugins that are testes on the same project have no such issue.

This PR converts such paths to relative paths.

