### PR TITLE
Fix false negatives for member access with `$` in `vue/this-in-template` rule

### DIFF
--- a/lib/rules/this-in-template.js
+++ b/lib/rules/this-in-template.js
@@ -83,7 +83,7 @@ module.exports = {
                 !propertyName ||
                 scopeStack.nodes.some((el) => el.name === propertyName) ||
                 RESERVED_NAMES.has(propertyName) || // this.class | this['class']
-                /^[0-9].*$|[^a-zA-Z0-9_]/.test(propertyName) // this['0aaaa'] | this['foo-bar bas']
+                /^[0-9].*$|[^a-zA-Z0-9_$]/.test(propertyName) // this['0aaaa'] | this['foo-bar bas']
               ) {
                 return
               }

--- a/tests/lib/rules/this-in-template.js
+++ b/tests/lib/rules/this-in-template.js
@@ -222,4 +222,16 @@ ruleTester.run('this-in-template', rule, {
     .concat(
       createInvalidTests('', ['always'], "Expected 'this'.", 'Identifier')
     )
+    .concat([
+      {
+        code: `<template><div v-if="fn(this.$foo)"></div></template><!-- never -->`,
+        errors: ["Unexpected usage of 'this'."],
+        options: ['never']
+      },
+      {
+        code: `<template><div :class="{ foo: this.$foo }"></div></template><!-- never -->`,
+        errors: ["Unexpected usage of 'this'."],
+        options: ['never']
+      }
+    ])
 })


### PR DESCRIPTION
This PR fixes false negatives for the `vue/this-in-template` rule.

The following code was not reported.

```vue
<template>
  {{ this.$foo }}
</template>
```