### PR TITLE
Fix crash for toLocaleString() in `vue/no-unused-properties` rule

### DIFF
--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -168,7 +168,7 @@ class UsedProperties {
    */
   constructor(option) {
     /** @type {Record<string, UsedPropertiesTracker[]>} */
-    this.map = {}
+    this.map = Object.create(null)
     /** @type {CallAndParamIndex[]} */
     this.calls = []
     this.unknown = (option && option.unknown) || false

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -1411,6 +1411,23 @@ tester.run('no-unused-properties', rule, {
         </script>
       `,
       options: deepDataOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div> {{ obj.num.toLocaleString() }} </div>
+      </template>
+      <script>
+      export default {
+        data () {
+          return {
+            obj: { num: 42 }
+          }
+        }
+      }
+      </script>`,
+      options: deepDataOptions
     }
   ],
 


### PR DESCRIPTION
fixes #1416