### PR TITLE
feat(max-attributes-per-line): singleline.allowFirstLine option

### DIFF
--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -57,7 +57,10 @@ There is a configurable number of attributes that are acceptable in one-line cas
 ```json
 {
   "vue/max-attributes-per-line": ["error", {
-    "singleline": 1,
+    "singleline": {
+      "max": 1,
+      "allowFirstLine": true
+    },      
     "multiline": {
       "max": 1,
       "allowFirstLine": false
@@ -66,7 +69,8 @@ There is a configurable number of attributes that are acceptable in one-line cas
 }
 ```
 
-- `singleline` (`number`) ... The number of maximum attributes per line when the opening tag is in a single line. Default is `1`.
+- `singleline.max` (`number`) ... The number of maximum attributes per line when the opening tag is in a single line. Default is `1`.
+- `singleline.allowFirstLine` (`boolean`) ... If `true`, it allows attributes on the same line as that tag name. Default is `true`.
 - `multiline.max` (`number`) ... The max number of attributes per line when the opening tag is in multiple lines. Default is `1`. This can be `{ multiline: 1 }` instead of `{ multiline: { max: 1 }}` if you don't configure `allowFirstLine` property.
 - `multiline.allowFirstLine` (`boolean`) ... If `true`, it allows attributes on the same line as that tag name. Default is `false`.
 
@@ -81,6 +85,24 @@ There is a configurable number of attributes that are acceptable in one-line cas
 
   <!-- ✗ BAD -->
   <MyComponent lorem="1" ipsum="2" dolor="3" sit="4" />
