### PR TITLE
update `no-deprecated-destroyed-lifecycle` rule

### DIFF
--- a/lib/rules/no-deprecated-destroyed-lifecycle.js
+++ b/lib/rules/no-deprecated-destroyed-lifecycle.js
@@ -23,15 +23,13 @@ module.exports = {
       categories: ['vue3-essential'],
       url: 'https://eslint.vuejs.org/rules/no-deprecated-destroyed-lifecycle.html'
     },
-    fixable: null,
+    fixable: 'code',
     schema: [],
     messages: {
       deprecatedDestroyed:
         'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
       deprecatedBeforeDestroy:
-        'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
-      insteadUnmounted: 'Instead, change to `unmounted`.',
-      insteadBeforeUnmount: 'Instead, change to `beforeUnmount`.'
+        'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.'
     }
   },
   /** @param {RuleContext} context */
@@ -43,15 +41,9 @@ module.exports = {
         context.report({
           node: destroyed.key,
           messageId: 'deprecatedDestroyed',
-          // I don't know if they have exactly the same function, so don't do autofix.
-          suggest: [
-            {
-              messageId: 'insteadUnmounted',
-              fix(fixer) {
-                return fix(fixer, destroyed, 'unmounted')
-              }
-            }
-          ]
+          fix(fixer) {
+            return fix(fixer, destroyed, 'unmounted')
+          }
         })
       }
 
@@ -60,15 +52,9 @@ module.exports = {
         context.report({
           node: beforeDestroy.key,
           messageId: 'deprecatedBeforeDestroy',
-          // I don't know if they have exactly the same function, so don't do autofix.
-          suggest: [
-            {
-              messageId: 'insteadBeforeUnmount',
-              fix(fixer) {
-                return fix(fixer, beforeDestroy, 'beforeUnmount')
-              }
-            }
-          ]
+          fix(fixer) {
+            return fix(fixer, beforeDestroy, 'beforeUnmount')
+          }
         })
       }
 

--- a/tests/lib/rules/no-deprecated-destroyed-lifecycle.js
+++ b/tests/lib/rules/no-deprecated-destroyed-lifecycle.js
@@ -111,42 +111,24 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
       }
       </script>
       `,
-      errors: [
-        {
-          message:
-            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
-          line: 4,
-          suggestions: [
-            {
-              desc: 'Instead, change to `beforeUnmount`.',
-              output: `
+      output: `
       <script>
       export default {
         beforeUnmount () {},
-        destroyed () {},
-      }
-      </script>
-      `
-            }
-          ]
-        },
-        {
-          message:
-            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
-          line: 5,
-          suggestions: [
-            {
-              desc: 'Instead, change to `unmounted`.',
-              output: `
-      <script>
-      export default {
-        beforeDestroy () {},
         unmounted () {},
       }
       </script>
-      `
-            }
-          ]
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 4
+        },
+        {
+          message:
+            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+          line: 5
         }
       ]
     },
@@ -160,42 +142,24 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
       }
       </script>
       `,
+      output: `
+      <script>
+      export default {
+        beforeUnmount:beforeDestroy,
+        unmounted:destroyed,
+      }
+      </script>
+      `,
       errors: [
         {
           message:
             'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
-          line: 4,
-          suggestions: [
-            {
-              desc: 'Instead, change to `beforeUnmount`.',
-              output: `
-      <script>
-      export default {
-        beforeUnmount:beforeDestroy,
-        destroyed,
-      }
-      </script>
-      `
-            }
-          ]
+          line: 4
         },
         {
           message:
             'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
-          line: 5,
-          suggestions: [
-            {
-              desc: 'Instead, change to `unmounted`.',
-              output: `
-      <script>
-      export default {
-        beforeDestroy,
-        unmounted:destroyed,
-      }
-      </script>
-      `
-            }
-          ]
+          line: 5
         }
       ]
     },
@@ -218,15 +182,7 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
       }
       </script>
       `,
-      errors: [
-        {
-          message:
-            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
-          line: 12,
-          suggestions: [
-            {
-              desc: 'Instead, change to `beforeUnmount`.',
-              output: `
+      output: `
       <script>
       export default {
         beforeCreate,
@@ -238,40 +194,21 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
         activated,
         deactivated,
         beforeUnmount:beforeDestroy,
-        destroyed,
-        errorCaptured,
-      }
-      </script>
-      `
-            }
-          ]
-        },
-        {
-          message:
-            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
-          line: 13,
-          suggestions: [
-            {
-              desc: 'Instead, change to `unmounted`.',
-              output: `
-      <script>
-      export default {
-        beforeCreate,
-        created,
-        beforeMount,
-        mounted,
-        beforeUpdate,
-        updated,
-        activated,
-        deactivated,
-        beforeDestroy,
         unmounted:destroyed,
         errorCaptured,
       }
       </script>
-      `
-            }
-          ]
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 12
+        },
+        {
+          message:
+            'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
+          line: 13
         }
       ]
     },
@@ -285,42 +222,24 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
       }
       </script>
       `,
-      errors: [
-        {
-          message:
-            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
-          line: 4,
-          suggestions: [
-            {
-              desc: 'Instead, change to `beforeUnmount`.',
-              output: `
+      output: `
       <script>
       export default {
         ['beforeUnmount']() {},
-        ['destroyed']() {},
+        ['unmounted']() {},
       }
       </script>
-      `
-            }
-          ]
+      `,
+      errors: [
+        {
+          message:
+            'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
+          line: 4
         },
         {
           message:
             'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
-          line: 5,
-          suggestions: [
-            {
-              desc: 'Instead, change to `unmounted`.',
-              output: `
-      <script>
-      export default {
-        ['beforeDestroy']() {},
-        ['unmounted']() {},
-      }
-      </script>
-      `
-            }
-          ]
+          line: 5
         }
       ]
     },
@@ -334,42 +253,24 @@ ruleTester.run('no-deprecated-destroyed-lifecycle', rule, {
       }
       </script>
       `,
+      output: `
+      <script>
+      export default {
+        [\`beforeUnmount\`]() {},
+        [\`unmounted\`]() {},
+      }
+      </script>
+      `,
       errors: [
         {
           message:
             'The `beforeDestroy` lifecycle hook is deprecated. Use `beforeUnmount` instead.',
-          line: 4,
-          suggestions: [
-            {
-              desc: 'Instead, change to `beforeUnmount`.',
-              output: `
-      <script>
-      export default {
-        [\`beforeUnmount\`]() {},
-        [\`destroyed\`]() {},
-      }
-      </script>
-      `
-            }
-          ]
+          line: 4
         },
         {
           message:
             'The `destroyed` lifecycle hook is deprecated. Use `unmounted` instead.',
-          line: 5,
-          suggestions: [
-            {
-              desc: 'Instead, change to `unmounted`.',
-              output: `
-      <script>
-      export default {
-        [\`beforeDestroy\`]() {},
-        [\`unmounted\`]() {},
-      }
-      </script>
-      `
-            }
-          ]
+          line: 5
         }
       ]
     }


### PR DESCRIPTION
in Vue 3.x:
- `destroyed` lifecycle option has been renamed to `unmounted`
- `beforeDestroy` lifecycle option has been renamed to `beforeUnmount`
see in https://v3.vuejs.org/guide/migration/introduction.html#other-minor-changes.

so we should fix them instead of giving suggestion