### PR TITLE
Change options schema to strictly.

### DIFF
--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -346,18 +346,33 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/attributes-order.html'
     },
     fixable: 'code',
-    schema: {
-      type: 'array',
-      properties: {
-        order: {
-          items: {
-            type: 'string'
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          order: {
+            type: 'array',
+            items: {
+              anyOf: [
+                { enum: Object.values(ATTRS) },
+                {
+                  type: 'array',
+                  items: {
+                    enum: Object.values(ATTRS),
+                    uniqueItems: true,
+                    additionalItems: false
+                  }
+                }
+              ]
+            },
+            uniqueItems: true,
+            additionalItems: false
           },
-          maxItems: 10,
-          minItems: 10
-        }
+          alphabetical: { type: 'boolean' }
+        },
+        additionalProperties: false
       }
-    }
+    ]
   },
   create
 }

--- a/lib/rules/component-tags-order.js
+++ b/lib/rules/component-tags-order.js
@@ -40,7 +40,8 @@ module.exports = {
             uniqueItems: true,
             additionalItems: false
           }
-        }
+        },
+        additionalProperties: false
       }
     ],
     messages: {

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -61,7 +61,8 @@ module.exports = {
               }
             ]
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },

--- a/lib/rules/new-line-between-multi-line-property.js
+++ b/lib/rules/new-line-between-multi-line-property.js
@@ -68,7 +68,8 @@ module.exports = {
             type: 'number',
             minimum: 2
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },

--- a/lib/rules/no-bare-strings-in-template.js
+++ b/lib/rules/no-bare-strings-in-template.js
@@ -149,7 +149,8 @@ module.exports = {
             items: { type: 'string', pattern: '^v-' },
             uniqueItems: true
           }
-        }
+        },
+        additionalProperties: false
       }
     ],
     messages: {

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -59,7 +59,8 @@ module.exports = {
           allowCoexistStyle: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },

--- a/lib/rules/no-potential-component-option-typo.js
+++ b/lib/rules/no-potential-component-option-typo.js
@@ -44,7 +44,8 @@ module.exports = {
             type: 'number',
             minimum: 1
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },

--- a/lib/rules/no-reserved-component-names.js
+++ b/lib/rules/no-reserved-component-names.js
@@ -84,7 +84,8 @@ module.exports = {
           disallowVue3BuiltInComponents: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }
     ],
     messages: {

--- a/lib/rules/no-use-v-if-with-v-for.js
+++ b/lib/rules/no-use-v-if-with-v-for.js
@@ -62,7 +62,8 @@ module.exports = {
           allowUsingIterationVar: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },

--- a/lib/rules/no-useless-mustaches.js
+++ b/lib/rules/no-useless-mustaches.js
@@ -50,7 +50,8 @@ module.exports = {
           ignoreStringEscape: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }
     ],
     type: 'suggestion'

--- a/lib/rules/no-useless-v-bind.js
+++ b/lib/rules/no-useless-v-bind.js
@@ -30,7 +30,8 @@ module.exports = {
           ignoreStringEscape: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }
     ],
     type: 'suggestion'

--- a/lib/rules/valid-v-slot.js
+++ b/lib/rules/valid-v-slot.js
@@ -287,7 +287,8 @@ module.exports = {
           allowModifiers: {
             type: 'boolean'
           }
-        }
+        },
+        additionalProperties: false
       }
     ],
     messages: {

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -259,7 +259,7 @@ tester.run('attributes-order', rule, {
           <div
             v-if="!visible"
             class="content"
-            :class="className"
+            v-model="foo"
             v-text="textContent"
             >
           </div>
@@ -273,7 +273,7 @@ tester.run('attributes-order', rule, {
             'DEFINITION',
             'EVENTS',
             'UNIQUE',
-            ['BINDING', 'OTHER_ATTR'],
+            ['TWO_WAY_BINDING', 'OTHER_ATTR'],
             'CONTENT',
             'GLOBAL'
           ]
@@ -705,7 +705,7 @@ tester.run('attributes-order', rule, {
             <div
               class="content"
               v-if="!visible"
-              :class="className"
+              v-model="foo"
               v-text="textContent"
               >
             </div>
@@ -719,7 +719,7 @@ tester.run('attributes-order', rule, {
             'DEFINITION',
             'EVENTS',
             'UNIQUE',
-            ['BINDING', 'OTHER_ATTR'],
+            ['TWO_WAY_BINDING', 'OTHER_ATTR'],
             'CONTENT',
             'GLOBAL'
           ]
@@ -729,7 +729,7 @@ tester.run('attributes-order', rule, {
             <div
               v-if="!visible"
               class="content"
-              :class="className"
+              v-model="foo"
               v-text="textContent"
               >
             </div>


### PR DESCRIPTION
This PR modifies the option schema of some rules to be strict.
This change causes an error to be thrown if the user specifies an incorrect option.

Targets:

- vue/attributes-order
- vue/component-tags-order
- vue/max-attributes-per-line
- vue/new-line-between-multi-line-property
- vue/no-bare-strings-in-template
- vue/no-duplicate-attributes
- vue/no-potential-component-option-typo
- vue/no-reserved-component-names
- vue/no-use-v-if-with-v-for
- vue/no-useless-mustaches
- vue/no-useless-v-bind
- vue/valid-v-slot

