### PR TITLE
Add Reactivity Transform macros

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -358,10 +358,10 @@ module.exports = {
 }
 ```
 
-#### Compiler macros such as `defineProps` and `defineEmits` generate `no-undef` warnings
+#### Compiler macros such as `defineProps` and `$ref` generate `no-undef` warnings
 
 You need to enable the compiler macros environment in your ESLint configuration file.
-If you don't want to expose these variables globally, you can use `/* global defineProps, defineEmits */` instead.
+If you don't want to expose these variables globally, you can use `/* global defineProps, $ref */` instead.
 
 Example **.eslintrc.js**:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -233,9 +233,16 @@ module.exports = {
   environments: {
     'setup-compiler-macros': {
       globals: {
-        defineProps: 'readonly',
+        $$: 'readonly',
+        $: 'readonly',
+        $computed: 'readonly',
+        $customRef: 'readonly',
+        $ref: 'readonly',
+        $shallowRef: 'readonly',
+        $toRef: 'readonly',
         defineEmits: 'readonly',
         defineExpose: 'readonly',
+        defineProps: 'readonly',
         withDefaults: 'readonly'
       }
     }

--- a/tools/update-lib-index.js
+++ b/tools/update-lib-index.js
@@ -41,9 +41,16 @@ module.exports = {
   environments: {
     'setup-compiler-macros': {
       globals: {
-        defineProps: 'readonly',
+        $$: 'readonly',
+        $: 'readonly',
+        $computed: 'readonly',
+        $customRef: 'readonly',
+        $ref: 'readonly',
+        $shallowRef: 'readonly',
+        $toRef: 'readonly',
         defineEmits: 'readonly',
         defineExpose: 'readonly',
+        defineProps: 'readonly',
         withDefaults: 'readonly'
       }
     }


### PR DESCRIPTION
Closes #1798

---

I noticed that the new [Reactivity Transform](https://vuejs.org/guide/extras/reactivity-transform.html) macros were missing in the `vue/setup-compiler-macros` option, resulting in e.g. `'$ref' is not defined  no-undef` errors when not explicitly importing the macros.

I hope this implementation is correct. I looked at #1685 as an example.