### PR TITLE
Fix false positives for assignments in `no-ref-as-operand` rule

### DIFF
--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -134,8 +134,11 @@ module.exports = {
         reportIfRefWrapped(node)
       },
       // refValue+=1, refValue-=1, foo+=refValue, foo-=refValue
-      /** @param {Identifier} node */
+      /** @param {Identifier & {parent: AssignmentExpression}} node */
       'AssignmentExpression>Identifier'(node) {
+        if (node.parent.operator === '=' && node.parent.left !== node) {
+          return
+        }
         reportIfRefWrapped(node)
       },
       // refValue || other, refValue && other. ignore: other || refValue

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -121,6 +121,16 @@ tester.run('no-ref-as-operand', rule, {
     const count = ref
     count++
     `,
+    `
+    import { ref } from 'vue'
+    const count = ref(0)
+    foo = count
+    `,
+    `
+    import { ref } from 'vue'
+    const count = ref(0)
+    const foo = count
+    `,
     {
       code: `
       <script>


### PR DESCRIPTION
fix #1408