### PR TITLE
Update `vue/require-name-property` rule to support `<script setup>`

### DIFF
--- a/lib/rules/require-name-property.js
+++ b/lib/rules/require-name-property.js
@@ -32,6 +32,9 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
+    if (utils.isScriptSetup(context)) {
+      return {}
+    }
     return utils.executeOnVue(context, (component, type) => {
       if (type === 'definition') {
         const defType = getVueComponentDefinitionType(component)

--- a/tests/lib/rules/require-name-property.js
+++ b/tests/lib/rules/require-name-property.js
@@ -51,6 +51,19 @@ ruleTester.run('require-name-property', rule, {
         })
       `,
       parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+      }
+      </script>
+      <script setup>
+      </script>
+      `,
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions
     }
   ],
 


### PR DESCRIPTION
Related to #1248