### PR TITLE
Add `vue/array-bracket-newline` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -325,6 +325,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
+| [vue/array-bracket-newline](./array-bracket-newline.md) | enforce linebreaks after opening and before closing array brackets | :wrench: |
 | [vue/array-bracket-spacing](./array-bracket-spacing.md) | enforce consistent spacing inside array brackets | :wrench: |
 | [vue/arrow-spacing](./arrow-spacing.md) | enforce consistent spacing before and after the arrow in arrow functions | :wrench: |
 | [vue/block-spacing](./block-spacing.md) | disallow or enforce spaces inside of blocks after opening block and before closing block | :wrench: |

--- a/docs/rules/array-bracket-newline.md
+++ b/docs/rules/array-bracket-newline.md
@@ -1,0 +1,25 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/array-bracket-newline
+description: enforce linebreaks after opening and before closing array brackets
+---
+# vue/array-bracket-newline
+> enforce linebreaks after opening and before closing array brackets
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [array-bracket-newline] rule but it applies to the expressions in `<template>`.
+
+## :books: Further Reading
+
+- [array-bracket-newline]
+
+[array-bracket-newline]: https://eslint.org/docs/rules/array-bracket-newline
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/array-bracket-newline.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/array-bracket-newline.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/array-bracket-newline)</sup>

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -5,6 +5,7 @@
  */
 module.exports = {
   rules: {
+    'vue/array-bracket-newline': 'off',
     'vue/array-bracket-spacing': 'off',
     'vue/arrow-spacing': 'off',
     'vue/block-spacing': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@
 
 module.exports = {
   rules: {
+    'array-bracket-newline': require('./rules/array-bracket-newline'),
     'array-bracket-spacing': require('./rules/array-bracket-spacing'),
     'arrow-spacing': require('./rules/arrow-spacing'),
     'attribute-hyphenation': require('./rules/attribute-hyphenation'),

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -1,0 +1,12 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule(
+  require('eslint/lib/rules/array-bracket-newline'),
+  { skipDynamicArguments: true }
+)

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -6,7 +6,6 @@
 const { wrapCoreRule } = require('../utils')
 
 // eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
-module.exports = wrapCoreRule(
-  require('eslint/lib/rules/array-bracket-newline'),
-  { skipDynamicArguments: true }
-)
+module.exports = wrapCoreRule('array-bracket-newline', {
+  skipDynamicArguments: true
+})

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -1,0 +1,108 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/array-bracket-newline')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('array-bracket-newline', rule, {
+  valid: [
+    '<template><div :attr="[a]" /></template>',
+    '<template><div :attr="[\na,\nb,\nc\n]" /></template>',
+    {
+      code: '<template><div :attr="[a]" /></template>',
+      options: ['never']
+    },
+    {
+      code: '<template><div :attr="[\na\n]" /></template>',
+      options: ['always']
+    },
+    '<template><div :[attr]="a" /></template>',
+    {
+      code: '<template><div :[attr]="a" /></template>',
+      options: ['always']
+    },
+    '<template><div :[[attr]]="a" /></template>',
+    {
+      code: '<template><div :[[attr]]="a" /></template>',
+      options: ['always']
+    }
+  ],
+  invalid: [
+    {
+      code: '<template><div :attr="[\na]" /></template>',
+      output: '<template><div :attr="[a]" /></template>',
+      errors: ["There should be no linebreak after '['."]
+    },
+    {
+      code: '<template><div :attr="[a\n]" /></template>',
+      output: '<template><div :attr="[a]" /></template>',
+      errors: ["There should be no linebreak before ']'."]
+    },
+    {
+      code: '<template><div :attr="[\na\n]" /></template>',
+      output: '<template><div :attr="[a]" /></template>',
+      errors: [
+        "There should be no linebreak after '['.",
+        "There should be no linebreak before ']'."
+      ]
+    },
+    {
+      code: '<template><div :attr="[\na]" /></template>',
+      options: ['never'],
+      output: '<template><div :attr="[a]" /></template>',
+      errors: ["There should be no linebreak after '['."]
+    },
+    {
+      code: '<template><div :attr="[a\n]" /></template>',
+      options: ['never'],
+      output: '<template><div :attr="[a]" /></template>',
+      errors: ["There should be no linebreak before ']'."]
+    },
+    {
+      code: '<template><div :attr="[\na\n]" /></template>',
+      options: ['never'],
+      output: '<template><div :attr="[a]" /></template>',
+      errors: [
+        "There should be no linebreak after '['.",
+        "There should be no linebreak before ']'."
+      ]
+    },
+    {
+      code: '<template><div :attr="[\na]" /></template>',
+      options: ['always'],
+      output: '<template><div :attr="[\na\n]" /></template>',
+      errors: ["A linebreak is required before ']'."]
+    },
+    {
+      code: '<template><div :attr="[a\n]" /></template>',
+      options: ['always'],
+      output: '<template><div :attr="[\na\n]" /></template>',
+      errors: ["A linebreak is required after '['."]
+    },
+    {
+      code: '<template><div :attr="[a]" /></template>',
+      options: ['always'],
+      output: '<template><div :attr="[\na\n]" /></template>',
+      errors: [
+        "A linebreak is required after '['.",
+        "A linebreak is required before ']'."
+      ]
+    },
+    {
+      code: '<template><div :[[attr]]="[a]" /></template>',
+      options: ['always'],
+      output: '<template><div :[[attr]]="[\na\n]" /></template>',
+      errors: [
+        "A linebreak is required after '['.",
+        "A linebreak is required before ']'."
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
`vue/array-bracket-newline` rule that applies `array-bracket-newline` rule to expressions in <template>.