### PR TITLE
Update `vue/no-unregistered-components` rule to support `<script setup>`

### DIFF
--- a/lib/rules/no-unregistered-components.js
+++ b/lib/rules/no-unregistered-components.js
@@ -61,6 +61,9 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
+    if (utils.isScriptSetup(context)) {
+      return {}
+    }
     const options = context.options[0] || {}
     /** @type {string[]} */
     const ignorePatterns = options.ignorePatterns || []

--- a/tests/lib/rules/no-unregistered-components.js
+++ b/tests/lib/rules/no-unregistered-components.js
@@ -490,6 +490,17 @@ tester.run('no-unregistered-components', rule, {
         }
         </script>
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <TheModal />
+      </template>
+
+      <script setup>
+      import TheModal from 'foo'
+      </script>`
     }
   ],
   invalid: [


### PR DESCRIPTION
Related to #1248