### PR TITLE
Add composition api's computed function support to vue/no-side-effects-in-computed-properties close #1393

### DIFF
--- a/docs/rules/no-side-effects-in-computed-properties.md
+++ b/docs/rules/no-side-effects-in-computed-properties.md
@@ -2,20 +2,20 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/no-side-effects-in-computed-properties
-description: disallow side effects in computed properties
+description: disallow side effects in computed properties and functions
 since: v3.6.0
 ---
 # vue/no-side-effects-in-computed-properties
 
-> disallow side effects in computed properties
+> disallow side effects in computed properties and functions
 
 - :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/essential"`, `"plugin:vue/vue3-strongly-recommended"`, `"plugin:vue/strongly-recommended"`, `"plugin:vue/vue3-recommended"` and `"plugin:vue/recommended"`.
 
 ## :book: Rule Details
 
-This rule is aimed at preventing the code which makes side effects in computed properties.
+This rule is aimed at preventing the code which makes side effects in computed properties and functions.
 
-It is considered a very bad practice to introduce side effects inside computed properties. It makes the code not predictable and hard to understand.
+It is considered a very bad practice to introduce side effects inside computed properties and functions. It makes the code not predictable and hard to understand.
 
 <eslint-code-block :rules="{'vue/no-side-effects-in-computed-properties': ['error']}">
 
@@ -51,6 +51,51 @@ export default {
     reversedArray () {
       return this.array.reverse() // <- side effect - orginal array is being mutated
     }
+  }
+}
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-side-effects-in-computed-properties': ['error']}">
+
+```vue
+<script>
+import {computed} from 'vue'
+/* ✓ GOOD */
+export default {
+  setup() {
+    const foo = useFoo()
+
+    const fullName = computed(() => `${foo.firstName} ${foo.lastName}`)
+    const reversedArray = computed(() => {
+      return foo.array.slice(0).reverse() // .slice makes a copy of the array, instead of mutating the orginal
+    })
+  }
+}
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-side-effects-in-computed-properties': ['error']}">
+
+```vue
+<script>
+import {computed} from 'vue'
+/* ✗ BAD */
+export default {
+  setup() {
+    const foo = useFoo()
+    
+    const fullName = computed(() => {
+      foo.firstName = 'lorem' // <- side effect
+      return `${foo.firstName} ${foo.lastName}`
+    })
+    const reversedArray = computed(() => {
+      return foo.array.reverse() // <- side effect - orginal array is being mutated
+    })
   }
 }
 </script>

