### PR TITLE
Update `vue/require-prop-types` rule to support `<script setup>`

### DIFF
--- a/lib/rules/require-prop-types.js
+++ b/lib/rules/require-prop-types.js
@@ -92,12 +92,24 @@ module.exports = {
     // Public
     // ----------------------------------------------------------------------
 
-    return utils.executeOnVue(context, (obj) => {
-      const props = utils.getComponentProps(obj)
+    return utils.compositingVisitors(
+      utils.defineScriptSetupVisitor(context, {
+        onDefinePropsEnter(_node, props) {
+          for (const prop of props) {
+            if (prop.type === 'type') {
+              continue
+            }
+            checkProperty(prop)
+          }
+        }
+      }),
+      utils.executeOnVue(context, (obj) => {
+        const props = utils.getComponentProps(obj)
 
-      for (const prop of props) {
-        checkProperty(prop)
-      }
-    })
+        for (const prop of props) {
+          checkProperty(prop)
+        }
+      })
+    )
   }
 }

--- a/tests/lib/rules/require-prop-types.js
+++ b/tests/lib/rules/require-prop-types.js
@@ -158,6 +158,32 @@ ruleTester.run('require-prop-types', rule, {
       `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser')
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps({
+        foo: String
+      })
+      </script>
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('vue-eslint-parser')
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      defineProps<{foo:string}>()
+      </script>
+      `,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+        parser: require.resolve('@typescript-eslint/parser')
+      },
+      parser: require.resolve('vue-eslint-parser')
     }
   ],
 
@@ -303,6 +329,40 @@ ruleTester.run('require-prop-types', rule, {
         {
           message: 'Prop "foo" should define at least its type.',
           line: 4
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps({
+        foo: {}
+      })
+      </script>
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('vue-eslint-parser'),
+      errors: [
+        {
+          message: 'Prop "foo" should define at least its type.',
+          line: 4
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps(['foo'])
+      </script>
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      parser: require.resolve('vue-eslint-parser'),
+      errors: [
+        {
+          message: 'Prop "foo" should define at least its type.',
+          line: 3
         }
       ]
     }


### PR DESCRIPTION
Related to #1248