### PR TITLE
New: Add `vue/no-invalid-model-keys` rule

### DIFF
--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -2,7 +2,7 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/no-invalid-model-keys
-description: require valid keys in model prop
+description: require valid keys in model option
 ---
 # vue/no-invalid-model-keys
 

--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -6,7 +6,7 @@ description: require valid keys in model prop
 ---
 # vue/no-invalid-model-keys
 
-> require valid keys in model prop
+> require valid keys in model option
 
 
 ## :book: Rule Details

--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -11,7 +11,7 @@ description: require valid keys in model prop
 
 ## :book: Rule Details
 
-This rule is aimed at preventing invalid keys in model property.
+This rule is aimed at preventing invalid keys in model option.
 
 <eslint-code-block :rules="{'vue/no-invalid-model-keys': ['error']}">
 ```vue

--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -8,7 +8,6 @@ description: require valid keys in model prop
 
 > require valid keys in model prop
 
-- :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/essential"`, `"plugin:vue/vue3-strongly-recommended"`, `"plugin:vue/strongly-recommended"`, `"plugin:vue/vue3-recommended"` and `"plugin:vue/recommended"`.
 
 ## :book: Rule Details
 

--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -96,9 +96,6 @@ export default {
 ```
 </eslint-code-block>
 
-## :rocket: Version
-
-This rule was introduced in eslint-plugin-vue v7.9.0
 
 ## :mag: Implementation
 

--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -1,0 +1,108 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-invalid-model-keys
+description: require valid keys in model prop
+since: v3.9.0
+---
+# vue/no-invalid-model-keys
+
+> require valid keys in model prop
+
+- :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/essential"`, `"plugin:vue/vue3-strongly-recommended"`, `"plugin:vue/strongly-recommended"`, `"plugin:vue/vue3-recommended"` and `"plugin:vue/recommended"`.
+
+## :book: Rule Details
+
+This rule is aimed at preventing invalid keys in model property.
+
+<eslint-code-block :rules="{'vue/no-invalid-model-keys': ['error']}">
+```vue
+<script>
+/* ✓ GOOD */
+export default {
+  model: {
+    prop: 'list',
+  }
+}
+</script>
+```
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-invalid-model-keys': ['error']}">
+```vue
+<script>
+/* ✓ GOOD */
+export default {
+  model: {
+    event: 'update'
+  }
+}
+</script>
+```
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-invalid-model-keys': ['error']}">
+```vue
+<script>
+/* ✓ GOOD */
+export default {
+  model: {
+    prop: 'list',
+    event: 'update'
+  }
+}
+</script>
+```
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-invalid-model-keys': ['error']}">
+```vue
+<script>
+/* ✗ BAD */
+export default {
+  model: {
+    prop: 'list',
+    events: 'update'
+  }
+}
+</script>
+```
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-invalid-model-keys': ['error']}">
+```vue
+<script>
+/* ✗ BAD */
+export default {
+  model: {
+    props: 'list',
+    events: 'update'
+  }
+}
+</script>
+```
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-invalid-model-keys': ['error']}">
+```vue
+<script>
+/* ✗ BAD */
+export default {
+  model: {
+    name: 'checked',
+    props: 'list',
+    event: 'update'
+  }
+}
+</script>
+```
+</eslint-code-block>
+
+## :rocket: Version
+
+This rule was introduced in eslint-plugin-vue v7.9.0
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-invalid-model-keys.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-invalid-model-keys.js)

--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -3,7 +3,6 @@ pageClass: rule-details
 sidebarDepth: 0
 title: vue/no-invalid-model-keys
 description: require valid keys in model prop