--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -33,6 +33,8 @@ module.exports = {
     const computedPropertiesMap = new Map()
     /** @type {Array<FunctionExpression | ArrowFunctionExpression>} */
     const computedCallNodes = []
+    /** @type {Array<FunctionExpression | ArrowFunctionExpression | FunctionDeclaration>} */
+    const setupFunctions = []
 
     /**
      * @typedef {object} ScopeStack
@@ -85,6 +87,9 @@ module.exports = {
         },
         ':function': onFunctionEnter,
         ':function:exit': onFunctionExit,
+        onSetupFunctionEnter(node) {
+          setupFunctions.push(node)
+        },
 
         /**
          * @param {(Identifier | ThisExpression) & {parent: MemberExpression}} node
@@ -151,25 +156,34 @@ module.exports = {
           }
 
           const variable = findVariable(context.getScope(), node)
-          if (variable) {
-            if (variable.defs.length !== 1) {
-              return
-            }
+          if (!variable || variable.defs.length !== 1) {
+            return
+          }
 
-            const def = variable.defs[0]
-            if (
-              def.type !== 'ImplicitGlobalVariable' &&
-              def.type !== 'TDZ' &&
-              def.type !== 'ImportBinding'
-            ) {
-              if (
-                def.node.loc.start.line >= computedFunction.loc.start.line &&
-                def.node.loc.end.line <= computedFunction.loc.end.line
-              ) {
-                // mutating local variables are accepted
-                return
-              }
-            }
+          const def = variable.defs[0]
+          if (
+            def.type === 'ImplicitGlobalVariable' ||
+            def.type === 'TDZ' ||
+            def.type === 'ImportBinding'
+          ) {
+            return
+          }
+
+          const isDeclaredInsideSetup = setupFunctions.some(
+            (setupFn) =>
+              def.node.loc.start.line >= setupFn.loc.start.line &&
+              def.node.loc.end.line <= setupFn.loc.end.line
+          )
+          if (!isDeclaredInsideSetup) {
+            return
+          }
+
+          if (
+            def.node.loc.start.line >= computedFunction.loc.start.line &&
+            def.node.loc.end.line <= computedFunction.loc.end.line
+          ) {
+            // mutating local variables are accepted
+            return
           }
 
           const invalid = utils.findMutating(node)

--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -172,7 +172,7 @@ module.exports = {
             }
           }
 
-          const invalid = utils.findMutating(mem)
+          const invalid = utils.findMutating(node)
           if (invalid) {
             context.report({
               node: invalid.node,

--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -3,7 +3,7 @@
  * @author Michał Sajnóg
  */
 'use strict'
-
+const { ReferenceTracker, findVariable } = require('eslint-utils')
 const utils = require('../utils')
 
 /**
@@ -31,6 +31,8 @@ module.exports = {
   create(context) {
     /** @type {Map<ObjectExpression, ComponentComputedProperty[]>} */
     const computedPropertiesMap = new Map()
+    /** @type {Array<FunctionExpression | ArrowFunctionExpression>} */
+    const computedCallNodes = []
 
     /**
      * @typedef {object} ScopeStack
@@ -54,56 +56,130 @@ module.exports = {
       scopeStack = scopeStack && scopeStack.upper
     }
 
-    return utils.defineVueVisitor(context, {
-      onVueObjectEnter(node) {
-        computedPropertiesMap.set(node, utils.getComputedProperties(node))
-      },
-      ':function': onFunctionEnter,
-      ':function:exit': onFunctionExit,
-
-      /**
-       * @param {(Identifier | ThisExpression) & {parent: MemberExpression}} node
-       * @param {VueObjectData} data
-       */
-      'MemberExpression > :matches(Identifier, ThisExpression)'(
-        node,
-        { node: vueNode }
-      ) {
-        if (!scopeStack) {
-          return
-        }
-        const targetBody = scopeStack.body
-        const computedProperty = /** @type {ComponentComputedProperty[]} */ (computedPropertiesMap.get(
-          vueNode
-        )).find((cp) => {
-          return (
-            cp.value &&
-            node.loc.start.line >= cp.value.loc.start.line &&
-            node.loc.end.line <= cp.value.loc.end.line &&
-            targetBody === cp.value
-          )
-        })
-        if (!computedProperty) {
-          return
-        }
-
-        if (!utils.isThis(node, context)) {
-          return
-        }
-        const mem = node.parent
-        if (mem.object !== node) {
-          return
-        }
-
-        const invalid = utils.findMutating(mem)
-        if (invalid) {
-          context.report({
-            node: invalid.node,
-            message: 'Unexpected side effect in "{{key}}" computed property.',
-            data: { key: computedProperty.key || 'Unknown' }
+    return Object.assign(
+      {
+        Program() {
+          const tracker = new ReferenceTracker(context.getScope())
+          const traceMap = utils.createCompositionApiTraceMap({
+            [ReferenceTracker.ESM]: true,
+            computed: {
+              [ReferenceTracker.CALL]: true
+            }
           })
+
+          for (const { node } of tracker.iterateEsmReferences(traceMap)) {
+            if (node.type !== 'CallExpression') {
+              continue
+            }
+
+            const getterBody = utils.getGetterBodyFromComputedFunction(node)
+            if (getterBody) {
+              computedCallNodes.push(getterBody)
+            }
+          }
         }
-      }
-    })
+      },
+      utils.defineVueVisitor(context, {
+        onVueObjectEnter(node) {
+          computedPropertiesMap.set(node, utils.getComputedProperties(node))
+        },
+        ':function': onFunctionEnter,
+        ':function:exit': onFunctionExit,
+
+        /**
+         * @param {(Identifier | ThisExpression) & {parent: MemberExpression}} node
+         * @param {VueObjectData} data
+         */
+        'MemberExpression > :matches(Identifier, ThisExpression)'(
+          node,
+          { node: vueNode }
+        ) {
+          if (!scopeStack) {
+            return
+          }
+          const targetBody = scopeStack.body
+
+          const computedProperty = /** @type {ComponentComputedProperty[]} */ (computedPropertiesMap.get(
+            vueNode
+          )).find((cp) => {
+            return (
+              cp.value &&
+              node.loc.start.line >= cp.value.loc.start.line &&
+              node.loc.end.line <= cp.value.loc.end.line &&
+              targetBody === cp.value
+            )
+          })
+          if (computedProperty) {
+            if (!utils.isThis(node, context)) {
+              return
+            }
+            const mem = node.parent
+            if (mem.object !== node) {
+              return
+            }
+
+            const invalid = utils.findMutating(mem)
+            if (invalid) {
+              context.report({
+                node: invalid.node,
+                message:
+                  'Unexpected side effect in "{{key}}" computed property.',
+                data: { key: computedProperty.key || 'Unknown' }
+              })
+            }
+            return
+          }
+
+          // ignore `this` for computed functions
+          if (node.type === 'ThisExpression') {
+            return
+          }
+
+          const computedFunction = computedCallNodes.find(
+            (c) =>
+              node.loc.start.line >= c.loc.start.line &&
+              node.loc.end.line <= c.loc.end.line
+          )
+          if (!computedFunction) {
+            return
+          }
+
+          const mem = node.parent
+          if (mem.object !== node) {
+            return
+          }
+
+          const variable = findVariable(context.getScope(), node)
+          if (variable) {
+            if (variable.defs.length !== 1) {
+              return
+            }
+
+            const def = variable.defs[0]
+            if (
+              def.type !== 'ImplicitGlobalVariable' &&
+              def.type !== 'TDZ' &&
+              def.type !== 'ImportBinding'
+            ) {
+              if (
+                def.node.loc.start.line >= computedFunction.loc.start.line &&
+                def.node.loc.end.line <= computedFunction.loc.end.line
+              ) {
+                // mutating local variables are accepted
+                return
+              }
+            }
+          }
+
+          const invalid = utils.findMutating(mem)
+          if (invalid) {
+            context.report({
+              node: invalid.node,
+              message: 'Unexpected side effect in computed function.'
+            })
+          }
+        }
+      })
+    )
   }
 }

