### PR TITLE
docs: remove mention of "prettier/vue"

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -286,11 +286,7 @@ module.exports = {
 }
 ```
 
-If Prettier conflicts with a rule you have set, [turn off that rule][prettier-linters].
-
-Example **.eslintrc.js**:
-
-You have `vue/html-indent` configured as `error` in `rules`, but it conflicts with Prettier.
+If Prettier conflicts with a rule you have set, [turn off that rule][prettier-linters]. For example, if you have `vue/html-indent` configured as `error` in `rules`, but it conflicts with Prettier, remove that line:
 
 ```diff
 module.exports = {

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -286,7 +286,26 @@ module.exports = {
 }
 ```
 
+If Prettier conflicts with a rule you have set, [turn off that rule][prettier-linters].
+
+Example **.eslintrc.js**:
+
+You have `vue/html-indent` configured as `error` in `rules`, but it conflicts with Prettier.
+
+```diff
+module.exports = {
+  // ...
+  rules: {
+    // ...
+-    "vue/html-indent": "error",
+    // ...
+  },
+  // ...
+}
+```
+
 [prettier]: https://prettier.io/
+[prettier-linters]: https://prettier.io/docs/en/integrating-with-linters.html
 [eslint-config-prettier]: https://github.com/prettier/eslint-config-prettier
 
 ### Using JSX

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -266,7 +266,7 @@ See also: "[How to use a custom parser?](#how-to-use-a-custom-parser)" section.
 
 ### Conflict with [Prettier]
 
-If the [Prettier] conflicts with the shareable config provided by this plugin, use [eslint-config-prettier] to resolve it.
+Use [eslint-config-prettier] for [Prettier] not to conflict with the shareable config provided by this plugin.
 
 Example **.eslintrc.js**:
 
@@ -279,30 +279,9 @@ module.exports = {
     // ...
     'plugin:vue/vue3-recommended',
     // ...
-    "prettier",
-    "prettier/vue",
-    // "prettier/@typescript-eslint", // required if you are using @typescript-eslint.
-    // Other settings may be required depending on the plugin you are using. See the eslint-config-prettier documentation for more details.
+    "prettier"
+    // Make sure "prettier" is the last element in this list.
   ],
-  // ...
-}
-```
-
-If the [Prettier] conflicts with the rule you have set, turn off that rule.
-
-Example **.eslintrc.js**:
-
-When the `vue/html-indent` rule conflict with [Prettier].
-
-```diff
-module.exports = {
-  // ...
-  rules: {
-    // ...
--    "vue/html-indent": "error",
-+    "vue/html-indent": "off",
-    // ...
-  },
   // ...
 }
 ```


### PR DESCRIPTION
`prettier/vue`, `prettier/@typescript-eslint`, etc. have been removed in `eslint-config-prettier` v8.0.0.
They are needed no longer.
See https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

I've also removed the "If [Prettier] conflicts with the rule you have set, turn off that rule" part because that's exactly what `eslint-config-prettier` is for.