### PR TITLE
Upgrade vue-eslint-parser to v7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-utils": "^2.1.0",
     "natural-compare": "^1.4.0",
     "semver": "^7.3.2",
-    "vue-eslint-parser": "^7.4.1"
+    "vue-eslint-parser": "^7.5.0"
   },
   "devDependencies": {
     "@types/eslint": "^7.2.0",

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -36,6 +36,20 @@ tester.run('no-restricted-syntax', rule, {
           message: 'Call expressions are not allowed.'
         }
       ]
+    },
+
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/870
+      code: `
+        <template>
+          <input :value="interpolate(foo, bar, true)">
+        </template>`,
+      options: [
+        {
+          selector: 'CallExpression > :nth-child(3)[value!=true]',
+          message: 'Third argument of interpolate must be true'
+        }
+      ]
     }
   ],
   invalid: [
@@ -147,6 +161,27 @@ tester.run('no-restricted-syntax', rule, {
       errors: [
         'Call expressions are not allowed.',
         'Call expressions are not allowed.'
+      ]
+    },
+
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/870
+      code: `
+        <template>
+          <input :value="interpolate(foo, bar, false)">
+        </template>`,
+      options: [
+        {
+          selector: 'CallExpression > :nth-child(3)[value!=true]',
+          message: 'Third argument of interpolate must be true'
+        }
+      ],
+      errors: [
+        {
+          message: 'Third argument of interpolate must be true',
+          line: 3,
+          column: 48
+        }
       ]
     }
   ]


### PR DESCRIPTION
This PR upgrades vue-eslint-parser to v7.5.0.
This change fixes an issue that caused a crash when traversing a template using queries such as `:nth-child`.

fixed #870