--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -138,7 +138,8 @@ module.exports = {
           const computedFunction = computedCallNodes.find(
             (c) =>
               node.loc.start.line >= c.loc.start.line &&
-              node.loc.end.line <= c.loc.end.line
+              node.loc.end.line <= c.loc.end.line &&
+              targetBody === c.body
           )
           if (!computedFunction) {
             return

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -192,6 +192,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       code: `
       <script>
       import { computed } from 'vue'
+      const utils = {}
       export default {
         setup() {
           const foo = useFoo()
@@ -266,6 +267,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             C.name = 'D'
           })
           const test18 = computed(() => (console.log('a'), true))
+          const test19 = computed(() => utils.reverse(foo.array))
         }
       }
       </script>`
@@ -487,10 +489,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           const test9 = computed(() => {
             A.name = ''
           })
-          const test10 = computed(() => {
-            console.log = () => {}
-          })
-          const test11 = computed(() => (foo.a = '', true))
+          const test10 = computed(() => (foo.a = '', true))
 
           const test100 = computed(() => {
             const a = foo
@@ -546,11 +545,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           message: 'Unexpected side effect in computed function.'
         },
         {
-          line: 43,
-          message: 'Unexpected side effect in computed function.'
-        },
-        {
-          line: 45,
+          line: 42,
           message: 'Unexpected side effect in computed function.'
         }
       ]

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -558,6 +558,27 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
     {
       filename: 'test.vue',
       code: `
+      <script>
+      import {reactive, computed} from 'vue'
+      export default {
+        setup() {
+          const arr = reactive([])
+
+          const test1 = computed(() => arr.reverse())
+        }
+      }
+      </script>
+      `,
+      errors: [
+        {
+          line: 8,
+          message: 'Unexpected side effect in computed function.'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
       <script lang="ts">
       import {ref, computed} from 'vue'
       export default {

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -20,7 +20,11 @@ const parserOptions = {
 // Tests
 // ------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester()
+const ruleTester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions
+})
+
 ruleTester.run('no-side-effects-in-computed-properties', rule, {
   valid: [
     {
@@ -101,8 +105,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             this.someArray.forEach(arr => console.log(arr))
           }
         }
-      })`,
-      parserOptions
+      })`
     },
     {
       code: `Vue.component('test', {
@@ -120,8 +123,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             return something.b
           }
         }
-      })`,
-      parserOptions
+      })`
     },
     {
       code: `Vue.component('test', {
@@ -129,8 +131,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
         data() {
           return {}
         }
-      })`,
-      parserOptions
+      })`
     },
     {
       code: `Vue.component('test', {
@@ -141,8 +142,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             return a
           },
         }
-      })`,
-      parserOptions
+      })`
     },
     {
       code: `Vue.component('test', {
@@ -161,8 +161,7 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             }
           },
         }