-since: v3.9.0
 ---
 # vue/no-invalid-model-keys
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,6 +81,7 @@ module.exports = {
     'no-empty-component-block': require('./rules/no-empty-component-block'),
     'no-empty-pattern': require('./rules/no-empty-pattern'),
     'no-extra-parens': require('./rules/no-extra-parens'),
+    'no-invalid-model-keys': require('./rules/no-invalid-model-keys'),
     'no-irregular-whitespace': require('./rules/no-irregular-whitespace'),
     'no-lifecycle-after-await': require('./rules/no-lifecycle-after-await'),
     'no-lone-template': require('./rules/no-lone-template'),

--- a/lib/rules/no-invalid-model-keys.js
+++ b/lib/rules/no-invalid-model-keys.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Requires valid keys in model property.
+ * @fileoverview Requires valid keys in model option.
  * @author Alex Sokolov
  */
 'use strict'

--- a/lib/rules/no-invalid-model-keys.js
+++ b/lib/rules/no-invalid-model-keys.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Requires valid keys in model property.
+ * @author Alex Sokolov
+ */
+'use strict'
+
+const utils = require('../utils')
+
+/**
+ * @typedef {import('../utils').GroupName} GroupName
+ */
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+/** @type {GroupName[]} */
+const GROUP_NAMES = ['model']
+
+const VALID_MODEL_KEYS = ['prop', 'event']
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require valid keys in model prop',
+      categories: ['vue3-recommended', 'recommended'],
+      url: 'https://eslint.vuejs.org/rules/no-invalid-model-keys.html'
+    },
+    fixable: null,
+    schema: []
+  },
+  /** @param {RuleContext} context */
+  create(context) {
+    const groups = new Set(GROUP_NAMES)
+
+    // ----------------------------------------------------------------------
+    // Public
+    // ----------------------------------------------------------------------
+
+    return utils.executeOnVue(context, (obj) => {
+      const properties = utils.iterateProperties(obj, groups)
+
+      for (const o of properties) {
+        if (VALID_MODEL_KEYS.indexOf(o.name) === -1) {
+          context.report({
+            node: o.node,
+            message: "Invalid key '{{name}}' in model prop.",
+            data: {
+              name: o.name
+            }
+          })
+        }
+      }
+    })
+  }
+}

--- a/lib/rules/no-invalid-model-keys.js
+++ b/lib/rules/no-invalid-model-keys.js
@@ -23,7 +23,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'require valid keys in model option',
-      categories: ['vue3-recommended', 'recommended'],
+      categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-invalid-model-keys.html'
     },
     fixable: null,

