### PR TITLE
Fix false negative with require-valid-default-prop on props with type assertion

### DIFF
--- a/lib/rules/require-valid-default-prop.js
+++ b/lib/rules/require-valid-default-prop.js
@@ -49,10 +49,11 @@ function getPropertyNode(obj, name) {
 }
 
 /**
- * @param {Expression} node
+ * @param {Expression} targetNode
  * @returns {string[]}
  */
-function getTypes(node) {
+function getTypes(targetNode) {
+  const node = utils.skipTSAsExpression(targetNode)
   if (node.type === 'Identifier') {
     return [node.name]
   } else if (node.type === 'ArrayExpression') {

--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -207,6 +207,51 @@ ruleTester.run('require-valid-default-prop', rule, {
         }
       }`,
       parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `export default Vue.extend({
+          props: {
+            foo: {
+              type: Array as PropType<string[]>,
+              default: () => []
+            }
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: errorMessage('function')
+    },
+    {
+      filename: 'test.vue',
+      code: `export default Vue.extend({
+          props: {
+            foo: {
+              type: Object as PropType<{ [key: number]: number }>,
+              default: () => {}
+            }
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: errorMessage('function')
+    },
+    {
+      filename: 'test.vue',
+      code: `export default Vue.extend({
+          props: {
+            foo: {
+              type: Function as PropType<() => number>,
+              default: () => 10
+            }
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: errorMessage('function')
     }
   ],
 
@@ -781,6 +826,51 @@ ruleTester.run('require-valid-default-prop', rule, {
       }`,
       parserOptions,
       errors: errorMessage('string')
+    },
+    {
+      filename: 'test.vue',
+      code: `export default Vue.extend({
+          props: {
+            foo: {
+              type: Array as PropType<string[]>,
+              default: []
+            }
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: errorMessage('function')
+    },
+    {
+      filename: 'test.vue',
+      code: `export default Vue.extend({
+          props: {
+            foo: {
+              type: Object as PropType<{ [key: number]: number }>,
+              default: {}
+            }
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: errorMessage('function')
+    },
+    {
+      filename: 'test.vue',
+      code: `export default Vue.extend({
+          props: {
+            foo: {
+              type: Function as PropType<() => number>,
+              default: 10
+            }
+          }
+        });
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('@typescript-eslint/parser'),
+      errors: errorMessage('function')
     }
   ]
 })


### PR DESCRIPTION
fix #1468.

This PR ensure that eslint-plugin-vue reports `Type of thye default value for 'foo' prop must be function` in following case.
(It works the same for `Object` or `Function`.)

```vue
<script lang="ts">
import Vue from "vue";
import { PropType } from "vue";

export default Vue.extend({
  props: {
    foo: {
      type: Array as PropType<string[]>,
      default: [],
    },
  },
});
</script>
```

Note: In following case, type cheking based on annotated type of the return value of the default function will not work.

```vue
<script lang="ts">
import Vue from "vue";
import { PropType } from "vue";

export default Vue.extend({
  props: {
    foo: {
      type: Array as PropType<string[]>,
      default: (): number[] => [], // The function should return array of string, but this PR can't check it.
    },
  },
});
</script>
```