### PR TITLE
Add vue/block-tag-newline rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -281,13 +281,14 @@ For example:
 ```json
 {
   "rules": {
-    "vue/component-name-in-template-casing": "error"
+    "vue/block-tag-newline": "error"
   }
 }
 ```
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
+| [vue/block-tag-newline](./block-tag-newline.md) | enforce line breaks after opening and before closing block-level tags | :wrench: |
 | [vue/component-name-in-template-casing](./component-name-in-template-casing.md) | enforce specific casing for the component naming style in template | :wrench: |
 | [vue/html-comment-content-newline](./html-comment-content-newline.md) | enforce unified line brake in HTML comments | :wrench: |
 | [vue/html-comment-content-spacing](./html-comment-content-spacing.md) | enforce unified spacing in HTML comments | :wrench: |

--- a/docs/rules/block-tag-newline.md
+++ b/docs/rules/block-tag-newline.md
@@ -1,0 +1,161 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/block-tag-newline
+description: enforce line breaks after opening and before closing block-level tags
+---
+# vue/block-tag-newline
+> enforce line breaks after opening and before closing block-level tags
+
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule enforces a line break (or no line break) after opening and before closing block tags.
+
+<eslint-code-block fix :rules="{'vue/block-tag-newline': ['error']}">
+
+```vue
+<!-- ✓ GOOD -->
+<template><input></template>
+
+<script>
+export default {}
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block fix :rules="{'vue/block-tag-newline': ['error']}">
+
+```vue
+<!-- ✗ BAD -->
+<template>
+<input></template>
+
+<script>
+export default {}</script>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+```json
+{
+  "vue/block-tag-newline": ["error", {
+    "singleline": "always" | "never" | "consistent" | "ignore",
+    "multiline": "always" | "never" | "consistent" | "ignore",
+    "maxEmptyLines": 0,
+    "blocks": {
+      "template": {
+        "singleline": "always" | "never" | "consistent" | "ignore",
+        "multiline": "always" | "never" | "consistent" | "ignore",
+        "maxEmptyLines": 0,
+      },
+      "script": {
+        "singleline": "always" | "never" | "consistent" | "ignore",
+        "multiline": "always" | "never" | "consistent" | "ignore",
+        "maxEmptyLines": 0,
+      },
+      "my-block": {
+        "singleline": "always" | "never" | "consistent" | "ignore",
+        "multiline": "always" | "never" | "consistent" | "ignore",
+        "maxEmptyLines": 0,
+      }
+    }
+  }]
+}
+```
+
+- `singleline` ... the configuration for single-line blocks.
+  - `"consistent"` ... (default) requires consistent usage of line breaks for each pair of tags. It reports an error if one tag in the pair has a linebreak inside it and the other tag does not.
+  - `"always"` ... require one line break after opening and before closing block tags.
+  - `"never"` ... disallow line breaks after opening and before closing block tags.
+- `multiline` ... the configuration for multi-line blocks.
+  - `"consistent"` ... requires consistent usage of line breaks for each pair of tags. It reports an error if one tag in the pair has a linebreak inside it and the other tag does not.
+  - `"always"` ... (default) require one line break after opening and before closing block tags.
+  - `"never"` ... disallow line breaks after opening and before closing block tags.
+- `maxEmptyLines` ... specifies the maximum number of empty lines allowed. default 0.
+- `blocks` ... specifies for each block name.
+
+### `{ "singleline": "never", "multiline": "always" }`
+
+<eslint-code-block fix :rules="{'vue/block-tag-newline': ['error', { 'singleline': 'never', 'multiline': 'always' }]}">
+
+```vue
+<!-- ✓ GOOD -->
+<template><input></template>
+
+<script>
+export default {
+}
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block fix :rules="{'vue/block-tag-newline': ['error', { 'singleline': 'never', 'multiline': 'always' }]}">
+
+```vue
+<!-- ✗ BAD -->
+<template>
+<input>
+</template>
+
+<script>export default {
+}</script>
+```
+
+</eslint-code-block>
+
+### `{ "singleline": "always", "multiline": "always", "maxEmptyLines": 1 }`
+
+<eslint-code-block fix :rules="{'vue/block-tag-newline': ['error', { 'singleline': 'always', 'multiline': 'always', 'maxEmptyLines': 1 }]}">
+
+```vue
+<!-- ✓ GOOD -->
+<template>
+
+<input>
+
+</template>
+
+<script>
+
+export default {
+}
+
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block fix :rules="{'vue/block-tag-newline': ['error', { 'singleline': 'always', 'multiline': 'always', 'maxEmptyLines': 1 }]}">
+
+```vue
+<!-- ✗ BAD -->
+<template>
+
+
+<input>
+
+
+</template>
+
+<script>
+
+
+export default {
+}
+
+
+</script>
+```
+
+</eslint-code-block>
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/block-tag-newline.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/block-tag-newline.js)

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -8,6 +8,7 @@ module.exports = {
     'vue/array-bracket-spacing': 'off',
     'vue/arrow-spacing': 'off',
     'vue/block-spacing': 'off',
+    'vue/block-tag-newline': 'off',
     'vue/brace-style': 'off',
     'vue/comma-dangle': 'off',
     'vue/comma-spacing': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'attribute-hyphenation': require('./rules/attribute-hyphenation'),
     'attributes-order': require('./rules/attributes-order'),
     'block-spacing': require('./rules/block-spacing'),
+    'block-tag-newline': require('./rules/block-tag-newline'),
     'brace-style': require('./rules/brace-style'),
     camelcase: require('./rules/camelcase'),
     'comma-dangle': require('./rules/comma-dangle'),

--- a/lib/rules/block-tag-newline.js
+++ b/lib/rules/block-tag-newline.js
@@ -1,0 +1,375 @@
+/**
+ * @fileoverview Enforce line breaks style after opening and before closing block-level tags.
+ * @author Yosuke Ota
+ */
+'use strict'
+const utils = require('../utils')
+
+/**
+ * @typedef { 'always' | 'never' | 'consistent' | 'ignore' } OptionType
+ * @typedef { { singleline?: OptionType, multiline?: OptionType, maxEmptyLines?: number } } ContentsOptions
+ * @typedef { ContentsOptions & { blocks?: { [element: string]: ContentsOptions } } } Options
+ * @typedef { Required<ContentsOptions> } ArgsOptions
+ */
+
+/**
+ * @param {string} text Source code as a string.
+ * @returns {number}
+ */
+function getLinebreakCount(text) {
+  return text.split(/\r\n|[\r\n\u2028\u2029]/gu).length - 1
+}
+
+/**
+ * @param {number} lineBreaks
+ */
+function getPhrase(lineBreaks) {
+  switch (lineBreaks) {
+    case 1:
+      return '1 line break'
+    default:
+      return `${lineBreaks} line breaks`
+  }
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+const ENUM_OPTIONS = { enum: ['always', 'never', 'consistent', 'ignore'] }
+module.exports = {
+  meta: {
+    type: 'layout',
+    docs: {
+      description:
+        'enforce line breaks after opening and before closing block-level tags',
+      categories: undefined,
+      url: 'https://eslint.vuejs.org/rules/block-tag-newline.html'
+    },
+    fixable: 'whitespace',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          singleline: ENUM_OPTIONS,
+          multiline: ENUM_OPTIONS,
+          maxEmptyLines: { type: 'number', minimum: 0 },
+          blocks: {
+            type: 'object',
+            patternProperties: {
+              '^(?:\\S+)$': {
+                type: 'object',
+                properties: {
+                  singleline: ENUM_OPTIONS,
+                  multiline: ENUM_OPTIONS,
+                  maxEmptyLines: { type: 'number', minimum: 0 }
+                },
+                additionalProperties: false
+              }
+            },
+            additionalProperties: false
+          }
+        },
+        additionalProperties: false
+      }
+    ],
+    messages: {
+      unexpectedOpeningLinebreak:
+        "There should be no line break after '<{{tag}}>'.",
+      unexpectedClosingLinebreak:
+        "There should be no line break before '</{{tag}}>'.",
+      expectedOpeningLinebreak:
+        "Expected {{expected}} after '<{{tag}}>', but {{actual}} found.",
+      expectedClosingLinebreak:
+        "Expected {{expected}}  before '</{{tag}}>', but {{actual}} found.",
+      missingOpeningLinebreak: "A line break is required after '<{{tag}}>'.",
+      missingClosingLinebreak: "A line break is required before '</{{tag}}>'."
+    }
+  },
+  /** @param {RuleContext} context */
+  create(context) {
+    const df =
+      context.parserServices.getDocumentFragment &&
+      context.parserServices.getDocumentFragment()
+    if (!df) {
+      return {}
+    }
+
+    const sourceCode = context.getSourceCode()
+
+    /**
+     * @param {VStartTag} startTag
+     * @param {string} beforeText
+     * @param {number} beforeLinebreakCount
+     * @param {'always' | 'never'} beforeOption
+     * @param {number} maxEmptyLines
+     * @returns {void}
+     */
+    function verifyBeforeSpaces(
+      startTag,
+      beforeText,
+      beforeLinebreakCount,
+      beforeOption,
+      maxEmptyLines
+    ) {
+      if (beforeOption === 'always') {
+        if (beforeLinebreakCount === 0) {
+          context.report({
+            loc: {
+              start: startTag.loc.end,
+              end: startTag.loc.end
+            },
+            messageId: 'missingOpeningLinebreak',
+            data: { tag: startTag.parent.name },
+            fix(fixer) {
+              return fixer.insertTextAfter(startTag, '\n')
+            }
+          })
+        } else if (maxEmptyLines < beforeLinebreakCount - 1) {
+          context.report({
+            loc: {
+              start: startTag.loc.end,
+              end: sourceCode.getLocFromIndex(
+                startTag.range[1] + beforeText.length
+              )
+            },
+            messageId: 'expectedOpeningLinebreak',
+            data: {
+              tag: startTag.parent.name,
+              expected: getPhrase(maxEmptyLines + 1),
+              actual: getPhrase(beforeLinebreakCount)
+            },
+            fix(fixer) {
+              return fixer.replaceTextRange(
+                [startTag.range[1], startTag.range[1] + beforeText.length],
+                '\n'.repeat(maxEmptyLines + 1)
+              )
+            }
+          })
+        }
+      } else {
+        if (beforeLinebreakCount > 0) {
+          context.report({
+            loc: {
+              start: startTag.loc.end,
+              end: sourceCode.getLocFromIndex(
+                startTag.range[1] + beforeText.length
+              )
+            },
+            messageId: 'unexpectedOpeningLinebreak',
+            data: { tag: startTag.parent.name },
+            fix(fixer) {
+              return fixer.removeRange([
+                startTag.range[1],
+                startTag.range[1] + beforeText.length
+              ])
+            }
+          })
+        }
+      }
+    }
+    /**
+     * @param {VEndTag} endTag
+     * @param {string} afterText
+     * @param {number} afterLinebreakCount
+     * @param {'always' | 'never'} afterOption
+     * @param {number} maxEmptyLines
+     * @returns {void}
+     */
+    function verifyAfterSpaces(
+      endTag,
+      afterText,
+      afterLinebreakCount,
+      afterOption,
+      maxEmptyLines
+    ) {
+      if (afterOption === 'always') {
+        if (afterLinebreakCount === 0) {
+          context.report({
+            loc: {
+              start: endTag.loc.start,
+              end: endTag.loc.start
+            },
+            messageId: 'missingClosingLinebreak',
+            data: { tag: endTag.parent.name },
+            fix(fixer) {
+              return fixer.insertTextBefore(endTag, '\n')
+            }
+          })
+        } else if (maxEmptyLines < afterLinebreakCount - 1) {
+          context.report({
+            loc: {
+              start: sourceCode.getLocFromIndex(
+                endTag.range[0] - afterText.length
+              ),
+              end: endTag.loc.start
+            },
+            messageId: 'expectedClosingLinebreak',
+            data: {
+              tag: endTag.parent.name,
+              expected: getPhrase(maxEmptyLines + 1),
+              actual: getPhrase(afterLinebreakCount)
+            },
+            fix(fixer) {
+              return fixer.replaceTextRange(
+                [endTag.range[0] - afterText.length, endTag.range[0]],
+                '\n'.repeat(maxEmptyLines + 1)
+              )
+            }
+          })
+        }
+      } else {
+        if (afterLinebreakCount > 0) {
+          context.report({
+            loc: {
+              start: sourceCode.getLocFromIndex(
+                endTag.range[0] - afterText.length
+              ),
+              end: endTag.loc.start
+            },
+            messageId: 'unexpectedOpeningLinebreak',
+            data: { tag: endTag.parent.name },
+            fix(fixer) {
+              return fixer.removeRange([
+                endTag.range[0] - afterText.length,
+                endTag.range[0]
+              ])
+            }
+          })
+        }
+      }
+    }
+    /**
+     * @param {VElement} element
+     * @param {ArgsOptions} options
+     * @returns {void}
+     */
+    function verifyElement(element, options) {
+      const { startTag, endTag } = element
+      if (startTag.selfClosing || endTag == null) {
+        return
+      }
+      const text = sourceCode.text.slice(startTag.range[1], endTag.range[0])
+
+      const trimText = text.trim()
+      if (!trimText) {
+        return
+      }
+
+      const option =
+        options.multiline === options.singleline
+          ? options.singleline
+          : /[\n\r\u2028\u2029]/u.test(text.trim())
+          ? options.multiline
+          : options.singleline
+      if (option === 'ignore') {
+        return
+      }
+      const beforeText = /** @type {RegExpExecArray} */ (/^\s*/u.exec(text))[0]
+      const afterText = /** @type {RegExpExecArray} */ (/\s*$/u.exec(text))[0]
+      const beforeLinebreakCount = getLinebreakCount(beforeText)
+      const afterLinebreakCount = getLinebreakCount(afterText)
+
+      /** @type {'always' | 'never'} */
+      let beforeOption
+      /** @type {'always' | 'never'} */
+      let afterOption
+      if (option === 'always' || option === 'never') {
+        beforeOption = option
+        afterOption = option
+      } else {
+        // consistent
+        if (beforeLinebreakCount > 0 === afterLinebreakCount > 0) {
+          return
+        }
+        beforeOption = 'always'
+        afterOption = 'always'
+      }
+
+      verifyBeforeSpaces(
+        startTag,
+        beforeText,
+        beforeLinebreakCount,
+        beforeOption,
+        options.maxEmptyLines
+      )
+
+      verifyAfterSpaces(
+        endTag,
+        afterText,
+        afterLinebreakCount,
+        afterOption,
+        options.maxEmptyLines
+      )
+    }
+
+    /**
+     * Normalizes a given option value.
+     * @param { Options | undefined } option An option value to parse.
+     * @returns { (element: VElement) => void } Verify function.
+     */
+    function normalizeOptionValue(option) {
+      if (!option) {
+        return normalizeOptionValue({})
+      }
+
+      /** @type {ContentsOptions} */
+      const contentsOptions = option
+      /** @type {ArgsOptions} */
+      const options = {
+        singleline: contentsOptions.singleline || 'consistent',
+        multiline: contentsOptions.multiline || 'always',
+        maxEmptyLines: contentsOptions.maxEmptyLines || 0
+      }
+      const { blocks } = option
+      if (!blocks) {
+        return (element) => verifyElement(element, options)
+      }
+
+      return (element) => {
+        const { name } = element
+        const elementsOptions = blocks[name]
+        if (!elementsOptions) {
+          verifyElement(element, options)
+        } else {
+          normalizeOptionValue({
+            singleline: elementsOptions.singleline || options.singleline,
+            multiline: elementsOptions.multiline || options.multiline,
+            maxEmptyLines:
+              elementsOptions.maxEmptyLines != null
+                ? elementsOptions.maxEmptyLines
+                : options.maxEmptyLines
+          })(element)
+        }
+      }
+    }
+
+    const documentFragment = df
+
+    const verify = normalizeOptionValue(context.options[0])
+
+    /**
+     * @returns {VElement[]}
+     */
+    function getTopLevelHTMLElements() {
+      return documentFragment.children.filter(utils.isVElement)
+    }
+
+    return utils.defineTemplateBodyVisitor(
+      context,
+      {},
+      {
+        /** @param {Program} node */
+        Program(node) {
+          if (utils.hasInvalidEOF(node)) {
+            return
+          }
+
+          for (const element of getTopLevelHTMLElements()) {
+            verify(element)
+          }
+        }
+      }
+    )
+  }
+}

