### PR TITLE
Update: allow more cases in `require-direct-export`

### DIFF
--- a/lib/rules/require-direct-export.js
+++ b/lib/rules/require-direct-export.js
@@ -55,6 +55,25 @@ module.exports = {
           // OK
           return
         }
+        if (node.type === 'CallExpression') {
+          const {
+            callee,
+            arguments: [firstArg]
+          } = node
+          if (firstArg && firstArg.type === 'ObjectExpression') {
+            if (
+              (callee.type === 'Identifier' &&
+                callee.name === 'defineComponent') ||
+              (callee.type === 'MemberExpression' &&
+                callee.object.type === 'Identifier' &&
+                callee.object.name === 'Vue' &&
+                callee.property.type === 'Identifier' &&
+                callee.property.name === 'extend')
+            ) {
+              return
+            }
+          }
+        }
         if (!disallowFunctional) {
           if (node.type === 'ArrowFunctionExpression') {
             if (node.body.type !== 'BlockStatement') {

--- a/tests/lib/rules/require-direct-export.js
+++ b/tests/lib/rules/require-direct-export.js
@@ -74,6 +74,20 @@ ruleTester.run('require-direct-export', rule, {
       import { h } from 'vue'
       export default props => h('div', props.msg)
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      import Vue from 'vue'
+      export default Vue.extend({})
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      import { defineComponent } from 'vue'
+      export default defineComponent({})
+      `
     }
   ],
 
@@ -223,6 +237,40 @@ ruleTester.run('require-direct-export', rule, {
       export default props => h('div', props.msg)
       `,
       options: [{ disallowFunctionalComponentFunction: true }],
+      errors: ['Expected the component literal to be directly exported.']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      import Vue from 'vue'
+      export default Vue.extend()
+      `,
+      errors: ['Expected the component literal to be directly exported.']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      import Vue from 'vue'
+      const A = {}
+      export default Vue.extend(A)
+      `,
+      errors: ['Expected the component literal to be directly exported.']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      import { defineComponent } from 'vue'
+      export default defineComponent()
+      `,
+      errors: ['Expected the component literal to be directly exported.']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      import { defineComponent } from 'vue'
+      const A = {}
+      export default defineComponent(A)
+      `,
       errors: ['Expected the component literal to be directly exported.']
     }
   ]


### PR DESCRIPTION
This PR allows two cases below with rule `require-direct-export` enabled:

```js
import Vue from 'vue'

export default Vue.extend({})
```

```js
import { defineComponent } from 'vue'

export default defineComponent({})
```

which will benefit TypeScript users.

Fixes #907