### PR TITLE
feat(no-bare-strings-in-template): ✨ allow to ignore specific elements

### DIFF
--- a/docs/rules/no-bare-strings-in-template.md
+++ b/docs/rules/no-bare-strings-in-template.md
@@ -12,7 +12,7 @@ since: v7.0.0
 ## :book: Rule Details
 
 This rule disallows the use of bare strings in `<template>`.  
-In order to be able to internationalize your application, you will need to avoid using plain strings in your templates. Instead, you would need to use a template helper specializing in translation.
+In order to be able to internationalize your application, you will need to avoid using plain strings in your templates. Instead, you would need to use a template helper specializing in translation.  
 
 This rule was inspired by [no-bare-strings rule in ember-template-lint](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-bare-strings.md).
 

--- a/docs/rules/no-bare-strings-in-template.md
+++ b/docs/rules/no-bare-strings-in-template.md
@@ -5,7 +5,6 @@ title: vue/no-bare-strings-in-template
 description: disallow the use of bare strings in `<template>`
 since: v7.0.0
 ---
-
 # vue/no-bare-strings-in-template
 
 > disallow the use of bare strings in `<template>`
@@ -16,6 +15,7 @@ This rule disallows the use of bare strings in `<template>`.
 In order to be able to internationalize your application, you will need to avoid using plain strings in your templates. Instead, you would need to use a template helper specializing in translation.
 
 This rule was inspired by [no-bare-strings rule in ember-template-lint](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-bare-strings.md).
+
 
 <eslint-code-block :rules="{'vue/no-bare-strings-in-template': ['error']}">
 