--- a/lib/rules/no-invalid-model-keys.js
+++ b/lib/rules/no-invalid-model-keys.js
@@ -44,7 +44,7 @@ module.exports = {
         if (VALID_MODEL_KEYS.indexOf(o.name) === -1) {
           context.report({
             node: o.node,
-            message: "Invalid key '{{name}}' in model prop.",
+            message: "Invalid key '{{name}}' in model option.",
             data: {
               name: o.name
             }

--- a/lib/rules/no-invalid-model-keys.js
+++ b/lib/rules/no-invalid-model-keys.js
@@ -22,7 +22,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'require valid keys in model prop',
+      description: 'require valid keys in model option',
       categories: ['vue3-recommended', 'recommended'],
       url: 'https://eslint.vuejs.org/rules/no-invalid-model-keys.html'
     },

--- a/tests/lib/rules/no-invalid-model-keys.js
+++ b/tests/lib/rules/no-invalid-model-keys.js
@@ -126,11 +126,6 @@ ruleTester.run('no-invalid-model-keys', rule, {
             prop: 'checked',
             props: 'list',
             event: 'update'
-          },
-          data () {
-            return {
-              dat: null
-            }
           }
         }
       `,

--- a/tests/lib/rules/no-invalid-model-keys.js
+++ b/tests/lib/rules/no-invalid-model-keys.js
@@ -66,7 +66,7 @@ ruleTester.run('no-invalid-model-keys', rule, {
           }
         }
       `,
-      errors: ["Invalid key 'props' in model prop."]
+      errors: ["Invalid key 'props' in model option."]
     },
     {
       filename: 'test.vue',
@@ -77,7 +77,7 @@ ruleTester.run('no-invalid-model-keys', rule, {
           }
         }
       `,
-      errors: ["Invalid key 'events' in model prop."]
+      errors: ["Invalid key 'events' in model option."]
     },
     {
       filename: 'test.vue',
@@ -89,7 +89,7 @@ ruleTester.run('no-invalid-model-keys', rule, {
           }
         }
       `,
-      errors: ["Invalid key 'props' in model prop."]
+      errors: ["Invalid key 'props' in model option."]
     },
     {
       filename: 'test.vue',
@@ -101,7 +101,7 @@ ruleTester.run('no-invalid-model-keys', rule, {
           }
         }
       `,
-      errors: ["Invalid key 'events' in model prop."]
+      errors: ["Invalid key 'events' in model option."]
     },
     {
       filename: 'test.vue',
@@ -114,8 +114,8 @@ ruleTester.run('no-invalid-model-keys', rule, {
         }
       `,
       errors: [
-        "Invalid key 'props' in model prop.",
-        "Invalid key 'events' in model prop."
+        "Invalid key 'props' in model option.",
+        "Invalid key 'events' in model option."
       ]
     },
     {
@@ -129,7 +129,7 @@ ruleTester.run('no-invalid-model-keys', rule, {
           }
         }
       `,
-      errors: ["Invalid key 'props' in model prop."]
+      errors: ["Invalid key 'props' in model option."]
     },
     {
       filename: 'test.vue',
@@ -143,8 +143,8 @@ ruleTester.run('no-invalid-model-keys', rule, {
         }
       `,
       errors: [
-        "Invalid key 'name' in model prop.",
-        "Invalid key 'props' in model prop."
+        "Invalid key 'name' in model option.",
+        "Invalid key 'props' in model option."
       ]
     }
   ]

--- a/tests/lib/rules/no-invalid-model-keys.js
+++ b/tests/lib/rules/no-invalid-model-keys.js
@@ -1,0 +1,156 @@
+/**
+ * @fileoverview Prevents invalid keys in model property.
+ * @author Alex Sokolov
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-invalid-model-keys')
+const RuleTester = require('eslint').RuleTester
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  }
+})
+ruleTester.run('no-invalid-model-keys', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            prop: 'list'
+          }
+        }
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            event: 'update'
+          }
+        }
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            prop: 'list',
+            event: 'update'
+          }
+        }
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            props: 'list'
+          }
+        }
+      `,
+      errors: ["Invalid key 'props' in model prop."]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            events: 'update'
+          }
+        }
+      `,
+      errors: ["Invalid key 'events' in model prop."]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            props: 'list',
+            event: 'update'
+          }
+        }
+      `,
+      errors: ["Invalid key 'props' in model prop."]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            prop: 'list',
+            events: 'update'
+          }
+        }
+      `,
+      errors: ["Invalid key 'events' in model prop."]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            props: 'list',
+            events: 'update'
+          }
+        }
+      `,
+      errors: [
+        "Invalid key 'props' in model prop.",
+        "Invalid key 'events' in model prop."
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            prop: 'checked',
+            props: 'list',
+            event: 'update'
+          },
+          data () {
+            return {
+              dat: null
+            }
+          }
+        }
+      `,
+      errors: ["Invalid key 'props' in model prop."]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          model: {
+            name: 'checked',
+            props: 'list',
+            event: 'update'
+          }
+        }
+      `,
+      errors: [
+        "Invalid key 'name' in model prop.",
+        "Invalid key 'props' in model prop."
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/no-invalid-model-keys.js
+++ b/tests/lib/rules/no-invalid-model-keys.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Prevents invalid keys in model property.
+ * @fileoverview Prevents invalid keys in model option.
  * @author Alex Sokolov
  */
 'use strict'


### PR DESCRIPTION
This PR adds the rule `vue/no-invalid-model-keys` which check `model` prop keys

REF: https://github.com/vuejs/eslint-plugin-vue/issues/824