--- a/tests/lib/rules/block-tag-newline.js
+++ b/tests/lib/rules/block-tag-newline.js
@@ -1,0 +1,247 @@
+/**
+ * @author Yosuke Ota
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/block-tag-newline')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('block-tag-newline', rule, {
+  valid: [
+    '<template><input></template>\n<script>let a</script>',
+    '<template>\n<input>\n</template>\n<script>\nlet a\n</script>',
+    '<template>\n<div>\n</div>\n</template>\n<script>\nlet a\nlet b\n</script>',
+    '<template></template>\n<script></script>',
+    '<template>\n\n</template>\n<script>\n\n</script>',
+    '<template />\n<script />',
+    {
+      code: '<template><div>\n</div></template>\n<script>let a</script>',
+      options: [{ singleline: 'never', multiline: 'never' }]
+    },
+    {
+      code:
+        '<template>\n<input>\n</template>\n<script>\nlet a\nlet b\n</script>',
+      options: [{ singleline: 'always', multiline: 'always' }]
+    },
+    {
+      code:
+        '<template>\n\n<input>\n\n</template>\n<script>\n\nlet a\nlet b\n\n</script>',
+      options: [{ singleline: 'always', multiline: 'always', maxEmptyLines: 1 }]
+    },
+    {
+      code: '<template>\n<input></template>\n<script>let a\nlet b\n</script>',
+      options: [{ singleline: 'ignore', multiline: 'ignore' }]
+    },
+    {
+      code: '<template><input></template>\n<script>\nlet a\n</script>',
+      options: [{ multiline: 'never' }]
+    },
+    {
+      code:
+        '<template>\n<div>\n</div>\n</template>\n<script>\nlet a\nlet b\n</script>',
+      options: [{ singleline: 'never' }]
+    },
+    // invalid
+    '<template><div a="></div>\n</template>\n<script>\nlet a</script>'
+  ],
+  invalid: [
+    {
+      code: '<template><input>\n</template>\n<script>let a\n</script>',
+      output: '<template>\n<input>\n</template>\n<script>\nlet a\n</script>',
+      errors: [
+        {
+          message: "A line break is required after '<template>'.",
+          line: 1,
+          column: 11
+        },
+        {
+          message: "A line break is required after '<script>'.",
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: '<template>\n<input></template>\n<script>\nlet a</script>',
+      output: '<template>\n<input>\n</template>\n<script>\nlet a\n</script>',
+      errors: [
+        {
+          message: "A line break is required before '</template>'.",
+          line: 2,
+          column: 8
+        },
+        {
+          message: "A line break is required before '</script>'.",
+          line: 4,
+          column: 6
+        }
+      ]
+    },
+    {
+      code: '<template><div>\n</div></template>\n<script>let a\nlet b</script>',
+      output:
+        '<template>\n<div>\n</div>\n</template>\n<script>\nlet a\nlet b\n</script>',
+      errors: [
+        {
+          message: "A line break is required after '<template>'.",
+          line: 1,
+          column: 11
+        },
+        {
+          message: "A line break is required before '</template>'.",
+          line: 2,
+          column: 7
+        },
+        {
+          message: "A line break is required after '<script>'.",
+          line: 3,
+          column: 9
+        },
+        {
+          message: "A line break is required before '</script>'.",
+          line: 4,
+          column: 6
+        }
+      ]
+    },
+    {
+      code:
+        '<template>\n<div>\n</div>\n</template>\n<script>\nlet a\n</script>',
+      output: '<template><div>\n</div></template>\n<script>let a</script>',
+      options: [{ singleline: 'never', multiline: 'never' }],
+      errors: [
+        {
+          message: "There should be no line break after '<template>'.",
+          line: 1,
+          column: 11
+        },
+        {
+          message: "There should be no line break after '<template>'.",
+          line: 3,
+          column: 7
+        },
+        {
+          message: "There should be no line break after '<script>'.",
+          line: 5,
+          column: 9
+        },
+        {
+          message: "There should be no line break after '<script>'.",
+          line: 6,
+          column: 6
+        }
+      ]
+    },
+    {
+      code: '<template><div>\n</div></template>\n<script>let a</script>',
+      output:
+        '<template>\n<div>\n</div>\n</template>\n<script>\nlet a\n</script>',
+      options: [{ singleline: 'always', multiline: 'always' }],
+      errors: [
+        {
+          message: "A line break is required after '<template>'.",
+          line: 1,
+          column: 11
+        },
+        {
+          message: "A line break is required before '</template>'.",
+          line: 2,
+          column: 7
+        },
+        {
+          message: "A line break is required after '<script>'.",
+          line: 3,
+          column: 9
+        },
+        {
+          message: "A line break is required before '</script>'.",
+          line: 3,
+          column: 14
+        }
+      ]
+    },
+    {
+      code:
+        '<template>\n\n<input>\n\n</template>\n<script>\n\nlet a\nlet b\n\n</script>',
+      output:
+        '<template>\n<input>\n</template>\n<script>\nlet a\nlet b\n</script>',
+      options: [{ singleline: 'always', multiline: 'always' }],
+      errors: [
+        {
+          message:
+            "Expected 1 line break after '<template>', but 2 line breaks found.",
+          line: 1,
+          column: 11
+        },
+        {
+          message:
+            "Expected 1 line break  before '</template>', but 2 line breaks found.",
+          line: 3,
+          column: 8
+        },
+        {
+          message:
+            "Expected 1 line break after '<script>', but 2 line breaks found.",
+          line: 6,
+          column: 9
+        },
+        {
+          message:
+            "Expected 1 line break  before '</script>', but 2 line breaks found.",
+          line: 9,
+          column: 6
+        }
+      ]
+    },
+    {
+      code:
+        '<template>\n\n\n<input>\n\n</template>\n<script>\n\nlet a\nlet b\n\n\n</script>',
+      output:
+        '<template>\n\n<input>\n\n</template>\n<script>\n\nlet a\nlet b\n\n</script>',
+      options: [
+        { singleline: 'always', multiline: 'always', maxEmptyLines: 1 }
+      ],
+      errors: [
+        {
+          message:
+            "Expected 2 line breaks after '<template>', but 3 line breaks found.",
+          line: 1,
+          column: 11
+        },
+        {
+          message:
+            "Expected 2 line breaks  before '</script>', but 3 line breaks found.",
+          line: 10,
+          column: 6
+        }
+      ]
+    },
+    {
+      code:
+        '<template><input>\n\n</template>\n<script>let a\nlet b\n\n\n</script><docs>\n#</docs>',
+      output:
+        '<template><input>\n\n</template>\n<script>let a\nlet b</script><docs>\n#\n</docs>',
+      options: [
+        {
+          blocks: {
+            template: {
+              singleline: 'ignore'
+            },
+            script: {
+              multiline: 'never'
+            }
+          }
+        }
+      ],
+      errors: [
+        "There should be no line break after '<script>'.",
+        "A line break is required before '</docs>'."
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds `vue/block-tag-newline` rule.

`vue/block-tag-newline` rule that enforces a line break (or no line break) after opening and before closing block tags.

close #1325