### PR TITLE
Fix false positives for call expression in `vue/no-mutating-props` rule.

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1706,7 +1706,7 @@ module.exports = {
           const callName = getStaticPropertyName(mem)
           if (
             callName &&
-            /^push|pop|shift|unshift|reverse|splice|sort|copyWithin|fill$/u.exec(
+            /^(?:push|pop|shift|unshift|reverse|splice|sort|copyWithin|fill)$/u.exec(
               callName
             )
           ) {

--- a/tests/lib/rules/no-mutating-props.js
+++ b/tests/lib/rules/no-mutating-props.js
@@ -318,6 +318,19 @@ ruleTester.run('no-mutating-props', rule, {
         value.value++
         </script>
       `
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/1579
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          props: ['prop'],
+          setup(props) {
+            props.prop.sortAscending()
+          }
+        }
+      </script>`
     }
   ],
 


### PR DESCRIPTION
fixes #1579 