### PR TITLE
Fix false positives for vars inside functions in `vue/valid-define-emits` and `vue/valid-define-props` rules

### DIFF
--- a/lib/rules/valid-define-emits.js
+++ b/lib/rules/valid-define-emits.js
@@ -70,8 +70,8 @@ module.exports = {
           }
         },
         Identifier(node) {
-          for (const def of emitsDefExpressions) {
-            if (utils.inRange(def.range, node)) {
+          for (const defineEmits of emitsDefExpressions) {
+            if (utils.inRange(defineEmits.range, node)) {
               const variable = findVariable(context.getScope(), node)
               if (
                 variable &&
@@ -79,8 +79,10 @@ module.exports = {
               ) {
                 if (
                   variable.defs.length &&
-                  variable.defs.every((def) =>
-                    utils.inRange(scriptSetup.range, def.name)
+                  variable.defs.every(
+                    (def) =>
+                      utils.inRange(scriptSetup.range, def.name) &&
+                      !utils.inRange(defineEmits.range, def.name)
                   )
                 ) {
                   //`defineEmits` are referencing locally declared variables.

--- a/lib/rules/valid-define-props.js
+++ b/lib/rules/valid-define-props.js
@@ -71,8 +71,8 @@ module.exports = {
           }
         },
         Identifier(node) {
-          for (const def of propsDefExpressions) {
-            if (utils.inRange(def.range, node)) {
+          for (const defineProps of propsDefExpressions) {
+            if (utils.inRange(defineProps.range, node)) {
               const variable = findVariable(context.getScope(), node)
               if (
                 variable &&
@@ -80,8 +80,10 @@ module.exports = {
               ) {
                 if (
                   variable.defs.length &&
-                  variable.defs.every((def) =>
-                    utils.inRange(scriptSetup.range, def.name)
+                  variable.defs.every(
+                    (def) =>
+                      utils.inRange(scriptSetup.range, def.name) &&
+                      !utils.inRange(defineProps.range, def.name)
                   )
                 ) {
                   //`defineProps` are referencing locally declared variables.

--- a/tests/lib/rules/valid-define-emits.js
+++ b/tests/lib/rules/valid-define-emits.js
@@ -61,6 +61,18 @@ tester.run('valid-define-emits', rule, {
         defineEmits(def)
       </script>
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+        defineEmits({
+          notify (payload) {
+            return typeof payload === 'string'
+          }
+        })
+      </script>
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/valid-define-props.js
+++ b/tests/lib/rules/valid-define-props.js
@@ -61,6 +61,21 @@ tester.run('valid-define-props', rule, {
         defineProps(def)
       </script>
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+        defineProps({
+          addFunction: {
+            type: Function,
+            default (a, b) {
+              return a + b
+            }
+          }
+        })
+      </script>
+      `
     }
   ],
   invalid: [


### PR DESCRIPTION
fixes #1651