### PR TITLE
Allow <option> Tag to be Written in a Single Line

### DIFF
--- a/lib/utils/inline-non-void-elements.json
+++ b/lib/utils/inline-non-void-elements.json
@@ -21,6 +21,7 @@
   "mark",
   "noscript",
   "object",
+  "option",
   "output",
   "picture",
   "q",

--- a/tests/lib/rules/singleline-html-element-content-newline.js
+++ b/tests/lib/rules/singleline-html-element-content-newline.js
@@ -85,6 +85,15 @@ tester.run('singleline-html-element-content-newline', rule, {
         </form>
       </template>
     `,
+    `
+      <template>
+        <select>
+          <option value="small">Small</option>
+          <option value="medium">Medium</option>
+          <option value="large">Large</option>
+        </select>
+      </template>
+    `,
 
     // ignoreWhenNoAttributes: true
     `


### PR DESCRIPTION
Ref: https://github.com/vuejs/eslint-plugin-vue/issues/1740