### PR TITLE
Update `vue/no-restricted-v-bind` and `vue/valid-v-bind` rules to support `attr` modifier.

### DIFF
--- a/lib/rules/no-restricted-v-bind.js
+++ b/lib/rules/no-restricted-v-bind.js
@@ -113,7 +113,7 @@ module.exports = {
                 type: 'array',
                 items: {
                   type: 'string',
-                  enum: ['prop', 'camel', 'sync']
+                  enum: ['prop', 'camel', 'sync', 'attr']
                 },
                 uniqueItems: true
               },

--- a/lib/rules/valid-v-bind.js
+++ b/lib/rules/valid-v-bind.js
@@ -15,7 +15,7 @@ const utils = require('../utils')
 // Helpers
 // ------------------------------------------------------------------------------
 
-const VALID_MODIFIERS = new Set(['prop', 'camel', 'sync'])
+const VALID_MODIFIERS = new Set(['prop', 'camel', 'sync', 'attr'])
 
 // ------------------------------------------------------------------------------
 // Rule Definition

--- a/tests/lib/rules/no-restricted-v-bind.js
+++ b/tests/lib/rules/no-restricted-v-bind.js
@@ -147,6 +147,13 @@ tester.run('no-restricted-v-bind', rule, {
       </template>`,
       options: [{ argument: 'foo', message: 'foo' }],
       errors: ['foo']
+    },
+
+    {
+      filename: 'test.vue',
+      code: '<template><div :foo.attr="foo" /><div :bar.attr="foo" /></template>',
+      options: [{ argument: 'foo', modifiers: ['attr'] }],
+      errors: ['Using `:foo.attr` is not allowed.']
     }
   ]
 })

--- a/tests/lib/rules/valid-v-bind.js
+++ b/tests/lib/rules/valid-v-bind.js
@@ -73,6 +73,10 @@ tester.run('valid-v-bind', rule, {
     },
     {
       filename: 'test.vue',
+      code: "<template><div :aaa.attr='bbb'></div></template>"
+    },
+    {
+      filename: 'test.vue',
       code: "<template><input v-bind='$attrs' /></template>"
     },
     // parsing error


### PR DESCRIPTION
This PR update rules to support the `attr` modifier.

`attr` modifier that will be added in Vue 3.2.
See also https://github.com/vuejs/docs/blob/3.2/src/api/directives.md#v-bind