### PR TITLE
Fix false positives for trailing comma with import in `vue/script-indent` rule

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -1498,8 +1498,11 @@ module.exports.defineVisitor = function create(
       }
       if (namedSpecifiers.length) {
         const leftBrace = tokenStore.getTokenBefore(namedSpecifiers[0])
-        const rightBrace = tokenStore.getTokenAfter(
-          namedSpecifiers[namedSpecifiers.length - 1]
+        const rightBrace = /** @type {Token} */ (
+          tokenStore.getTokenAfter(
+            namedSpecifiers[namedSpecifiers.length - 1],
+            isClosingBraceToken
+          )
         )
         processNodeList(namedSpecifiers, leftBrace, rightBrace, 1)
         for (const token of tokenStore.getTokensBetween(

--- a/tests/fixtures/script-indent/import-declaration-11.vue
+++ b/tests/fixtures/script-indent/import-declaration-11.vue
@@ -1,0 +1,7 @@
+<!--{ "options": [4, { "baseIndent": 1, "switchCase": 1 } ] }-->
+<script>
+    import {
+        computed, defineComponent, PropType, ref, watch,
+    } from '@vue/composition-api';
+</script>
+<!-- https://github.com/vuejs/eslint-plugin-vue/issues/1524 -->


### PR DESCRIPTION


fixes #1524