### PR TITLE
Fix false positive for filename in `vue/multi-word-component-names` rule

### DIFF
--- a/lib/rules/multi-word-component-names.js
+++ b/lib/rules/multi-word-component-names.js
@@ -8,6 +8,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
+const path = require('path')
 const casing = require('../utils/casing')
 const utils = require('../utils')
 
@@ -111,7 +112,7 @@ module.exports = {
           if (hasName) return
           if (!hasVue && node.body.length > 0) return
           const fileName = context.getFilename()
-          const componentName = fileName.replace(/\.[^/.]+$/, '')
+          const componentName = path.basename(fileName, path.extname(fileName))
           if (
             utils.isVueFile(fileName) &&
             !isValidComponentName(componentName)

--- a/tests/lib/rules/multi-word-component-names.js
+++ b/tests/lib/rules/multi-word-component-names.js
@@ -40,6 +40,10 @@ tester.run('multi-word-component-names', rule, {
       code: ''
     },
     {
+      filename: 'path/to/app.vue',
+      code: '<script></script>'
+    },
+    {
       filename: 'invalid.vue',
       code: `
         <script>


### PR DESCRIPTION
fixes #1688 