### PR TITLE
docs: remove autofix info from vue/eqeqeq

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -350,7 +350,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/comma-style](./comma-style.md) | enforce consistent comma style | :wrench: |
 | [vue/dot-location](./dot-location.md) | enforce consistent newlines before and after dots | :wrench: |
 | [vue/dot-notation](./dot-notation.md) | enforce dot notation whenever possible | :wrench: |
-| [vue/eqeqeq](./eqeqeq.md) | require the use of `===` and `!==` | :wrench: |
+| [vue/eqeqeq](./eqeqeq.md) | require the use of `===` and `!==` |  |
 | [vue/func-call-spacing](./func-call-spacing.md) | require or disallow spacing between function identifiers and their invocations | :wrench: |
 | [vue/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in object literal properties | :wrench: |
 | [vue/keyword-spacing](./keyword-spacing.md) | enforce consistent spacing before and after keywords | :wrench: |

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -9,8 +9,6 @@ since: v5.2.0
 
 > require the use of `===` and `!==`
 
-- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
-
 This rule is the same rule as core [eqeqeq] rule but it applies to the expressions in `<template>`.
 
 ## :books: Further Reading


### PR DESCRIPTION
`vue/eqeqeq` is marked as autofixable, while it is not.
- [ESLint eqeqeq document](https://eslint.org/docs/2.0.0/rules/eqeqeq)
  - there is no `autofix` phrase
- [a thread related to this issue](https://github.com/eslint/eslint/issues/4578)
  - they have removed autofix from eqeqeq in 2015