### PR TITLE
Fix broken links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Be sure to read the [official ESLint guide](https://eslint.org/docs/developer-gu
 
 To see what an abstract syntax tree (AST) of your code looks like, you may use [AST Explorer](https://astexplorer.net). After opening [AST Explorer](https://astexplorer.net), select `Vue` as the syntax and `vue-eslint-parser` as the parser.
 
-The default JavaScript parser must be replaced because [Vue.js single file components](https://v3.vuejs.org/guide/single-file-component.html#single-file-components) are not plain JavaScript, but a custom file format. [`vue-eslint-parser`](https://github.com/vuejs/vue-eslint-parser) is a replacement parser that generates an enhanced AST with nodes that represent specific parts of the template syntax, as well as the contents of the `<script>` tag.
+The default JavaScript parser must be replaced because [Vue.js single file components](https://vuejs.org/guide/scaling-up/sfc.html) are not plain JavaScript, but a custom file format. [`vue-eslint-parser`](https://github.com/vuejs/vue-eslint-parser) is a replacement parser that generates an enhanced AST with nodes that represent specific parts of the template syntax, as well as the contents of the `<script>` tag.
 
 To learn more about certain nodes in a produced AST, see the [ESTree project page](https://github.com/estree/estree) and the [vue-eslint-parser AST documentation](https://github.com/vuejs/vue-eslint-parser/blob/master/docs/ast.md).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://img.shields.io/npm/v/eslint-plugin-vue.svg?style=flat)](https://npmjs.org/package/eslint-plugin-vue)
 [![NPM downloads](https://img.shields.io/npm/dm/eslint-plugin-vue.svg?style=flat)](https://npmjs.org/package/eslint-plugin-vue)
 [![CircleCI](https://img.shields.io/circleci/project/github/vuejs/eslint-plugin-vue/master.svg?style=flat)](https://circleci.com/gh/vuejs/eslint-plugin-vue)
-[![License](https://img.shields.io/github/license/vuejs/eslint-plugin-vue.svg?style=flat)](https://github.com/vuejs/eslint-plugin-vue/blob/master/LICENSE.md)
+[![License](https://img.shields.io/github/license/vuejs/eslint-plugin-vue.svg?style=flat)](https://github.com/vuejs/eslint-plugin-vue/blob/master/LICENSE)
 
 > Official ESLint plugin for Vue.js
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Official ESLint plugin for Vue.js.
 This plugin allows us to check the `<template>` and `<script>` of `.vue` files with ESLint, as well as Vue code in `.js` files.
 
 - Finds syntax errors.
-- Finds the wrong use of [Vue.js Directives](https://v3.vuejs.org/api/directives.html).
+- Finds the wrong use of [Vue.js Directives](https://vuejs.org/api/built-in-directives.html).
 - Finds the violation for [Vue.js Style Guide](https://vuejs.org/style-guide/).
 
 ESLint editor integrations are useful to check your code in real-time.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ This plugin allows us to check the `<template>` and `<script>` of `.vue` files w
 
 - Finds syntax errors.
 - Finds the wrong use of [Vue.js Directives](https://v3.vuejs.org/api/directives.html).
-- Finds the violation for [Vue.js Style Guide](https://v3.vuejs.org/style-guide/).
+- Finds the violation for [Vue.js Style Guide](https://vuejs.org/style-guide/).
 
 ESLint editor integrations are useful to check your code in real-time.
 

--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -14,7 +14,7 @@ since: v4.3.0
 
 ## :book: Rule Details
 
-This rule aims to enforce ordering of component attributes. The default order is specified in the [Vue.js Style Guide](https://v3.vuejs.org/style-guide/#element-attribute-order-recommended) and is:
+This rule aims to enforce ordering of component attributes. The default order is specified in the [Vue.js Style Guide](https://vuejs.org/style-guide/rules-recommended.html#element-attribute-order) and is:
 
 - `DEFINITION`
   e.g. 'is', 'v-is'
@@ -247,7 +247,7 @@ Note that `v-bind="object"` syntax is considered to be the same as the next or p
 
 ## :books: Further Reading
 
-- [Style guide - Element attribute order](https://v3.vuejs.org/style-guide/#element-attribute-order-recommended)
+- [Style guide - Element attribute order](https://vuejs.org/style-guide/rules-recommended.html#element-attribute-order)
 - [Style guide (for v2) - Element attribute order](https://vuejs.org/v2/style-guide/#Element-attribute-order-recommended)
 
 ## :rocket: Version

--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -248,7 +248,7 @@ Note that `v-bind="object"` syntax is considered to be the same as the next or p
 ## :books: Further Reading
 
 - [Style guide - Element attribute order](https://vuejs.org/style-guide/rules-recommended.html#element-attribute-order)
-- [Style guide (for v2) - Element attribute order](https://vuejs.org/v2/style-guide/#Element-attribute-order-recommended)
+- [Style guide (for v2) - Element attribute order](https://v2.vuejs.org/v2/style-guide/#Element-attribute-order-recommended)
 
 ## :rocket: Version
 

--- a/docs/rules/component-api-style.md
+++ b/docs/rules/component-api-style.md
@@ -79,8 +79,8 @@ export default {
 ```
 
 - Array options ... Defines the API styles you want to allow. Default is `["script-setup", "composition"]`. You can use the following values.
-  - `"script-setup"` ... If set, allows [`<script setup>`](https://v3.vuejs.org/api/sfc-script-setup.html).
-  - `"composition"` ... If set, allows [Composition API](https://v3.vuejs.org/api/composition-api.html) (not `<script setup>`).
+  - `"script-setup"` ... If set, allows [`<script setup>`](https://vuejs.org/api/sfc-script-setup.html).
+  - `"composition"` ... If set, allows [Composition API](https://vuejs.org/api/#composition-api) (not `<script setup>`).
   - `"composition-vue2"` ... If set, allows [Composition API for Vue 2](https://github.com/vuejs/composition-api) (not `<script setup>`). In particular, it allows `render`, `renderTracked` and `renderTriggered` alongside `setup`.
   - `"options"` ... If set, allows Options API.
 

--- a/docs/rules/component-definition-name-casing.md
+++ b/docs/rules/component-definition-name-casing.md
@@ -121,7 +121,7 @@ Vue.component('MyComponent', {
 
 ## :books: Further Reading
 
-- [Style guide - Component name casing in JS/JSX](https://v3.vuejs.org/style-guide/#component-name-casing-in-js-jsx-strongly-recommended)
+- [Style guide - Component name casing in JS/JSX](https://vuejs.org/style-guide/rules-strongly-recommended.html#component-name-casing-in-js-jsx)
 
 ## :rocket: Version
 

--- a/docs/rules/component-name-in-template-casing.md
+++ b/docs/rules/component-name-in-template-casing.md
@@ -143,7 +143,7 @@ export default {
 
 ## :books: Further Reading
 
-- [Style guide - Component name casing in templates](https://v3.vuejs.org/style-guide/#component-name-casing-in-templates-strongly-recommended)
+- [Style guide - Component name casing in templates](https://vuejs.org/style-guide/rules-strongly-recommended.html#component-name-casing-in-templates)
 
 ## :rocket: Version
 

--- a/docs/rules/component-tags-order.md
+++ b/docs/rules/component-tags-order.md
@@ -114,7 +114,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 ## :books: Further Reading
 
-- [Style guide - Single-file component top-level element order](https://v3.vuejs.org/style-guide/#single-file-component-top-level-element-order-recommended)
+- [Style guide - Single-file component top-level element order](https://vuejs.org/style-guide/rules-recommended.html#single-file-component-top-level-element-order)
 
 ## :rocket: Version
 

--- a/docs/rules/custom-event-name-casing.md
+++ b/docs/rules/custom-event-name-casing.md
@@ -168,7 +168,7 @@ export default {
 - [Guide - Custom Events]
 - [Guide (for v2) - Custom Events]
 
-[Guide - Custom Events]: https://v3.vuejs.org/guide/component-custom-events.html
+[Guide - Custom Events]: https://vuejs.org/guide/components/events.html
 [Guide (for v2) - Custom Events]: https://v2.vuejs.org/v2/guide/components-custom-events.html
 
 ## :couple: Related Rules

--- a/docs/rules/custom-event-name-casing.md
+++ b/docs/rules/custom-event-name-casing.md
@@ -169,7 +169,7 @@ export default {
 - [Guide (for v2) - Custom Events]
 
 [Guide - Custom Events]: https://v3.vuejs.org/guide/component-custom-events.html
-[Guide (for v2) - Custom Events]: https://vuejs.org/v2/guide/components-custom-events.html
+[Guide (for v2) - Custom Events]: https://v2.vuejs.org/v2/guide/components-custom-events.html
 
 ## :couple: Related Rules
 

--- a/docs/rules/first-attribute-linebreak.md
+++ b/docs/rules/first-attribute-linebreak.md
@@ -156,7 +156,7 @@ This rule aims to enforce a consistent location for the first attribute.
 
 ## :books: Further Reading
 
-- [Style guide - Multi attribute elements](https://v3.vuejs.org/style-guide/#multi-attribute-elements-strongly-recommended)
+- [Style guide - Multi attribute elements](https://vuejs.org/style-guide/rules-strongly-recommended.html#multi-attribute-elements)
 
 ## :rocket: Version
 

--- a/docs/rules/html-quotes.md
+++ b/docs/rules/html-quotes.md
@@ -94,7 +94,7 @@ Object option:
 
 ## :books: Further Reading
 
-- [Style guide - Quoted attribute values](https://v3.vuejs.org/style-guide/#Quoted-attribute-values-strongly-recommended)
+- [Style guide - Quoted attribute values](https://vuejs.org/style-guide/rules-strongly-recommended.html#quoted-attribute-values)
 
 ## :rocket: Version
 

--- a/docs/rules/html-self-closing.md
+++ b/docs/rules/html-self-closing.md
@@ -95,7 +95,7 @@ Every option can be set to one of the following values:
 
 ## :books: Further Reading
 
-- [Style guide - Self closing components](https://v3.vuejs.org/style-guide/#Self-closing-components-strongly-recommended)
+- [Style guide - Self closing components](https://vuejs.org/style-guide/rules-strongly-recommended.html#self-closing-components)
 
 ## :rocket: Version
 

--- a/docs/rules/match-component-file-name.md
+++ b/docs/rules/match-component-file-name.md
@@ -308,7 +308,7 @@ export default {
 
 ## :books: Further Reading
 
-- [Style guide - Single-file component filename casing](https://v3.vuejs.org/style-guide/#single-file-component-filename-casing-strongly-recommended)
+- [Style guide - Single-file component filename casing](https://vuejs.org/style-guide/rules-strongly-recommended.html#single-file-component-filename-casing)
 
 ## :rocket: Version
 

--- a/docs/rules/max-attributes-per-line.md
+++ b/docs/rules/max-attributes-per-line.md
@@ -114,7 +114,7 @@ There is a configurable number of attributes that are acceptable in one-line cas
 
 ## :books: Further Reading
 
-- [Style guide - Multi attribute elements](https://v3.vuejs.org/style-guide/#multi-attribute-elements-strongly-recommended)
+- [Style guide - Multi attribute elements](https://vuejs.org/style-guide/rules-strongly-recommended.html#multi-attribute-elements)
 
 ## :rocket: Version
 

--- a/docs/rules/multi-word-component-names.md
+++ b/docs/rules/multi-word-component-names.md
@@ -118,7 +118,7 @@ export default {
 
 ## :books: Further Reading
 
-- [Style guide - Multi-word component names](https://v3.vuejs.org/style-guide/#multi-word-component-names-essential)
+- [Style guide - Multi-word component names](https://vuejs.org/style-guide/rules-essential.html#use-multi-word-component-names)
 
 ## :rocket: Version
 

--- a/docs/rules/name-property-casing.md
+++ b/docs/rules/name-property-casing.md
@@ -83,7 +83,7 @@ This rule aims at enforcing the style for the `name` property casing for consist
 
 ## :books: Further Reading
 
-- [Style guide - Component name casing in JS/JSX](https://v3.vuejs.org/style-guide/#component-name-casing-in-js-jsx-strongly-recommended)
+- [Style guide - Component name casing in JS/JSX](https://vuejs.org/style-guide/rules-strongly-recommended.html#component-name-casing-in-js-jsx)
 
 ## :rocket: Version
 

--- a/docs/rules/new-line-between-multi-line-property.md
+++ b/docs/rules/new-line-between-multi-line-property.md
@@ -89,7 +89,7 @@ export default {
 
 ## :books: Further Reading
 
-- [Style guide - Empty lines in component/instance options](https://v3.vuejs.org/style-guide/#empty-lines-in-component-instance-options-recommended)
+- [Style guide - Empty lines in component/instance options](https://vuejs.org/style-guide/rules-recommended.html#empty-lines-in-component-instance-options)
 
 ## :rocket: Version
 

--- a/docs/rules/next-tick-style.md
+++ b/docs/rules/next-tick-style.md
@@ -93,7 +93,7 @@ export default {
 
 - [`Vue.nextTick` API in Vue 2](https://vuejs.org/v2/api/#Vue-nextTick)
 - [`vm.$nextTick` API in Vue 2](https://vuejs.org/v2/api/#vm-nextTick)
-- [Global API Treeshaking](https://v3.vuejs.org/guide/migration/global-api-treeshaking.html)
+- [Global API Treeshaking](https://v3-migration.vuejs.org/breaking-changes/global-api-treeshaking.html)
 - [Global `nextTick` API in Vue 3](https://v3.vuejs.org/api/global-api.html#nexttick)
 - [Instance `$nextTick` API in Vue 3](https://v3.vuejs.org/api/instance-methods.html#nexttick)
 

--- a/docs/rules/next-tick-style.md
+++ b/docs/rules/next-tick-style.md
@@ -94,8 +94,8 @@ export default {
 - [`Vue.nextTick` API in Vue 2](https://v2.vuejs.org/v2/api/#Vue-nextTick)
 - [`vm.$nextTick` API in Vue 2](https://v2.vuejs.org/v2/api/#vm-nextTick)
 - [Global API Treeshaking](https://v3-migration.vuejs.org/breaking-changes/global-api-treeshaking.html)
-- [Global `nextTick` API in Vue 3](https://v3.vuejs.org/api/global-api.html#nexttick)
-- [Instance `$nextTick` API in Vue 3](https://v3.vuejs.org/api/instance-methods.html#nexttick)
+- [Global `nextTick` API in Vue 3](https://vuejs.org/api/general.html#nexttick)
+- [Instance `$nextTick` API in Vue 3](https://vuejs.org/api/component-instance.html#nexttick)
 
 ## :rocket: Version
 

--- a/docs/rules/next-tick-style.md
+++ b/docs/rules/next-tick-style.md
@@ -91,8 +91,8 @@ export default {
 
 ## :books: Further Reading
 
-- [`Vue.nextTick` API in Vue 2](https://vuejs.org/v2/api/#Vue-nextTick)
-- [`vm.$nextTick` API in Vue 2](https://vuejs.org/v2/api/#vm-nextTick)
+- [`Vue.nextTick` API in Vue 2](https://v2.vuejs.org/v2/api/#Vue-nextTick)
+- [`vm.$nextTick` API in Vue 2](https://v2.vuejs.org/v2/api/#vm-nextTick)
 - [Global API Treeshaking](https://v3-migration.vuejs.org/breaking-changes/global-api-treeshaking.html)
 - [Global `nextTick` API in Vue 3](https://v3.vuejs.org/api/global-api.html#nexttick)
 - [Instance `$nextTick` API in Vue 3](https://v3.vuejs.org/api/instance-methods.html#nexttick)

--- a/docs/rules/no-arrow-functions-in-watch.md
+++ b/docs/rules/no-arrow-functions-in-watch.md
@@ -13,7 +13,7 @@ since: v7.0.0
 
 ## :book: Rule Details
 
-This rules disallows using arrow functions to defined watcher.The reason is arrow functions bind the parent context, so `this` will not be the Vue instance as you expect.([see here for more details](https://v3.vuejs.org/api/options-data.html#watch))
+This rules disallows using arrow functions to defined watcher.The reason is arrow functions bind the parent context, so `this` will not be the Vue instance as you expect.([see here for more details](https://vuejs.org/api/options-state.html#watch))
 
 <eslint-code-block :rules="{'vue/no-arrow-functions-in-watch': ['error']}">
 

--- a/docs/rules/no-child-content.md
+++ b/docs/rules/no-child-content.md
@@ -44,8 +44,8 @@ This rule reports child content of elements that have a directive which overwrit
 
 ## :books: Further Reading
 
-- [`v-html` directive](https://v3.vuejs.org/api/directives.html#v-html)
-- [`v-text` directive](https://v3.vuejs.org/api/directives.html#v-text)
+- [`v-html` directive](https://vuejs.org/api/built-in-directives.html#v-html)
+- [`v-text` directive](https://vuejs.org/api/built-in-directives.html#v-text)
 
 ## :rocket: Version
 

--- a/docs/rules/no-confusing-v-for-v-if.md
+++ b/docs/rules/no-confusing-v-for-v-if.md
@@ -50,7 +50,7 @@ In that case, the `v-if` should be written on the wrapper element.
 ::: warning Note
 When they exist on the same node, `v-for` has a higher priority than `v-if`. That means the `v-if` will be run on each iteration of the loop separately.
 
-[https://v3.vuejs.org/guide/list.html#v-for-with-v-if](https://v3.vuejs.org/guide/list.html#v-for-with-v-if)
+[https://vuejs.org/guide/essentials/list.html#v-for-with-v-if](https://vuejs.org/guide/essentials/list.html#v-for-with-v-if)
 :::
 
 ## :wrench: Options
@@ -60,8 +60,8 @@ Nothing.
 ## :books: Further Reading
 
 - [Style guide - Avoid v-if with v-for](https://vuejs.org/style-guide/rules-essential.html#avoid-v-if-with-v-for)
-- [Guide - Conditional Rendering / v-if with v-for](https://v3.vuejs.org/guide/conditional.html#v-if-with-v-for)
-- [Guide - List Rendering / v-for with v-if](https://v3.vuejs.org/guide/list.html#v-for-with-v-if)
+- [Guide - Conditional Rendering / v-if with v-for](https://vuejs.org/guide/essentials/conditional.html#v-if-with-v-for)
+- [Guide - List Rendering / v-for with v-if](https://vuejs.org/guide/essentials/list.html#v-for-with-v-if)
 
 ## :rocket: Version
 

--- a/docs/rules/no-confusing-v-for-v-if.md
+++ b/docs/rules/no-confusing-v-for-v-if.md
@@ -59,7 +59,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide - Avoid v-if with v-for](https://v3.vuejs.org/style-guide/#avoid-v-if-with-v-for-essential)
+- [Style guide - Avoid v-if with v-for](https://vuejs.org/style-guide/rules-essential.html#avoid-v-if-with-v-for)
 - [Guide - Conditional Rendering / v-if with v-for](https://v3.vuejs.org/guide/conditional.html#v-if-with-v-for)
 - [Guide - List Rendering / v-for with v-if](https://v3.vuejs.org/guide/list.html#v-for-with-v-if)
 

--- a/docs/rules/no-deprecated-data-object-declaration.md
+++ b/docs/rules/no-deprecated-data-object-declaration.md
@@ -17,7 +17,7 @@ since: v7.0.0
 This rule reports use of deprecated object declaration on `data` property (in Vue.js 3.0.0+).
 The different from `vue/no-shared-component-data` is the root instance being also disallowed.
 
-See [Migration Guide - Data Option](https://v3.vuejs.org/guide/migration/data-option.html) for more details.
+See [Migration Guide - Data Option](https://v3-migration.vuejs.org/breaking-changes/data-option.html) for more details.
 
 <eslint-code-block fix :rules="{'vue/no-deprecated-data-object-declaration': ['error']}" language="javascript" filename="example.js">
 
@@ -79,7 +79,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Data Option](https://v3.vuejs.org/guide/migration/data-option.html)
+- [Migration Guide - Data Option](https://v3-migration.vuejs.org/breaking-changes/data-option.html)
 - [Vue RFCs - 0019-remove-data-object-declaration](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0019-remove-data-object-declaration.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-dollar-scopedslots-api.md
+++ b/docs/rules/no-deprecated-dollar-scopedslots-api.md
@@ -16,7 +16,7 @@ since: v7.0.0
 
 This rule reports use of deprecated `$scopedSlots`. (in Vue.js 3.0.0+).
 
-See [Migration Guide - Slots Unification](https://v3.vuejs.org/guide/migration/slots-unification.html) for more details.
+See [Migration Guide - Slots Unification](https://v3-migration.vuejs.org/breaking-changes/slots-unification.html) for more details.
 
 <eslint-code-block fix :rules="{'vue/no-deprecated-dollar-scopedslots-api': ['error']}">
 
@@ -43,7 +43,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Slots Unification](https://v3.vuejs.org/guide/migration/slots-unification.html)
+- [Migration Guide - Slots Unification](https://v3-migration.vuejs.org/breaking-changes/slots-unification.html)
 - [Vue RFCs - 0006-slots-unification](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0006-slots-unification.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-events-api.md
+++ b/docs/rules/no-deprecated-events-api.md
@@ -15,7 +15,7 @@ since: v7.0.0
 
 This rule reports use of deprecated `$on`, `$off` `$once` api. (in Vue.js 3.0.0+).
 
-See [Migration Guide - Events API](https://v3.vuejs.org/guide/migration/events-api.html) for more details.
+See [Migration Guide - Events API](https://v3-migration.vuejs.org/breaking-changes/events-api.html) for more details.
 
 <eslint-code-block :rules="{'vue/no-deprecated-events-api': ['error']}">
 
@@ -61,7 +61,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Events API](https://v3.vuejs.org/guide/migration/events-api.html)
+- [Migration Guide - Events API](https://v3-migration.vuejs.org/breaking-changes/events-api.html)
 - [Vue RFCs - 0020-events-api-change](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0020-events-api-change.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-filter.md
+++ b/docs/rules/no-deprecated-filter.md
@@ -15,7 +15,7 @@ since: v7.0.0
 
 This rule reports deprecated `filters` syntax (removed in Vue.js v3.0.0+).
 
-See [Migration Guide - Filters](https://v3.vuejs.org/guide/migration/filters.html) for more details.
+See [Migration Guide - Filters](https://v3-migration.vuejs.org/breaking-changes/filters.html) for more details.
 
 <eslint-code-block :rules="{'vue/no-deprecated-filter': ['error']}">
 
@@ -63,7 +63,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Filters](https://v3.vuejs.org/guide/migration/filters.html)
+- [Migration Guide - Filters](https://v3-migration.vuejs.org/breaking-changes/filters.html)
 - [Vue RFCs - 0015-remove-filters](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0015-remove-filters.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-functional-template.md
+++ b/docs/rules/no-deprecated-functional-template.md
@@ -36,7 +36,7 @@ Nothing.
 
 - [Migration Guide - Functional Components](https://v3-migration.vuejs.org/breaking-changes/functional-components.html)
 - [Vue RFCs - 0007-functional-async-api-change](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0007-functional-async-api-change.md)
-- [Guide - Functional Components](https://vuejs.org/v2/guide/render-function.html#Functional-Components)
+- [Guide - Functional Components](https://v2.vuejs.org/v2/guide/render-function.html#Functional-Components)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-functional-template.md
+++ b/docs/rules/no-deprecated-functional-template.md
@@ -15,7 +15,7 @@ since: v7.0.0
 
 This rule reports deprecated the `functional` template (in Vue.js 3.0.0+).
 
-See [Migration Guide - Functional Components](https://v3.vuejs.org/guide/migration/functional-components.html) for more details.
+See [Migration Guide - Functional Components](https://v3-migration.vuejs.org/breaking-changes/functional-components.html) for more details.
 
 <eslint-code-block :rules="{'vue/no-deprecated-functional-template': ['error']}">
 
@@ -34,7 +34,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Functional Components](https://v3.vuejs.org/guide/migration/functional-components.html)
+- [Migration Guide - Functional Components](https://v3-migration.vuejs.org/breaking-changes/functional-components.html)
 - [Vue RFCs - 0007-functional-async-api-change](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0007-functional-async-api-change.md)
 - [Guide - Functional Components](https://vuejs.org/v2/guide/render-function.html#Functional-Components)
 

--- a/docs/rules/no-deprecated-html-element-is.md
+++ b/docs/rules/no-deprecated-html-element-is.md
@@ -15,7 +15,7 @@ since: v7.0.0
 
 This rule reports deprecated the `is` attribute on HTML elements (removed in Vue.js v3.0.0+).
 
-See [Migration Guide - Custom Elements Interop](https://v3.vuejs.org/guide/migration/custom-elements-interop.html#customized-built-in-elements) for more details.
+See [Migration Guide - Custom Elements Interop](https://v3-migration.vuejs.org/breaking-changes/custom-elements-interop.html#customized-built-in-elements) for more details.
 
 <eslint-code-block :rules="{'vue/no-deprecated-html-element-is': ['error']}">
 
@@ -39,7 +39,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Custom Elements Interop](https://v3.vuejs.org/guide/migration/custom-elements-interop.html#customized-built-in-elements)
+- [Migration Guide - Custom Elements Interop](https://v3-migration.vuejs.org/breaking-changes/custom-elements-interop.html#customized-built-in-elements)
 - [Vue RFCs - 0027-custom-elements-interop](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0027-custom-elements-interop.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-inline-template.md
+++ b/docs/rules/no-deprecated-inline-template.md
@@ -15,7 +15,7 @@ since: v7.0.0
 
 This rule reports deprecated `inline-template` attributes (removed in Vue.js v3.0.0+).
 
-See [Migration Guide - Inline Template Attribute](https://v3.vuejs.org/guide/migration/inline-template-attribute.html) for more details.
+See [Migration Guide - Inline Template Attribute](https://v3-migration.vuejs.org/breaking-changes/inline-template-attribute.html) for more details.
 
 <eslint-code-block :rules="{'vue/no-deprecated-inline-template': ['error']}">
 
@@ -42,7 +42,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Inline Template Attribute](https://v3.vuejs.org/guide/migration/inline-template-attribute.html)
+- [Migration Guide - Inline Template Attribute](https://v3-migration.vuejs.org/breaking-changes/inline-template-attribute.html)
 - [Vue RFCs - 0016-remove-inline-templates](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0016-remove-inline-templates.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-props-default-this.md
+++ b/docs/rules/no-deprecated-props-default-this.md
@@ -16,7 +16,7 @@ since: v7.0.0
 This rule reports the use of `this` within the props default value factory functions.
 In Vue.js 3.0.0+, props default value factory functions no longer have access to `this`.
 
-See [Migration Guide - Props Default Function `this` Access](https://v3.vuejs.org/guide/migration/props-default-this.html) for more details.
+See [Migration Guide - Props Default Function `this` Access](https://v3-migration.vuejs.org/breaking-changes/props-default-this.html) for more details.
 
 <eslint-code-block :rules="{'vue/no-deprecated-props-default-this': ['error']}">
 
@@ -64,7 +64,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - Props Default Function `this` Access](https://v3.vuejs.org/guide/migration/props-default-this.html)
+- [Migration Guide - Props Default Function `this` Access](https://v3-migration.vuejs.org/breaking-changes/props-default-this.html)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-scope-attribute.md
+++ b/docs/rules/no-deprecated-scope-attribute.md
@@ -42,7 +42,7 @@ This rule reports deprecated `scope` attribute in Vue.js v2.5.0+.
 
 ## :books: Further Reading
 
-- [API - scope](https://vuejs.org/v2/api/#scope-removed)
+- [API - scope](https://v2.vuejs.org/v2/api/#scope-removed)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-slot-attribute.md
+++ b/docs/rules/no-deprecated-slot-attribute.md
@@ -39,7 +39,7 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
 
 ## :books: Further Reading
 
-- [API - slot](https://vuejs.org/v2/api/#slot-deprecated)
+- [API - slot](https://v2.vuejs.org/v2/api/#slot-deprecated)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-slot-scope-attribute.md
+++ b/docs/rules/no-deprecated-slot-scope-attribute.md
@@ -39,7 +39,7 @@ This rule reports deprecated `slot-scope` attribute in Vue.js v2.6.0+.
 
 ## :books: Further Reading
 
-- [API - slot-scope](https://vuejs.org/v2/api/#slot-scope-deprecated)
+- [API - slot-scope](https://v2.vuejs.org/v2/api/#slot-scope-deprecated)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-v-bind-sync.md
+++ b/docs/rules/no-deprecated-v-bind-sync.md
@@ -16,7 +16,7 @@ since: v7.0.0
 
 This rule reports use of deprecated `.sync` modifier on `v-bind` directive (in Vue.js 3.0.0+).
 
-See [Migration Guide - `v-model`](https://v3.vuejs.org/guide/migration/v-model.html) for more details.
+See [Migration Guide - `v-model`](https://v3-migration.vuejs.org/breaking-changes/v-model.html) for more details.
 
 <eslint-code-block fix :rules="{'vue/no-deprecated-v-bind-sync': ['error']}">
 
@@ -49,7 +49,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - `v-model`](https://v3.vuejs.org/guide/migration/v-model.html)
+- [Migration Guide - `v-model`](https://v3-migration.vuejs.org/breaking-changes/v-model.html)
 - [Vue RFCs - 0005-replace-v-bind-sync-with-v-model-argument](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0005-replace-v-bind-sync-with-v-model-argument.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-v-is.md
+++ b/docs/rules/no-deprecated-v-is.md
@@ -16,7 +16,7 @@ since: v7.11.0
 
 This rule reports deprecated `v-is` directive in Vue.js v3.1.0+.
 
-Use [`is` attribute with `vue:` prefix](https://v3.vuejs.org/api/special-attributes.html#is) instead.
+Use [`is` attribute with `vue:` prefix](https://vuejs.org/api/built-in-special-attributes.html#is) instead.
 
 <eslint-code-block fix :rules="{'vue/no-deprecated-v-is': ['error']}">
 
@@ -41,7 +41,8 @@ Use [`is` attribute with `vue:` prefix](https://v3.vuejs.org/api/special-attribu
 
 ## :books: Further Reading
 
-- [API - v-is](https://v3.vuejs.org/api/directives.html#v-is)
+- [Migration Guide - Custom Elements Interop](https://v3-migration.vuejs.org/breaking-changes/custom-elements-interop.html#vue-prefix-for-in-dom-template-parsing-workarounds)
+- [API - v-is](https://vuejs.org/api/built-in-special-attributes.html#is)
 - [API - v-is (Old)](https://github.com/vuejs/docs-next/blob/008613756c3d781128d96b64a2d27f7598f8f548/src/api/directives.md#v-is)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-v-on-number-modifiers.md
+++ b/docs/rules/no-deprecated-v-on-number-modifiers.md
@@ -16,7 +16,7 @@ since: v7.0.0
 
 This rule reports use of deprecated `KeyboardEvent.keyCode` modifier on `v-on` directive (in Vue.js 3.0.0+).
 
-See [Migration Guide - KeyCode Modifiers](https://v3.vuejs.org/guide/migration/keycode-modifiers.html) for more details.
+See [Migration Guide - KeyCode Modifiers](https://v3-migration.vuejs.org/breaking-changes/keycode-modifiers.html) for more details.
 
 <eslint-code-block fix :rules="{'vue/no-deprecated-v-on-number-modifiers': ['error']}">
 
@@ -48,7 +48,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - KeyCode Modifiers](https://v3.vuejs.org/guide/migration/keycode-modifiers.html)
+- [Migration Guide - KeyCode Modifiers](https://v3-migration.vuejs.org/breaking-changes/keycode-modifiers.html)
 - [Vue RFCs - 0014-drop-keycode-support](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0014-drop-keycode-support.md)
 
 ## :rocket: Version

--- a/docs/rules/no-deprecated-vue-config-keycodes.md
+++ b/docs/rules/no-deprecated-vue-config-keycodes.md
@@ -46,7 +46,7 @@ Nothing.
 
 [Migration Guide - KeyCode Modifiers]: https://v3-migration.vuejs.org/breaking-changes/keycode-modifiers.html
 [Vue RFCs - 0014-drop-keycode-support]: https://github.com/vuejs/rfcs/blob/master/active-rfcs/0014-drop-keycode-support.md
-[API - Global Config - keyCodes]: https://vuejs.org/v2/api/#keyCodes
+[API - Global Config - keyCodes]: https://v2.vuejs.org/v2/api/#keyCodes
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-vue-config-keycodes.md
+++ b/docs/rules/no-deprecated-vue-config-keycodes.md
@@ -15,7 +15,7 @@ since: v7.0.0
 
 This rule reports use of deprecated `Vue.config.keyCodes` (in Vue.js 3.0.0+).
 
-See [Migration Guide - KeyCode Modifiers](https://v3.vuejs.org/guide/migration/keycode-modifiers.html) for more details.
+See [Migration Guide - KeyCode Modifiers](https://v3-migration.vuejs.org/breaking-changes/keycode-modifiers.html) for more details.
 
 <eslint-code-block filename="a.js" language="javascript" :rules="{'vue/no-deprecated-vue-config-keycodes': ['error']}">
 
@@ -44,7 +44,7 @@ Nothing.
 - [Vue RFCs - 0014-drop-keycode-support]
 - [API - Global Config - keyCodes]
 
-[Migration Guide - KeyCode Modifiers]: https://v3.vuejs.org/guide/migration/keycode-modifiers.html
+[Migration Guide - KeyCode Modifiers]: https://v3-migration.vuejs.org/breaking-changes/keycode-modifiers.html
 [Vue RFCs - 0014-drop-keycode-support]: https://github.com/vuejs/rfcs/blob/master/active-rfcs/0014-drop-keycode-support.md
 [API - Global Config - keyCodes]: https://vuejs.org/v2/api/#keyCodes
 

--- a/docs/rules/no-mutating-props.md
+++ b/docs/rules/no-mutating-props.md
@@ -92,7 +92,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide - Implicit parent-child communication](https://v3.vuejs.org/style-guide/#implicit-parent-child-communication-use-with-caution)
+- [Style guide - Implicit parent-child communication](https://vuejs.org/style-guide/rules-use-with-caution.html#implicit-parent-child-communication)
 - [Vue - Prop Mutation - deprecated](https://vuejs.org/v2/guide/migration.html#Prop-Mutation-deprecated)
 
 ## :rocket: Version

--- a/docs/rules/no-mutating-props.md
+++ b/docs/rules/no-mutating-props.md
@@ -93,7 +93,7 @@ Nothing.
 ## :books: Further Reading
 
 - [Style guide - Implicit parent-child communication](https://vuejs.org/style-guide/rules-use-with-caution.html#implicit-parent-child-communication)
-- [Vue - Prop Mutation - deprecated](https://vuejs.org/v2/guide/migration.html#Prop-Mutation-deprecated)
+- [Vue - Prop Mutation - deprecated](https://v2.vuejs.org/v2/guide/migration.html#Prop-Mutation-deprecated)
 
 ## :rocket: Version
 

--- a/docs/rules/no-reserved-component-names.md
+++ b/docs/rules/no-reserved-component-names.md
@@ -75,7 +75,7 @@ export default {
 - [List of html elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
 - [List of SVG elements](https://developer.mozilla.org/en-US/docs/Web/SVG/Element)
 - [Kebab case elements](https://stackoverflow.com/questions/22545621/do-custom-elements-require-a-dash-in-their-name/22545622#22545622)
-- [Valid custom element name](https://w3c.github.io/webcomponents/spec/custom/#valid-custom-element-name)
+- [Valid custom element name](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name)
 - [API - Built-In Components](https://v3.vuejs.org/api/built-in-components.html)
 - [API (for v2) - Built-In Components](https://v2.vuejs.org/v2/api/index.html#Built-In-Components)
 

--- a/docs/rules/no-reserved-component-names.md
+++ b/docs/rules/no-reserved-component-names.md
@@ -77,7 +77,7 @@ export default {
 - [Kebab case elements](https://stackoverflow.com/questions/22545621/do-custom-elements-require-a-dash-in-their-name/22545622#22545622)
 - [Valid custom element name](https://w3c.github.io/webcomponents/spec/custom/#valid-custom-element-name)
 - [API - Built-In Components](https://v3.vuejs.org/api/built-in-components.html)
-- [API (for v2) - Built-In Components](https://vuejs.org/v2/api/index.html#Built-In-Components)
+- [API (for v2) - Built-In Components](https://v2.vuejs.org/v2/api/index.html#Built-In-Components)
 
 ## :rocket: Version
 

--- a/docs/rules/no-shared-component-data.md
+++ b/docs/rules/no-shared-component-data.md
@@ -70,7 +70,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide (for v2) - Component data](https://vuejs.org/v2/style-guide/#Component-data-essential)
+- [Style guide (for v2) - Component data](https://v2.vuejs.org/v2/style-guide/#Component-data-essential)
 - [API - data](https://v3.vuejs.org/api/options-data.html#data-2)
 - [API (for v2) - data](https://v3.vuejs.org/api/options-data.html#data-2)
 

--- a/docs/rules/no-unsupported-features.md
+++ b/docs/rules/no-unsupported-features.md
@@ -45,7 +45,7 @@ The `"ignores"` option accepts an array of the following strings.
     - `"dynamic-directive-arguments"` ... [dynamic directive arguments](https://v3.vuejs.org/guide/template-syntax.html#dynamic-arguments).
     - `"v-slot"` ... [v-slot](https://v3.vuejs.org/api/directives.html#v-slot) directive.
   - Vue.js 2.5.0+
-    - `"slot-scope-attribute"` ... [slot-scope](https://vuejs.org/v2/api/#slot-scope-deprecated) attributes.
+    - `"slot-scope-attribute"` ... [slot-scope](https://v2.vuejs.org/v2/api/#slot-scope-deprecated) attributes.
 
 ### `{"version": "^2.6.0"}`
 
@@ -104,7 +104,7 @@ The `"ignores"` option accepts an array of the following strings.
 - [API - v-is (Old)](https://github.com/vuejs/docs-next/blob/008613756c3d781128d96b64a2d27f7598f8f548/src/api/directives.md#v-is)
 - [Guide - Dynamic Arguments](https://v3.vuejs.org/guide/template-syntax.html#dynamic-arguments)
 - [API - v-slot](https://v3.vuejs.org/api/directives.html#v-slot)
-- [API (for v2) - slot-scope](https://vuejs.org/v2/api/#slot-scope-deprecated)
+- [API (for v2) - slot-scope](https://v2.vuejs.org/v2/api/#slot-scope-deprecated)
 - [Vue RFCs - 0001-new-slot-syntax]
 - [Vue RFCs - 0002-slot-syntax-shorthand]
 - [Vue RFCs - 0003-dynamic-directive-arguments]

--- a/docs/rules/no-use-v-if-with-v-for.md
+++ b/docs/rules/no-use-v-if-with-v-for.md
@@ -89,7 +89,7 @@ There are two common cases where this can be tempting:
 
 ## :books: Further Reading
 
-- [Style guide - Avoid v-if with v-for](https://v3.vuejs.org/style-guide/#avoid-v-if-with-v-for-essential)
+- [Style guide - Avoid v-if with v-for](https://vuejs.org/style-guide/rules-essential.html#avoid-v-if-with-v-for)
 - [Guide - Conditional Rendering / v-if with v-for](https://v3.vuejs.org/guide/conditional.html#v-if-with-v-for)
 - [Guide - List Rendering / v-for with v-if](https://v3.vuejs.org/guide/list.html#v-for-with-v-if)
 

--- a/docs/rules/no-v-for-template-key-on-child.md
+++ b/docs/rules/no-v-for-template-key-on-child.md
@@ -17,7 +17,7 @@ This rule reports the key of the `<template v-for>` placed on the child elements
 
 In Vue.js 3.x, with the support for fragments, the `<template v-for>` key can be placed on the `<template>` tag.  
 
-See [Migration Guide - `key` attribute > With `<template v-for>`](https://v3.vuejs.org/guide/migration/key-attribute.html#with-template-v-for) for more details.
+See [Migration Guide - `key` attribute > With `<template v-for>`](https://v3-migration.vuejs.org/breaking-changes/key-attribute.html#with-template-v-for) for more details.
 
 ::: warning Note
 Do not use with the [vue/no-v-for-template-key] rule for Vue.js 2.x.  
@@ -54,7 +54,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Migration Guide - `key` attribute > With `<template v-for>`](https://v3.vuejs.org/guide/migration/key-attribute.html#with-template-v-for)
+- [Migration Guide - `key` attribute > With `<template v-for>`](https://v3-migration.vuejs.org/breaking-changes/key-attribute.html#with-template-v-for)
 
 ## :rocket: Version
 

--- a/docs/rules/no-v-for-template-key.md
+++ b/docs/rules/no-v-for-template-key.md
@@ -59,7 +59,7 @@ Nothing.
 ## :books: Further Reading
 
 - [API - Special Attributes - key](https://v3.vuejs.org/api/special-attributes.html#key)
-- [API (for v2) - Special Attributes - key](https://vuejs.org/v2/api/#key)
+- [API (for v2) - Special Attributes - key](https://v2.vuejs.org/v2/api/#key)
 
 ## :rocket: Version
 

--- a/docs/rules/one-component-per-file.md
+++ b/docs/rules/one-component-per-file.md
@@ -50,7 +50,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide - Component files](https://v3.vuejs.org/style-guide/#component-files-strongly-recommended)
+- [Style guide - Component files](https://vuejs.org/style-guide/rules-strongly-recommended.html#component-files)
 
 ## :rocket: Version
 

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -114,7 +114,7 @@ export default {
 ## :books: Further Reading
 
 - [Style guide - Component/instance options order](https://vuejs.org/style-guide/rules-recommended.html#component-instance-options-order)
-- [Style guide (for v2) - Component/instance options order](https://vuejs.org/v2/style-guide/#Component-instance-options-order-recommended)
+- [Style guide (for v2) - Component/instance options order](https://v2.vuejs.org/v2/style-guide/#Component-instance-options-order-recommended)
 
 ## :rocket: Version
 

--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -15,7 +15,7 @@ since: v3.2.0
 ## :book: Rule Details
 
 This rule makes sure you keep declared order of properties in components.
-Recommended order of properties can be [found here](https://v3.vuejs.org/style-guide/#component-instance-options-order-recommended).
+Recommended order of properties can be [found here](https://vuejs.org/style-guide/rules-recommended.html#component-instance-options-order).
 
 <eslint-code-block fix :rules="{'vue/order-in-components': ['error']}">
 
@@ -113,7 +113,7 @@ export default {
 
 ## :books: Further Reading
 
-- [Style guide - Component/instance options order](https://v3.vuejs.org/style-guide/#component-instance-options-order-recommended)
+- [Style guide - Component/instance options order](https://vuejs.org/style-guide/rules-recommended.html#component-instance-options-order)
 - [Style guide (for v2) - Component/instance options order](https://vuejs.org/v2/style-guide/#Component-instance-options-order-recommended)
 
 ## :rocket: Version

--- a/docs/rules/prop-name-casing.md
+++ b/docs/rules/prop-name-casing.md
@@ -68,7 +68,7 @@ export default {
 
 ## :books: Further Reading
 
-- [Style guide - Prop name casing](https://v3.vuejs.org/style-guide/#prop-name-casing-strongly-recommended)
+- [Style guide - Prop name casing](https://vuejs.org/style-guide/rules-strongly-recommended.html#prop-name-casing)
 
 ## :couple: Related Rules
 

--- a/docs/rules/require-default-prop.md
+++ b/docs/rules/require-default-prop.md
@@ -63,7 +63,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide - Prop definitions](https://v3.vuejs.org/style-guide/#prop-definitions-essential)
+- [Style guide - Prop definitions](https://vuejs.org/style-guide/rules-essential.html#use-detailed-prop-definitions)
 
 ## :rocket: Version
 

--- a/docs/rules/require-prop-types.md
+++ b/docs/rules/require-prop-types.md
@@ -65,7 +65,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide - Prop definitions](https://v3.vuejs.org/style-guide/#prop-definitions-essential)
+- [Style guide - Prop definitions](https://vuejs.org/style-guide/rules-essential.html#use-detailed-prop-definitions)
 
 ## :rocket: Version
 

--- a/docs/rules/require-v-for-key.md
+++ b/docs/rules/require-v-for-key.md
@@ -49,7 +49,7 @@ Nothing.
 ## :books: Further Reading
 
 - [Style guide - Keyed v-for](https://vuejs.org/style-guide/rules-essential.html#use-keyed-v-for)
-- [Guide (for v2) - v-for with a Component](https://vuejs.org/v2/guide/list.html#v-for-with-a-Component)
+- [Guide (for v2) - v-for with a Component](https://v2.vuejs.org/v2/guide/list.html#v-for-with-a-Component)
 
 ## :rocket: Version
 

--- a/docs/rules/require-v-for-key.md
+++ b/docs/rules/require-v-for-key.md
@@ -48,7 +48,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Style guide - Keyed v-for](https://v3.vuejs.org/style-guide/#keyed-v-for-essential)
+- [Style guide - Keyed v-for](https://vuejs.org/style-guide/rules-essential.html#use-keyed-v-for)
 - [Guide (for v2) - v-for with a Component](https://vuejs.org/v2/guide/list.html#v-for-with-a-Component)
 
 ## :rocket: Version

--- a/docs/rules/script-indent.md
+++ b/docs/rules/script-indent.md
@@ -117,7 +117,7 @@ This rule only checks `.vue` files and does not interfere with other `.js` files
 
 - [indent](https://eslint.org/docs/rules/indent)
 - [vue/html-indent](./html-indent.md)
-- [@typescript-eslint/indent](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/indent.md)
+- [@typescript-eslint/indent](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/indent.md)
 
 ## :rocket: Version
 

--- a/docs/rules/v-bind-style.md
+++ b/docs/rules/v-bind-style.md
@@ -60,7 +60,7 @@ Default is set to `shorthand`.
 
 ## :books: Further Reading
 
-- [Style guide - Directive shorthands](https://v3.vuejs.org/style-guide/#directive-shorthands-strongly-recommended)
+- [Style guide - Directive shorthands](https://vuejs.org/style-guide/rules-strongly-recommended.html#directive-shorthands)
 
 ## :rocket: Version
 

--- a/docs/rules/v-on-style.md
+++ b/docs/rules/v-on-style.md
@@ -60,7 +60,7 @@ Default is set to `shorthand`.
 
 ## :books: Further Reading
 
-- [Style guide - Directive shorthands](https://v3.vuejs.org/style-guide/#directive-shorthands-strongly-recommended)
+- [Style guide - Directive shorthands](https://vuejs.org/style-guide/rules-strongly-recommended.html#directive-shorthands)
 
 ## :rocket: Version
 

--- a/docs/rules/v-slot-style.md
+++ b/docs/rules/v-slot-style.md
@@ -105,7 +105,7 @@ And a string option is supported to be consistent to similar `vue/v-bind-style` 
 
 ## :books: Further Reading
 
-- [Style guide - Directive shorthands](https://v3.vuejs.org/style-guide/#directive-shorthands-strongly-recommended)
+- [Style guide - Directive shorthands](https://vuejs.org/style-guide/rules-strongly-recommended.html#directive-shorthands)
 
 ## :rocket: Version
 

--- a/docs/rules/valid-next-tick.md
+++ b/docs/rules/valid-next-tick.md
@@ -80,7 +80,7 @@ Nothing.
 
 - [`Vue.nextTick` API in Vue 2](https://vuejs.org/v2/api/#Vue-nextTick)
 - [`vm.$nextTick` API in Vue 2](https://vuejs.org/v2/api/#vm-nextTick)
-- [Global API Treeshaking](https://v3.vuejs.org/guide/migration/global-api-treeshaking.html)
+- [Global API Treeshaking](https://v3-migration.vuejs.org/breaking-changes/global-api-treeshaking.html)
 - [Global `nextTick` API in Vue 3](https://v3.vuejs.org/api/global-api.html#nexttick)
 - [Instance `$nextTick` API in Vue 3](https://v3.vuejs.org/api/instance-methods.html#nexttick)
 

--- a/docs/rules/valid-next-tick.md
+++ b/docs/rules/valid-next-tick.md
@@ -78,8 +78,8 @@ Nothing.
 
 ## :books: Further Reading
 
-- [`Vue.nextTick` API in Vue 2](https://vuejs.org/v2/api/#Vue-nextTick)
-- [`vm.$nextTick` API in Vue 2](https://vuejs.org/v2/api/#vm-nextTick)
+- [`Vue.nextTick` API in Vue 2](https://v2.vuejs.org/v2/api/#Vue-nextTick)
+- [`vm.$nextTick` API in Vue 2](https://v2.vuejs.org/v2/api/#vm-nextTick)
 - [Global API Treeshaking](https://v3-migration.vuejs.org/breaking-changes/global-api-treeshaking.html)
 - [Global `nextTick` API in Vue 3](https://v3.vuejs.org/api/global-api.html#nexttick)
 - [Instance `$nextTick` API in Vue 3](https://v3.vuejs.org/api/instance-methods.html#nexttick)

--- a/docs/rules/valid-v-bind-sync.md
+++ b/docs/rules/valid-v-bind-sync.md
@@ -70,7 +70,7 @@ Nothing.
 
 ## :books: Further Reading
 
-- [Guide (for v2) - `.sync` Modifier](https://vuejs.org/v2/guide/components-custom-events.html#sync-Modifier)
+- [Guide (for v2) - `.sync` Modifier](https://v2.vuejs.org/v2/guide/components-custom-events.html#sync-Modifier)
 
 ## :rocket: Version
 

--- a/lib/rules/no-use-v-if-with-v-for.js
+++ b/lib/rules/no-use-v-if-with-v-for.js
@@ -1,7 +1,7 @@
 /**
  * @author Yosuke Ota
  *
- * Style guide: https://v3.vuejs.org/style-guide/#avoid-v-if-with-v-for-essential
+ * Style guide: https://vuejs.org/style-guide/rules-essential.html#avoid-v-if-with-v-for
  */
 'use strict'
 


### PR DESCRIPTION
Fixes #1802.

My process:

1. Search and replace all:
	```diff
	- https://v3.vuejs.org/style-guide/#([\w-]+?)-(essential|strongly-recommended|recommended|use-with-caution)
	+ https://vuejs.org/style-guide/rules-$2.html#$1
	```
	Then manually go through all changed links and adjust them if necessary: [`e756226`](https://github.com/vuejs/eslint-plugin-vue/pull/1803/commits/e756226ddcf8b7537b5fbbd890e79843a829eafb)
2. Search and replace all:
	```diff
	- https://v3.vuejs.org/guide/migration/([\w-]+).html
	+ https://v3-migration.vuejs.org/breaking-changes/$1.html
	```
	Then manually go through all changed links and adjust them if necessary: [`d195cab`](https://github.com/vuejs/eslint-plugin-vue/pull/1803/commits/d195cab74c84871278738c71cee3c48304120fc7)
3. Search and replace all:
	```diff
	- https://vuejs.org/v2
	+ https://v2.vuejs.org/v2
	```
	Then manually go through all changed links and adjust them if necessary: [`6a3070e`](https://github.com/vuejs/eslint-plugin-vue/pull/1803/commits/6a3070e552d065a1921ebcec42df03a5c948dbaf)
4. Manually go through all `https://v3.vuejs.org/` links and adjust them: [`143d896`](https://github.com/vuejs/eslint-plugin-vue/pull/1803/commits/143d896ceffacac93444f06ab4edcfaf050947a5)
5. Temporarily install https://github.com/tcort/markdown-link-check with `npm i -D markdown-link-check`
6. Run `find -name "*.md" -not -path "./node_modules/*" -print0 | xargs -0 -n1 npx markdown-link-check --progress --quiet --alive 200 --retry` and fix all failing links: [`bc5cc10`](https://github.com/vuejs/eslint-plugin-vue/pull/1803/commits/bc5cc1035b119be9484a1a788066a406fe4bfddc)