### PR TITLE
feat: add `setup-compiler-macros` environment

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -358,25 +358,20 @@ module.exports = {
 }
 ```
 
-#### Compiler macros such as `defineProps` and `defineEmits` are warned by `no-undef` rule
+#### Compiler macros such as `defineProps` and `defineEmits` generate `no-undef` warnings
 
-You need to define [global variables](https://eslint.org/docs/user-guide/configuring/language-options#using-configuration-files-1) in your ESLint configuration file.  
-If you don't want to define global variables, use `import { defineProps, defineEmits } from 'vue'`.
+You need to enable the compiler macros environment in your ESLint configuration file.
+If you don't want to expose these variables globally, you can use `/* global defineProps, defineEmits */` instead.
 
 Example **.eslintrc.js**:
 
 ```js
 module.exports = {
-  globals: {
-    defineProps: "readonly",
-    defineEmits: "readonly",
-    defineExpose: "readonly",
-    withDefaults: "readonly"
+  env: {
+    'vue/setup-compiler-macros': true
   }
 }
 ```
-
-See also [ESLint - Specifying Globals > Using configuration files](https://eslint.org/docs/user-guide/configuring/language-options#using-configuration-files-1).
 
 #### Parsing error with Top Level `await`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -218,5 +218,15 @@ module.exports = {
   },
   processors: {
     '.vue': require('./processor')
+  },
+  environments: {
+    'setup-compiler-macros': {
+      globals: {
+        defineProps: 'readonly',
+        defineEmits: 'readonly',
+        defineExpose: 'readonly',
+        withDefaults: 'readonly'
+      }
+    }
   }
 }

--- a/tools/update-lib-index.js
+++ b/tools/update-lib-index.js
@@ -37,6 +37,16 @@ module.exports = {
   },
   processors: {
     '.vue': require('./processor')
+  },
+  environments: {
+    'setup-compiler-macros': {
+      globals: {
+        defineProps: 'readonly',
+        defineEmits: 'readonly',
+        defineExpose: 'readonly',
+        withDefaults: 'readonly'
+      }
+    }
   }
 }
 `


### PR DESCRIPTION
Adds a `setup-compiler-macros` environment which allows users to enable the globals used in `<script setup>` and prevent `no-undef` warnings per #1662.

Use via:
```js
module.exports = {
  env: {
    'vue/setup-compiler-macros': true
  }
}
```

Modifies docs to illustrate correct usage.

Let me know if this is an acceptable approach, and if you'd like me to make additional changes!

Closes #1662
