### PR TITLE
Add `vue/object-shorthand` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -396,6 +396,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/object-curly-newline](./object-curly-newline.md) | enforce consistent line breaks after opening and before closing braces | :wrench: |
 | [vue/object-curly-spacing](./object-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |
 | [vue/object-property-newline](./object-property-newline.md) | enforce placing object properties on separate lines | :wrench: |
+| [vue/object-shorthand](./object-shorthand.md) | require or disallow method and property shorthand syntax for object literals | :wrench: |
 | [vue/operator-linebreak](./operator-linebreak.md) | enforce consistent linebreak style for operators | :wrench: |
 | [vue/prefer-template](./prefer-template.md) | require template literals instead of string concatenation | :wrench: |
 | [vue/space-in-parens](./space-in-parens.md) | enforce consistent spacing inside parentheses | :wrench: |

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -1,0 +1,27 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/object-shorthand
+description: require or disallow method and property shorthand syntax for object literals
+---
+# vue/object-shorthand
+
+> require or disallow method and property shorthand syntax for object literals
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+This rule is the same rule as core [object-shorthand] rule but it applies to the expressions in `<template>`.
+
+## :books: Further Reading
+
+- [object-shorthand]
+
+[object-shorthand]: https://eslint.org/docs/rules/object-shorthand
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/object-shorthand.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/object-shorthand.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/object-shorthand)</sup>

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,6 +151,7 @@ module.exports = {
     'object-curly-newline': require('./rules/object-curly-newline'),
     'object-curly-spacing': require('./rules/object-curly-spacing'),
     'object-property-newline': require('./rules/object-property-newline'),
+    'object-shorthand': require('./rules/object-shorthand'),
     'one-component-per-file': require('./rules/one-component-per-file'),
     'operator-linebreak': require('./rules/operator-linebreak'),
     'order-in-components': require('./rules/order-in-components'),

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -1,0 +1,12 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule('object-shorthand', {
+  skipDynamicArguments: true
+})

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -1,0 +1,81 @@
+/**
+ * @author Yosuke Ota
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/object-shorthand')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  }
+})
+
+tester.run('object-shorthand', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :style="{height}"></div>
+      </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :style="{height: height}"></div>
+      </template>
+      `,
+      options: ['never']
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :style="{height: height}"></div>
+      </template>
+      `,
+      output: `
+      <template>
+        <div :style="{height}"></div>
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Expected property shorthand.',
+          line: 3,
+          column: 23
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :style="{height}"></div>
+      </template>
+      `,
+      output: `
+      <template>
+        <div :style="{height: height}"></div>
+      </template>
+      `,
+      options: ['never'],
+      errors: [
+        {
+          message: 'Expected longform property syntax.',
+          line: 3,
+          column: 23
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds `vue/object-shorthand` rule that applies `object-shorthand` rule to expressions in `<template>`.