### PR TITLE
Fix multiple reporting of same warnings in `vue/no-unregistered-component`

### DIFF
--- a/lib/rules/no-unregistered-components.js
+++ b/lib/rules/no-unregistered-components.js
@@ -126,7 +126,7 @@ module.exports = {
           usedComponentNodes.push({ node, name: node.value.value })
         },
         /** @param {VElement} node */
-        "VElement[name='template']:exit"() {
+        "VElement[name='template'][parent.type='VDocumentFragment']:exit"() {
           // All registered components, transformed to kebab-case
           const registeredComponentNames = registeredComponents.map(
             ({ name }) => casing.kebabCase(name)

--- a/tests/lib/rules/no-unregistered-components.js
+++ b/tests/lib/rules/no-unregistered-components.js
@@ -458,7 +458,26 @@ tester.run('no-unregistered-components', rule, {
         }
         </script>
       `
-    }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <CustomComponentWithNamedSlots>
+            <template #slotA>
+              <div>Text</div>
+            </template>
+          </CustomComponentWithNamedSlots>
+        </template>
+        <script>
+        export default {
+          components: {
+            CustomComponentWithNamedSlots
+          }
+        }
+        </script>
+      `
+    },
   ],
   invalid: [
     {
@@ -668,6 +687,25 @@ tester.run('no-unregistered-components', rule, {
           line: 3
         }
       ]
-    }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <CustomComponentWithNamedSlots>
+            <template #slotA>
+              <div>Text</div>
+            </template>
+          </CustomComponentWithNamedSlots>
+        </template>
+      `,
+      errors: [
+        {
+          message:
+            'The "CustomComponentWithNamedSlots" component has been used but not registered.',
+          line: 3
+        }
+      ]
+    },
   ]
 })

--- a/tests/lib/rules/no-unregistered-components.js
+++ b/tests/lib/rules/no-unregistered-components.js
@@ -477,7 +477,7 @@ tester.run('no-unregistered-components', rule, {
         }
         </script>
       `
-    },
+    }
   ],
   invalid: [
     {
@@ -706,6 +706,6 @@ tester.run('no-unregistered-components', rule, {
           line: 3
         }
       ]
-    },
+    }
   ]
 })


### PR DESCRIPTION
Hi 👋 First, thank you for your work on this project 🙏 
It is my first open-source PR, I hope it is the right way to do. 

# Issue

In components' templates using multiple `<template>` to target named `slot`s, I noticed the `vue/no-unregistered-component` linter warnings were repeated as many times as there are `<template>`s, for the same unregistered components.
It is not very convenient, especially for large projects ongoing refactoring. 

# Example

```
<template>
  <TableView>

    <template #name>
      {{ tableViewName }}
    </template>

    <template #footer>
      <TableViewFooter>

        <template #action>
          <CustomButton />
        </template>

      </TableViewFooter>
    </template>

  </TableView>
</template>
```

<details><summary>
Would display these errors:
</summary>

```
warning: The "TableView" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:2:3:
  1 | <template>
> 2 |   <TableView>
    |   ^
  3 |     <template #name>
  4 |       {{ tableViewName }}
  5 |     </template>


warning: The "TableView" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:2:3:
  1 | <template>
> 2 |   <TableView>
    |   ^
  3 |     <template #name>
  4 |       {{ tableViewName }}
  5 |     </template>


warning: The "TableView" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:2:3:
  1 | <template>
> 2 |   <TableView>
    |   ^
  3 |     <template #name>
  4 |       {{ tableViewName }}
  5 |     </template>


warning: The "TableView" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:2:3:
  1 | <template>
> 2 |   <TableView>
    |   ^
  3 |     <template #name>
  4 |       {{ tableViewName }}
  5 |     </template>


warning: The "TableViewFooter" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:7:7:
   5 |     </template>
   6 |     <template #footer>
>  7 |       <TableViewFooter>
     |       ^
   8 |         <template #action>
   9 |           <CustomButton />
  10 |         </template>


warning: The "TableViewFooter" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:7:7:
   5 |     </template>
   6 |     <template #footer>
>  7 |       <TableViewFooter>
     |       ^
   8 |         <template #action>
   9 |           <CustomButton />
  10 |         </template>


warning: The "TableViewFooter" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:7:7:
   5 |     </template>
   6 |     <template #footer>
>  7 |       <TableViewFooter>
     |       ^
   8 |         <template #action>
   9 |           <CustomButton />
  10 |         </template>


warning: The "CustomButton" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:9:11:
   7 |       <TableViewFooter>
   8 |         <template #action>
>  9 |           <CustomButton />
     |           ^
  10 |         </template>
  11 |       </TableViewFooter>
  12 |     </template>


warning: The "CustomButton" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:9:11:
   7 |       <TableViewFooter>
   8 |         <template #action>
>  9 |           <CustomButton />
     |           ^
  10 |         </template>
  11 |       </TableViewFooter>
  12 |     </template>


warning: The "CustomButton" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:9:11:
   7 |       <TableViewFooter>
   8 |         <template #action>
>  9 |           <CustomButton />
     |           ^
  10 |         </template>
  11 |       </TableViewFooter>
  12 |     </template>


10 warnings found.
```
</details>

# Potential fix

Quick fix I could find from the existing code is to only use the root `template` to report the errors. 

<details><summary>
Resulting in the following warnings:
</summary>

```
warning: The "TableView" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:2:3:
  1 | <template>
> 2 |   <TableView>
    |   ^
  3 |     <template #name>
  4 |       {{ tableViewName }}
  5 |     </template>


warning: The "TableViewFooter" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:7:7:
   5 |     </template>
   6 |     <template #footer>
>  7 |       <TableViewFooter>
     |       ^
   8 |         <template #action>
   9 |           <CustomButton />
  10 |         </template>


warning: The "CustomButton" component has been used but not registered (vue/no-unregistered-components) at src/components/HelloWorld.vue:9:11:
   7 |       <TableViewFooter>
   8 |         <template #action>
>  9 |           <CustomButton />
     |           ^
  10 |         </template>
  11 |       </TableViewFooter>
  12 |     </template>


3 warnings found.
```

</details>

# Changes

* Target `<template>` whose parent is of type `VDocumentFragment` (root template) to report the unregisteredComponents.
* Add tests using named template to prevent potential regressions. 