### PR TITLE
fix: detect prop usage in toRef

### DIFF
--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -1006,6 +1006,26 @@ tester.run('no-unused-properties', rule, {
       </script>`,
       options: [{ groups: ['props', 'setup'] }]
     },
+    // prop usage in toRef()
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        import { toRef } from 'vue'
+
+        export default {
+          props: ['testId'],
+
+          setup(props) {
+            const testIdRef = toRef(props, 'testId');
+
+            // do something with testIdRef
+            console.log(testIdRef);
+          }
+        }
+      </script>`,
+      options: [{ groups: ['props'] }]
+    },
 
     // sparse array
     {


### PR DESCRIPTION
When using a prop in `toRef`, it is wrongly considered unused. This is due to the call signature of `toRef`:

```js
const propAsRef = toRef(props, 'propName');
```

This is a common use-case suggested in the Vue documentation. See https://v3.vuejs.org/api/refs-api.html#toref

While I'm not sure how viable the detection of this usage is, I would like to try and implement it.
Maybe you can give me some pointers.