### PR TITLE
Fix returns the case where nextTick has parameters (#1776)

### DIFF
--- a/lib/rules/valid-next-tick.js
+++ b/lib/rules/valid-next-tick.js
@@ -74,14 +74,14 @@ function isAwaitedPromise(callExpression) {
 
   if (callExpression.parent.type === 'ReturnStatement') {
     // cases like `return nextTick()`
-    return true
+    return callExpression.arguments.length === 0
   }
   if (
     callExpression.parent.type === 'ArrowFunctionExpression' &&
     callExpression.parent.body === callExpression
   ) {
     // cases like `() => nextTick()`
-    return true
+    return callExpression.parent.body.arguments.length === 0
   }
 
   if (

--- a/lib/rules/valid-next-tick.js
+++ b/lib/rules/valid-next-tick.js
@@ -73,14 +73,14 @@ function isAwaitedPromise(callExpression) {
   }
 
   if (callExpression.parent.type === 'ReturnStatement') {
-    // cases like `return nextTick()`
+    // cases like `return nextTick()` or `return nextTick(cb)`
     return callExpression.arguments.length === 0
   }
   if (
     callExpression.parent.type === 'ArrowFunctionExpression' &&
     callExpression.parent.body === callExpression
   ) {
-    // cases like `() => nextTick()`
+    // cases like `() => nextTick()` or `return () => nextTick(cb)`
     return callExpression.parent.body.arguments.length === 0
   }
 

--- a/tests/lib/rules/valid-next-tick.js
+++ b/tests/lib/rules/valid-next-tick.js
@@ -127,6 +127,12 @@ tester.run('valid-next-tick', rule, {
             return this.$nextTick()
               .then(() => this.$nextTick())
           },
+          fn3 () {
+            return this.$nextTick(() => {})
+          },
+          fn4 () {
+            return this.$nextTick().then(() => this.$nextTick(() => {}))
+          }
         }
       }</script>`
     },


### PR DESCRIPTION
returns the case where nextTick has parameters  `return nextTick(cb);`, This should not be a mistake

Fixes #1776 ([comment](https://github.com/vuejs/eslint-plugin-vue/issues/1776#issuecomment-1020746592)).