### PR TITLE
Fix false positives for non-vue file in `vue/multi-word-component-names` rule

### DIFF
--- a/tests/lib/rules/multi-word-component-names.js
+++ b/tests/lib/rules/multi-word-component-names.js
@@ -169,6 +169,35 @@ tester.run('multi-word-component-names', rule, {
       }
       </script>
       `
+    },
+    {
+      filename: 'test.js',
+      code: `
+      new Vue({})
+      `
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/1670
+      filename: 'main.ts',
+      code: `
+      import Vue from 'vue'
+      import VueCompositionAPI, { h } from '@vue/composition-api'
+      import i18n from '@/i18n'
+      import router from '@/router'
+      import store from '@/store'
+      // ...
+
+      Vue.use(VueCompositionAPI)
+
+      new Vue({
+          i18n,
+          router,
+          store,
+          setup() {
+              return () => h(App)
+          },
+      }).$mount('#app')
+      `
     }
   ],
   invalid: [


### PR DESCRIPTION
fixes #1670

It was already fixed in #1681, but I will add a test case in this PR to confirm that it has been fixed.