+</template>
+```
+
+</eslint-code-block>
+
+### `"singleline": 1, "allowFirstLine": false`
+
+<eslint-code-block fix :rules="{'vue/max-attributes-per-line': ['error', {singleline: { allowFirstLine: false }}]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <MyComponent
+    lorem="1"
+  />
+
+  <!-- ✗ BAD -->
+  <MyComponent lorem="1" />
 </template>
 ```
 

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -26,14 +26,14 @@ module.exports = {
             anyOf: [
               {
                 type: 'number',
-                minimum: 1
+                minimum: 0
               },
               {
                 type: 'object',
                 properties: {
                   max: {
                     type: 'number',
-                    minimum: 1
+                    minimum: 0
                   }
                 },
                 additionalProperties: false
@@ -121,7 +121,10 @@ module.exports = {
       if (options) {
         if (typeof options.singleline === 'number') {
           defaults.singleline = options.singleline
-        } else if (options.singleline && options.singleline.max) {
+        } else if (
+          options.singleline &&
+          typeof options.singleline.max === 'number'
+        ) {
           defaults.singleline = options.singleline.max
         }
 

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -26,14 +26,17 @@ module.exports = {
             anyOf: [
               {
                 type: 'number',
-                minimum: 0
+                minimum: 1
               },
               {
                 type: 'object',
                 properties: {
                   max: {
                     type: 'number',
-                    minimum: 0
+                    minimum: 1
+                  },
+                  allowFirstLine: {
+                    type: 'boolean'
                   }
                 },
                 additionalProperties: false
@@ -72,7 +75,8 @@ module.exports = {
     const configuration = parseOptions(context.options[0])
     const multilineMaximum = configuration.multiline
     const singlelinemMaximum = configuration.singleline
-    const canHaveFirstLine = configuration.allowFirstLine
+    const canHaveSinglelineFirstLine = configuration.singlelineAllowFirstLine
+    const canHaveMultilineFirstLine = configuration.multilineAllowFirstLine
     const template =
       context.parserServices.getTemplateBodyTokenStore &&
       context.parserServices.getTemplateBodyTokenStore()
@@ -83,16 +87,22 @@ module.exports = {
 
         if (!numberOfAttributes) return
 
-        if (
-          utils.isSingleLine(node) &&
-          numberOfAttributes > singlelinemMaximum
-        ) {
-          showErrors(node.attributes.slice(singlelinemMaximum))
+        if (utils.isSingleLine(node)) {
+          if (
+            !canHaveSinglelineFirstLine &&
+            node.attributes[0].loc.start.line === node.loc.start.line
+          ) {
+            showErrors([node.attributes[0]])
+          }
+
+          if (numberOfAttributes > singlelinemMaximum) {
+            showErrors(node.attributes.slice(singlelinemMaximum))
+          }
         }
 
         if (!utils.isSingleLine(node)) {
           if (
-            !canHaveFirstLine &&
+            !canHaveMultilineFirstLine &&
             node.attributes[0].loc.start.line === node.loc.start.line
           ) {
             showErrors([node.attributes[0]])
@@ -114,30 +124,36 @@ module.exports = {
     function parseOptions(options) {
       const defaults = {
         singleline: 1,
+        singlelineAllowFirstLine: true,
         multiline: 1,
-        allowFirstLine: false
+        multilineAllowFirstLine: false
       }
 
       if (options) {
         if (typeof options.singleline === 'number') {
           defaults.singleline = options.singleline
-        } else if (
-          options.singleline &&
-          typeof options.singleline.max === 'number'
-        ) {
-          defaults.singleline = options.singleline.max
+        } else if (typeof options.singleline === 'object') {
+          if (typeof options.singleline.max === 'number') {
+            defaults.singleline = options.singleline.max
+          }
+
+          if (typeof options.singleline.allowFirstLine === 'boolean') {
+            defaults.singlelineAllowFirstLine =
+              options.singleline.allowFirstLine
+          }
         }
 
         if (options.multiline) {
           if (typeof options.multiline === 'number') {
             defaults.multiline = options.multiline
           } else if (typeof options.multiline === 'object') {
-            if (options.multiline.max) {
+            if (typeof options.multiline.max === 'number') {
               defaults.multiline = options.multiline.max
             }
 
-            if (options.multiline.allowFirstLine) {
-              defaults.allowFirstLine = options.multiline.allowFirstLine
+            if (typeof options.multiline.allowFirstLine === 'boolean') {
+              defaults.multilineAllowFirstLine =
+                options.multiline.allowFirstLine
             }
           }
         }

--- a/tests/lib/rules/max-attributes-per-line.js
+++ b/tests/lib/rules/max-attributes-per-line.js
@@ -299,6 +299,19 @@ petname="Snoopy" extra="foo">
           line: 3
         }
       ]
+    },
+    {
+      code: `<template><component name="John Doe"></component></template>`,
+      options: [{ singleline: { max: 0 } }],
+      output: `<template><component
+name="John Doe"></component></template>`,
+      errors: [
+        {
+          message: "'name' should be on a new line.",
+          type: 'VAttribute',
+          line: 1
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/max-attributes-per-line.js
+++ b/tests/lib/rules/max-attributes-per-line.js
@@ -302,7 +302,7 @@ petname="Snoopy" extra="foo">
     },
     {
       code: `<template><component name="John Doe"></component></template>`,
-      options: [{ singleline: { max: 0 } }],
+      options: [{ singleline: { allowFirstLine: false } }],
       output: `<template><component
 name="John Doe"></component></template>`,
       errors: [


### PR DESCRIPTION
**What rule do you want to change?**
`max-attributes-per-line`

**Does this change cause the rule to produce more or fewer warnings?**
More

**How will the change be implemented? (New option, new default behavior, etc.)?**
Lower the minimum value on `singleline`/`singleline.max` to 0 on the schema.

Update:
Add a `singleline.allowFirstLine` option that defaults to `true`, but prevents single attributes from being on the same line if set to `false`.

**Please provide some example code that this change will affect:**
When setting `singleline.max = 0`, the following should be marked incorrect:

Update:
When setting `singleline.allowFirstLine = false`, the following should be marked incorrect:

```vue
<template>
	<component name="John Doe" />
</template>
```

**What does the rule currently do for this code?**
Currently, can't set `singleline` to 0 because of the schema validation. 

**What will the rule do after it's changed?**
Correct it to:
```vue
<template>
	<component
		name="John Doe"
	/>
</template>
```

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->

- This was working in prior versions of ESLint that did not enforce the JSON schema on options. But since upgrading ESLint, this appeared to be a regression. Since it's not a regression in this plugin, I labeled this as a feature request.

- This is style used by a large codebase I'm contributing to.