@@ -35,13 +35,15 @@ This rule was inspired by [no-bare-strings rule in ember-template-lint](https://
     aria-roledescription="Lorem ipsum"
     aria-valuetext="Lorem ipsum"
   />
-  <img alt="Lorem ipsum" />
-  <input placeholder="Lorem ipsum" />
+  <img alt="Lorem ipsum">
+  <input placeholder="Lorem ipsum">
   <h1 v-text="'Lorem ipsum'" />
 
   <!-- Does not check -->
   <h1>{{ 'Lorem ipsum' }}</h1>
-  <div v-bind:title="'Lorem ipsum'" />
+  <div
+    v-bind:title="'Lorem ipsum'"
+  />
 </template>
 ```
 
@@ -54,8 +56,7 @@ If you want to report these string literals, enable the [vue/no-useless-v-bind] 
 
 ## :wrench: Options
 
-<!-- prettier-ignore -->
-```json
+```js
 {
   "vue/no-bare-strings-in-template": ["error", {
     "allowlist": [
@@ -67,21 +68,19 @@ If you want to report these string literals, enable the [vue/no-useless-v-bind] 
       "img": ["alt"]
     },
     "directives": ["v-text"],
-    "ignores": ["h1", "custom-component", "CustomComponent"]
+    "ignoreComponents": ["h1", "custom-component", "CustomComponent"]
   }]
 }
 ```
-
-<!-- prettier-ignore-end -->
 
 - `allowlist` ... An array of allowed strings.
 - `attributes` ... An object whose keys are tag name or patterns and value is an array of attributes to check for that tag name.
 - `directives` ... An array of directive names to check literal value.
 - `ignores` ... An array of element names to ignore. RegExp is allowed.
 
-### `{ "ignores": ["h1", "custom-component", "CustomComponent"] }`
+### `{ "ignoreComponents": ["h1", "custom-component", "CustomComponent"] }`
 
-<eslint-code-block fix :rules="{'vue/no-bare-strings-in-template': ['error', { 'ignores': ['h1', 'custom-component', 'CustomComponent'] }]}">
+<eslint-code-block fix :rules="{'vue/no-bare-strings-in-template': ['error', { 'ignoreComponents': ['h1', 'custom-component', 'CustomComponent'] }]}">
 
 ```vue
 <template>

--- a/docs/rules/no-bare-strings-in-template.md
+++ b/docs/rules/no-bare-strings-in-template.md
@@ -5,6 +5,7 @@ title: vue/no-bare-strings-in-template
 description: disallow the use of bare strings in `<template>`
 since: v7.0.0
 ---
+
 # vue/no-bare-strings-in-template
 
 > disallow the use of bare strings in `<template>`
@@ -12,10 +13,9 @@ since: v7.0.0
 ## :book: Rule Details
 
 This rule disallows the use of bare strings in `<template>`.  
-In order to be able to internationalize your application, you will need to avoid using plain strings in your templates. Instead, you would need to use a template helper specializing in translation.  
+In order to be able to internationalize your application, you will need to avoid using plain strings in your templates. Instead, you would need to use a template helper specializing in translation.
 
 This rule was inspired by [no-bare-strings rule in ember-template-lint](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-bare-strings.md).
-
 
 <eslint-code-block :rules="{'vue/no-bare-strings-in-template': ['error']}">
 
@@ -35,15 +35,13 @@ This rule was inspired by [no-bare-strings rule in ember-template-lint](https://
     aria-roledescription="Lorem ipsum"
     aria-valuetext="Lorem ipsum"
   />
-  <img alt="Lorem ipsum">
-  <input placeholder="Lorem ipsum">
+  <img alt="Lorem ipsum" />
+  <input placeholder="Lorem ipsum" />
   <h1 v-text="'Lorem ipsum'" />
 
   <!-- Does not check -->
   <h1>{{ 'Lorem ipsum' }}</h1>
-  <div
-    v-bind:title="'Lorem ipsum'"
-  />
+  <div v-bind:title="'Lorem ipsum'" />
 </template>
 ```
 
@@ -56,7 +54,8 @@ If you want to report these string literals, enable the [vue/no-useless-v-bind] 
 
 ## :wrench: Options
 
-```js
+<!-- prettier-ignore -->
+```json
 {
   "vue/no-bare-strings-in-template": ["error", {
     "allowlist": [
@@ -67,14 +66,38 @@ If you want to report these string literals, enable the [vue/no-useless-v-bind] 
       "input": ["placeholder"],
       "img": ["alt"]
     },
-    "directives": ["v-text"]
+    "directives": ["v-text"],
+    "ignores": ["h1", "custom-component", "CustomComponent"]
   }]
 }
 ```
 
+<!-- prettier-ignore-end -->
+
 - `allowlist` ... An array of allowed strings.
 - `attributes` ... An object whose keys are tag name or patterns and value is an array of attributes to check for that tag name.
 - `directives` ... An array of directive names to check literal value.
+- `ignores` ... An array of element names to ignore. RegExp is allowed.
+
+### `{ "ignores": ["h1", "custom-component", "CustomComponent"] }`
+
+<eslint-code-block fix :rules="{'vue/no-bare-strings-in-template': ['error', { 'ignores': ['h1', 'custom-component', 'CustomComponent'] }]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <h1>Heading</h1>
+  <custom-component>Some text</custom-component>
+  <CustomComponent>Some more text</CustomComponent>
+
+  <!-- ✗ BAD -->
+  <h2>Lorem ipsum</h2>
+  <another-component>Lorem ipsum</another-component>
+  <AnotherComponent>Lorem ipsum</AnotherComponent>
+</template>
+```
+
+</eslint-code-block>
 
 ## :couple: Related Rules
 

--- a/lib/rules/no-bare-strings-in-template.js
+++ b/lib/rules/no-bare-strings-in-template.js
@@ -167,6 +167,8 @@ module.exports = {
     const allowlist = opts.allowlist || DEFAULT_ALLOWLIST
     const attributes = parseTargetAttrs(opts.attributes || DEFAULT_ATTRIBUTES)
     const directives = opts.directives || DEFAULT_DIRECTIVES
+    /** @type {RegExp[]} */
+    const ignores = (opts.ignores || []).map(regexp.toRegExp)
 
     const allowlistRe = new RegExp(
       allowlist.map((w) => regexp.escape(w)).join('|'),
@@ -210,9 +212,23 @@ module.exports = {
       return (attributes.cache[tagName] = new Set(result))
     }
 
+    /**
+     * Checks whether the given node should be ignored.
+     * @param {VText} node text node
+     * @returns {boolean} `true` if the given node should be ignored.
+     */
+    function isIgnored({ parent }) {
+      return (
+        parent.type === 'VElement' &&
+        ignores.some((re) => re.test(parent.rawName))
+      )
+    }
+
     return utils.defineTemplateBodyVisitor(context, {
       /** @param {VText} node */
       VText(node) {
+        if (isIgnored(node)) return
+
         if (getBareString(node.value)) {
           context.report({
             node,

--- a/lib/rules/no-bare-strings-in-template.js
+++ b/lib/rules/no-bare-strings-in-template.js
@@ -168,7 +168,7 @@ module.exports = {
     const attributes = parseTargetAttrs(opts.attributes || DEFAULT_ATTRIBUTES)
     const directives = opts.directives || DEFAULT_DIRECTIVES
     /** @type {RegExp[]} */
-    const ignores = (opts.ignores || []).map(regexp.toRegExp)
+    const ignoreComponents = (opts.ignoreComponents || []).map(regexp.toRegExp)
 
     const allowlistRe = new RegExp(
       allowlist.map((w) => regexp.escape(w)).join('|'),
@@ -220,7 +220,7 @@ module.exports = {
     function isIgnored({ parent }) {
       return (
         parent.type === 'VElement' &&
-        ignores.some((re) => re.test(parent.rawName))
+        ignoreComponents.some((re) => re.test(parent.rawName))
       )
     }
 

--- a/tests/lib/rules/no-bare-strings-in-template.js
+++ b/tests/lib/rules/no-bare-strings-in-template.js
@@ -128,7 +128,9 @@ tester.run('no-bare-strings-in-template', rule, {
         <CustomComponent>Some more text</CustomComponent>
       </template>
       `,
-      options: [{ ignores: ['h1', 'custom-component', 'CustomComponent'] }],
+      options: [
+        { ignoreComponents: ['h1', 'custom-component', 'CustomComponent'] }
+      ],
       errors: [
         {
           message: 'Unexpected non-translated string used.',

--- a/tests/lib/rules/no-bare-strings-in-template.js
+++ b/tests/lib/rules/no-bare-strings-in-template.js
@@ -121,32 +121,17 @@ tester.run('no-bare-strings-in-template', rule, {
     </template>
     `,
     {
+      options: [
+        { ignoreComponents: ['h1', 'custom-component', 'CustomComponent'] }
+      ],
       code: `
       <template>
         <h1>Heading 1</h1>
         <custom-component>Some text</custom-component>
         <CustomComponent>Some more text</CustomComponent>
+        <CustomComponent v-text="Some more text" />
       </template>
-      `,
-      options: [
-        { ignoreComponents: ['h1', 'custom-component', 'CustomComponent'] }
-      ],
-      errors: [
-        {
-          message: 'Unexpected non-translated string used.',
-          line: 3,
-          column: 13,
-          endLine: 3,
-          endColumn: 22
-        },
-        {
-          message: 'Unexpected non-translated string used.',
-          line: 4,
-          column: 13,
-          endLine: 4,
-          endColumn: 22
-        }
-      ]
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-bare-strings-in-template.js
+++ b/tests/lib/rules/no-bare-strings-in-template.js
@@ -119,7 +119,33 @@ tester.run('no-bare-strings-in-template', rule, {
         title="( ) , . & + - = * / # % ! ? : [ ] { } < > • —   | &lpar; &rpar; &comma; &period; &amp; &AMP; &plus; &minus; &equals; &ast; &midast; &sol; &num; &percnt; &excl; &quest; &colon; &lsqb; &lbrack; &rsqb; &rbrack; &lcub; &lbrace; &rcub; &rbrace; &lt; &LT; &gt; &GT; &bull; &bullet; &mdash; &ndash; &nbsp; &Tab; &NewLine; &verbar; &vert; &VerticalLine;"
       />
     </template>
-    `
+    `,
+    {
+      code: `
+      <template>
+        <h1>Heading 1</h1>
+        <custom-component>Some text</custom-component>
+        <CustomComponent>Some more text</CustomComponent>
+      </template>
+      `,
+      options: [{ ignores: ['h1', 'custom-component', 'CustomComponent'] }],
+      errors: [
+        {
+          message: 'Unexpected non-translated string used.',
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 22
+        },
+        {
+          message: 'Unexpected non-translated string used.',
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 22
+        }
+      ]
+    }
   ],
   invalid: [
     {


### PR DESCRIPTION
This rule is awesome, but there are some elements which should always be ignored. A good example for this is the [VIcon](https://vuetifyjs.com/en/components/icons/) element from [Vuetify](https://vuetifyjs.com/en/), which is used like this:

```vue
<VIcon>mdi-alarm</VIcon>
```

With the changes I introduced, this element can be ignored like this:

```json
{
  "vue/no-bare-strings-in-template": [
    "error",
    {
      "ignores": ["VIcon", "v-icon"]
    }
  ]
}
```