-      })`,
-      parserOptions
+      })`
     },
     {
       code: `Vue.component('test', {
@@ -171,15 +170,13 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             return this.something['a']().reverse()
           },
         }
-      })`,
-      parserOptions
+      })`
     },
     {
       code: `const test = { el: '#app' }
         Vue.component('test', {
         el: test.el
-      })`,
-      parserOptions
+      })`
     },
     {
       code: `Vue.component('test', {
@@ -188,8 +185,90 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             return [...this.items].reverse()
           },
         }
-      })`,
-      parserOptions
+      })`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      import { computed } from 'vue'
+      export default {
+        setup() {
+          const foo = useFoo()
+          function bar () {}
+          class Baz {}
+
+          const test0 = computed(test0f)
+          const test1 = computed(() => foo.firstName + ' ' + foo.lastName)
+          const test2 = computed(() => foo.something.slice(0).reverse())
+          const test3 = computed(() => {
+            return {
+              ...foo.something,
+              test: 'example'
+            }
+          })
+          const test5 = computed({
+            get: () => foo.firstName + ' ' + foo.lastName,
+            set: newValue => {
+              const names = newValue.split(' ')
+              foo.firstName = names[0]
+              foo.lastName = names[names.length - 1]
+            }
+          })
+          const test6 = computed({
+            get: () => foo.something.slice(0).reverse()
+          })
+          const test7 = computed({
+            get: () => {
+              const example = foo.something * 2
+              return example + 'test'
+            }
+          })
+          const test8 = computed({
+            get: () => {
+              return {
+                ...foo.something,
+                test: 'example'
+              }
+            }
+          })
+          const test9 = computed(() => Object.keys(foo.a).sort())
+          const test10 = computed({
+            get: () => Object.keys(foo.a).sort()
+          })
+          const test11 = computed(() => {
+            const categories = {}
+
+            foo.types.forEach(c => {
+              categories[c.category] = categories[c.category] || []
+              categories[c.category].push(c)
+            })
+
+            return categories
+          })
+          const test12 = computed(() => {
+            return foo.types.map(t => {
+              // [].push('xxx')
+              return t
+            })
+          })
+          const test13 = computed(() => {
+            foo.someArray.forEach(arr => console.log(arr))
+          })
+          const test14 = computed(() => bar.name)
+          const test15 = computed(() => Baz.name)
+          const test16 = computed(() => {
+            function b () {}
+            b.name = 'c'
+          })
+          const test17 = computed(() => {
+            class C {}
+            C.name = 'D'
+          })
+          const test18 = computed(() => (console.log('a'), true))
+        }
+      }
+      </script>`
     }
   ],
   invalid: [
@@ -222,7 +301,6 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           }
         }
       })`,
-      parserOptions,
       errors: [
         {
           line: 4,
@@ -286,7 +364,6 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           },
         }
       })`,
