### PR TITLE
Fix crash on `<textarea>` without end tag in `vue/html-indent` rule

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -311,11 +311,9 @@ module.exports.defineVisitor = function create(
           token.type === 'HTMLEndTagOpen' ||
           token.type === 'HTMLComment')
     }
-    for (const token of tokenStore.getTokensBetween(
-      node.startTag,
-      endToken,
-      option
-    )) {
+    for (const token of endToken
+      ? tokenStore.getTokensBetween(node.startTag, endToken, option)
+      : tokenStore.getTokensAfter(node.startTag, option)) {
       ignoreTokens.add(token)
     }
     ignoreTokens.add(endToken)

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -301,7 +301,7 @@ module.exports.defineVisitor = function create(
       tokenStore.getTokenAfter(node)
 
     /** @type {SourceCode.CursorWithSkipOptions} */
-    const option = {
+    const cursorOptions = {
       includeComments: true,
       filter: (token) =>
         token != null &&
@@ -311,9 +311,11 @@ module.exports.defineVisitor = function create(
           token.type === 'HTMLEndTagOpen' ||
           token.type === 'HTMLComment')
     }
-    for (const token of endToken
-      ? tokenStore.getTokensBetween(node.startTag, endToken, option)
-      : tokenStore.getTokensAfter(node.startTag, option)) {
+    const contentTokens = endToken
+      ? tokenStore.getTokensBetween(node.startTag, endToken, cursorOptions)
+      : tokenStore.getTokensAfter(node.startTag, cursorOptions)
+
+    for (const token of contentTokens) {
       ignoreTokens.add(token)
     }
     ignoreTokens.add(endToken)

--- a/tests/lib/rules/html-indent.js
+++ b/tests/lib/rules/html-indent.js
@@ -403,6 +403,22 @@ tester.run(
         text <span /> <!-- comment --></pre>
         </template>
       `
+      },
+      {
+        filename: 'test.vue',
+        code: unIndent`
+        <template>
+          <textarea>
+        </template>
+        `
+      },
+      {
+        filename: 'test.vue',
+        code: unIndent`
+        <template>
+          <pre>
+        </template>
+        `
       }
     ],
 
@@ -926,6 +942,25 @@ tester.run(
         errors: [
           {
             message: 'Expected "\\t" character, but found " " character.',
+            line: 2
+          }
+        ]
+      },
+      {
+        filename: 'test.vue',
+        code: unIndent`
+        <template>
+            <textarea>
+        </template>
+        `,
+        output: unIndent`
+        <template>
+          <textarea>
+        </template>
+        `,
+        errors: [
+          {
+            message: 'Expected indentation of 2 spaces but found 4 spaces.',
             line: 2
           }
         ]


### PR DESCRIPTION
fixes #1752