### PR TITLE
Add "ignores" list to prop names casing

### DIFF
--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -16,7 +16,6 @@ function create(context) {
   const options = context.options[0]
   const ignores = (context.options[1] && context.options[1].ignores) || []
 
-
   const caseType =
     ALLOWED_CASE_OPTIONS.indexOf(options) !== -1 ? options : 'camelCase'
   const checker = casing.getChecker(caseType)
@@ -28,8 +27,7 @@ function create(context) {
   return utils.executeOnVue(context, (obj) => {
     for (const item of utils.getComponentProps(obj)) {
       const propName = item.propName
-      const isIgnored = ignores.some(pattern => propName.match(pattern))
-      if (propName == null || isIgnored) {
+      if (propName == null || ignores.some((pattern) => propName.match(pattern))) {
         continue
       }
       if (!checker(propName)) {
@@ -88,7 +86,7 @@ module.exports = {
           enum: ALLOWED_CASE_OPTIONS
         }
       ]
-    },
+    }
   },
   create
 }

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -6,7 +6,7 @@
 
 const utils = require('../utils')
 const casing = require('../utils/casing')
-const allowedCaseOptions = ['camelCase', 'snake_case']
+const ALLOWED_CASE_OPTIONS = ['camelCase', 'snake_case']
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -14,8 +14,11 @@ const allowedCaseOptions = ['camelCase', 'snake_case']
 /** @param {RuleContext} context */
 function create(context) {
   const options = context.options[0]
+  const ignores = (context.options[1] && context.options[1].ignores) || []
+
+
   const caseType =
-    allowedCaseOptions.indexOf(options) !== -1 ? options : 'camelCase'
+    ALLOWED_CASE_OPTIONS.indexOf(options) !== -1 ? options : 'camelCase'
   const checker = casing.getChecker(caseType)
 
   // ----------------------------------------------------------------------
@@ -25,7 +28,8 @@ function create(context) {
   return utils.executeOnVue(context, (obj) => {
     for (const item of utils.getComponentProps(obj)) {
       const propName = item.propName
-      if (propName == null) {
+      const isIgnored = ignores.some(pattern => propName.match(pattern))
+      if (propName == null || isIgnored) {
         continue
       }
       if (!checker(propName)) {
@@ -45,6 +49,18 @@ function create(context) {
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+const OBJECT_OPTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    ignores: {
+      type: 'array',
+      items: { type: 'string' },
+      uniqueItems: true,
+      additionalItems: false
+    }
+  },
+  additionalProperties: false
+}
 
 module.exports = {
   meta: {
@@ -56,11 +72,23 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/prop-name-casing.html'
     },
     fixable: null, // null or "code" or "whitespace"
-    schema: [
-      {
-        enum: allowedCaseOptions
-      }
-    ]
+    schema: {
+      anyOf: [
+        {
+          type: 'array',
+          items: [
+            {
+              enum: ALLOWED_CASE_OPTIONS
+            },
+            OBJECT_OPTION_SCHEMA
+          ]
+        },
+        // For backward compatibility
+        {
+          enum: ALLOWED_CASE_OPTIONS
+        }
+      ]
+    },
   },
   create
 }

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -27,7 +27,9 @@ function create(context) {
   return utils.executeOnVue(context, (obj) => {
     for (const item of utils.getComponentProps(obj)) {
       const propName = item.propName
-      if (propName == null || ignores.some((pattern) => propName.match(pattern))) {
+      const isIgnored = propName == null || ignores.some((pattern) => propName.match(pattern))
+      
+      if (isIgnored) {
         continue
       }
       if (!checker(propName)) {

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -27,8 +27,9 @@ function create(context) {
   return utils.executeOnVue(context, (obj) => {
     for (const item of utils.getComponentProps(obj)) {
       const propName = item.propName
-      const isIgnored = propName == null || ignores.some((pattern) => propName.match(pattern))
-      
+      const isIgnored =
+        propName == null || ignores.some((pattern) => propName.match(pattern))
+
       if (isIgnored) {
         continue
       }


### PR DESCRIPTION
Using Vue 3, it is recommended to use the `emits` option to define the events emitted by a component. However, in doing so, the events are not available in the `attrs` object anymore and need to be registered as props. Following the pattern of `update:modelValue`, it is very common to use `:` inside an event's name, which is currently not possible using the `vue/prop-name-casing` rule. This commit allows for adding an `ignores` option (array of regex patterns) just like the `custom-event-name-casing` rule. 

PS: A default value for this "ignores" option should probably be `[".*?:.*?"]`.