-      parserOptions,
       errors: [
         {
           line: 5,
@@ -321,7 +398,6 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           }
         });
       `,
-      parserOptions,
       errors: [
         {
           line: 5,
@@ -341,7 +417,6 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           },
         }
       })`,
-      parserOptions,
       errors: [
         {
           line: 4,
@@ -363,11 +438,142 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           },
         }
       })`,
-      parserOptions,
       errors: [
         'Unexpected side effect in "test1" computed property.',
         'Unexpected side effect in "test2" computed property.',
         'Unexpected side effect in "test3" computed property.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      import {ref, computed} from 'vue'
+      export default {
+        setup() {
+          const foo = useFoo()
+          const asd = { qwe: {} }
+          function a () {}
+          class A {}
+
+          const test1 = computed(() => {
+            foo.firstName = 'lorem'
+            asd.qwe.zxc = 'lorem'
+            return foo.firstName + ' ' + foo.lastName
+          })
+          const test2 = computed(() => {
+            foo.count += 2;
+            foo.count++;
+            return foo.count;
+          })
+          const test3 = computed(() => foo.something.reverse())
+          const test4 = computed(() => {
+            const test = foo.another.something.push('example')
+            return 'something'
+          })
+          const test5 = computed(() => {
+            foo.something[index] = foo.thing[index]
+            return foo.something
+          })
+          const test6 = computed(() => foo.something.keys.sort())
+          const test7 = computed({
+            get() {
+              return foo.something.reverse()
+            }
+          })
+          const test8 = computed(() => {
+            a.name = ''
+          })
+          const test9 = computed(() => {
+            A.name = ''
+          })
+          const test10 = computed(() => {
+            console.log = () => {}
+          })
+          const test11 = computed(() => (foo.a = '', true))
+
+          const test100 = computed(() => {
+            const a = foo
+            a.count++ // false negative
+          })
+        }
+      }
+      </script>
+      `,
+      errors: [
+        {
+          line: 12,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 13,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 17,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 18,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 21,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 23,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 27,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 30,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 33,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 37,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 40,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 43,
+          message: 'Unexpected side effect in computed function.'
+        },
+        {
+          line: 45,
+          message: 'Unexpected side effect in computed function.'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script lang="ts">
+      import {ref, computed} from 'vue'
+      export default {
+        setup() {
+          const foo = useFoo()
+
+          const test1 = computed(() => foo.something.reverse())
+        }
+      }
+      </script>
+      `,
+      errors: [
+        {
+          line: 8,
+          message: 'Unexpected side effect in computed function.'
+        }
       ]
     }
   ]


### PR DESCRIPTION
This PR adds support for composition api's computed function to `vue/no-side-effects-in-computed-properties`.
close #1393

With computed properties, this rule only warned about mutating `this`.
But since computed functions does not use `this`, I made it warn about mutating any variables which are not declared inside the computed function.

For example
```ts
const foo = ref(0)
const bar = computed(() => {
  foo.value = 3 // here it will be warned, since `foo` is not declared inside computed
  return foo.value + 3
})

const baz = computed(() => {
  const foobar = [3,5,6]
  return foobar.sort().map(v => v + foo.value) // here it will not be warned, since `foobar` is declared inside computed
})
```

Is this approach ok? Any other one is better?
If it is ok, should I change the behavior with computed properties to this one?
