### PR TITLE
docs: fix typo in rule example

### DIFF
--- a/docs/rules/no-restricted-class.md
+++ b/docs/rules/no-restricted-class.md
@@ -20,7 +20,7 @@ in the rule configuration.
 
 ```json
 {
-  "vue/no-restricted-props": ["error", "forbidden", "forbidden-two", "forbidden-three"]
+  "vue/no-restricted-class": ["error", "forbidden", "forbidden-two", "forbidden-three"]
 }
 ```
 


### PR DESCRIPTION
Doc template was copied from another rule
overlooked renaming one entry