### PR TITLE
Fix false positives for import brace in `vue/script-indent` rule

### DIFF
--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -1573,10 +1573,10 @@ module.exports.defineVisitor = function create(
           )
         )
         processNodeList(namedSpecifiers, leftBrace, rightBrace, 1)
-        for (const token of tokenStore.getTokensBetween(
-          leftBrace,
+        for (const token of [
+          ...tokenStore.getTokensBetween(leftBrace, rightBrace),
           rightBrace
-        )) {
+        ]) {
           const i = beforeTokens.indexOf(token)
           if (i >= 0) {
             beforeTokens.splice(i, 1)

--- a/tests/fixtures/script-indent/import-declaration-12.vue
+++ b/tests/fixtures/script-indent/import-declaration-12.vue
@@ -1,0 +1,11 @@
+<!--{}-->
+<script>
+import Def, {
+  foo
+} from 'mod';
+import
+  Def2, {
+    bar
+  } from 'mod';
+</script>
+<!-- https://github.com/vuejs/eslint-plugin-vue/issues/1766 -->


### PR DESCRIPTION
fixed #1766 