### PR TITLE
Fix rules index for `require-emit-validator`

### DIFF
--- a/lib/rules/require-emit-validator.js
+++ b/lib/rules/require-emit-validator.js
@@ -20,7 +20,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'require type definitions in emits',
-      categories: [],
+      categories: undefined,
       url: 'https://eslint.vuejs.org/rules/require-emit-validator.html'
     },
     fixable: null,


### PR DESCRIPTION
This PR fixes rule `require-emit-validator` doesn't appear at [Available rules](https://eslint.vuejs.org/rules/) page.