### PR TITLE
Auto-fix for vue/component-tags-order

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -167,7 +167,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [vue/attributes-order](./attributes-order.md) | enforce order of attributes | :wrench: |
-| [vue/component-tags-order](./component-tags-order.md) | enforce order of component top-level elements |  |
+| [vue/component-tags-order](./component-tags-order.md) | enforce order of component top-level elements | :wrench: |
 | [vue/no-lone-template](./no-lone-template.md) | disallow unnecessary `<template>` |  |
 | [vue/no-multiple-slot-args](./no-multiple-slot-args.md) | disallow to pass multiple arguments to scoped slots |  |
 | [vue/no-v-html](./no-v-html.md) | disallow use of v-html to prevent XSS attack |  |
@@ -283,7 +283,7 @@ Enforce all the rules in this category, as well as all higher priority rules, wi
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 | [vue/attributes-order](./attributes-order.md) | enforce order of attributes | :wrench: |
-| [vue/component-tags-order](./component-tags-order.md) | enforce order of component top-level elements |  |
+| [vue/component-tags-order](./component-tags-order.md) | enforce order of component top-level elements | :wrench: |
 | [vue/no-lone-template](./no-lone-template.md) | disallow unnecessary `<template>` |  |
 | [vue/no-multiple-slot-args](./no-multiple-slot-args.md) | disallow to pass multiple arguments to scoped slots |  |
 | [vue/no-v-html](./no-v-html.md) | disallow use of v-html to prevent XSS attack |  |

--- a/docs/rules/component-tags-order.md
+++ b/docs/rules/component-tags-order.md
@@ -10,6 +10,7 @@ since: v6.1.0
 > enforce order of component top-level elements
 
 - :gear: This rule is included in `"plugin:vue/vue3-recommended"` and `"plugin:vue/recommended"`.
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details
 
@@ -29,7 +30,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 ### `{ "order": [ [ "script", "template" ], "style" ] }` (default)
 
-<eslint-code-block :rules="{'vue/component-tags-order': ['error']}">
+<eslint-code-block fix :rules="{'vue/component-tags-order': ['error']}">
 
 ```vue
 <!-- ✓ GOOD -->
@@ -40,7 +41,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/component-tags-order': ['error']}">
+<eslint-code-block fix :rules="{'vue/component-tags-order': ['error']}">
 
 ```vue
 <!-- ✓ GOOD -->
@@ -51,7 +52,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/component-tags-order': ['error']}">
+<eslint-code-block fix :rules="{'vue/component-tags-order': ['error']}">
 
 ```vue
 <!-- ✗ BAD -->
@@ -64,7 +65,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 ### `{ "order": ["template", "script", "style"] }`
 
-<eslint-code-block :rules="{'vue/component-tags-order': ['error', { 'order': ['template', 'script', 'style'] }]}">
+<eslint-code-block fix :rules="{'vue/component-tags-order': ['error', { 'order': ['template', 'script', 'style'] }]}">
 
 ```vue
 <!-- ✓ GOOD -->
@@ -75,7 +76,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/component-tags-order': ['error', { 'order': ['template', 'script', 'style'] }]}">
+<eslint-code-block fix :rules="{'vue/component-tags-order': ['error', { 'order': ['template', 'script', 'style'] }]}">
 
 ```vue
 <!-- ✗ BAD -->
@@ -88,7 +89,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 ### `{ "order": ["docs", "template", "script", "style"] }`
 
-<eslint-code-block :rules="{'vue/component-tags-order': ['error', { 'order': ['docs', 'template', 'script', 'style'] }]}">
+<eslint-code-block fix :rules="{'vue/component-tags-order': ['error', { 'order': ['docs', 'template', 'script', 'style'] }]}">
 
 ```vue
 <!-- ✓ GOOD -->
@@ -100,7 +101,7 @@ This rule warns about the order of the `<script>`, `<template>` & `<style>` tags
 
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/component-tags-order': ['error', { 'order': ['docs', 'template', 'script', 'style'] }]}">
+<eslint-code-block fix :rules="{'vue/component-tags-order': ['error', { 'order': ['docs', 'template', 'script', 'style'] }]}">
 
 ```vue
 <!-- ✗ BAD -->

--- a/lib/rules/component-tags-order.js
+++ b/lib/rules/component-tags-order.js
@@ -24,7 +24,7 @@ module.exports = {
       categories: ['vue3-recommended', 'recommended'],
       url: 'https://eslint.vuejs.org/rules/component-tags-order.html'
     },
-    fixable: null,
+    fixable: 'code',
     schema: [
       {
         type: 'object',
@@ -87,30 +87,13 @@ module.exports = {
       return []
     }
 
-    /**
-     * @param {VElement} element
-     * @param {VElement} firstUnorderedElement
-     */
-    function report(element, firstUnorderedElement) {
-      context.report({
-        node: element,
-        loc: element.loc,
-        messageId: 'unexpected',
-        data: {
-          name: element.name,
-          firstUnorderedName: firstUnorderedElement.name,
-          line: firstUnorderedElement.loc.start.line
-        }
-      })
-    }
-
     return {
       Program(node) {
         if (utils.hasInvalidEOF(node)) {
           return
         }
         const elements = getTopLevelHTMLElements()
-
+        const sourceCode = context.getSourceCode()
         elements.forEach((element, index) => {
           const expectedIndex = getOrderPosition(element.name)
           if (expectedIndex < 0) {
@@ -123,7 +106,35 @@ module.exports = {
               (e1, e2) => getOrderPosition(e1.name) - getOrderPosition(e2.name)
             )[0]
           if (firstUnordered) {
-            report(element, firstUnordered)
+            context.report({
+              node: element,
+              loc: element.loc,
+              messageId: 'unexpected',
+              data: {
+                name: element.name,
+                firstUnorderedName: firstUnordered.name,
+                line: firstUnordered.loc.start.line
+              },
+              *fix(fixer) {
+                // insert element before firstUnordered
+                const fixedElements = elements.flatMap((it) => {
+                  if (it === firstUnordered) {
+                    return [element, it]
+                  } else if (it === element) {
+                    return []
+                  }
+                  return [it]
+                })
+                for (let i = elements.length - 1; i >= 0; i--) {
+                  if (elements[i] !== fixedElements[i]) {
+                    yield fixer.replaceTextRange(
+                      elements[i].range,
+                      sourceCode.text.slice(...fixedElements[i].range)
+                    )
+                  }
+                }
+              }
+            })
           }
         })
       }

--- a/tests/lib/rules/component-tags-order.js
+++ b/tests/lib/rules/component-tags-order.js
@@ -357,7 +357,9 @@ describe('suppress reporting with eslint-disable-next-line', () => {
     const code = `<style></style><template></template>
     <!-- eslint-disable-next-line vue/component-tags-order -->
     <script></script>`
-    const [{ messages, output }] = await eslint.lintText(code, { filePath: 'test.vue' })
+    const [{ messages, output }] = await eslint.lintText(code, {
+      filePath: 'test.vue'
+    })
     assert.strictEqual(messages.length, 0)
     // should not fix <script>
     assert.strictEqual(

--- a/tests/lib/rules/component-tags-order.js
+++ b/tests/lib/rules/component-tags-order.js
@@ -26,7 +26,8 @@ const eslint = new ESLint({
     }
   },
   useEslintrc: false,
-  plugins: { vue: require('../../../lib/index') }
+  plugins: { vue: require('../../../lib/index') },
+  fix: true
 })
 
 // ------------------------------------------------------------------------------
@@ -356,12 +357,14 @@ describe('suppress reporting with eslint-disable-next-line', () => {
     const code = `<style></style><template></template>
     <!-- eslint-disable-next-line vue/component-tags-order -->
     <script></script>`
-    const [{ messages }] = await eslint.lintText(code, { filePath: 'test.vue' })
-    assert.strictEqual(messages.length, 1)
+    const [{ messages, output }] = await eslint.lintText(code, { filePath: 'test.vue' })
+    assert.strictEqual(messages.length, 0)
     // should not fix <script>
     assert.strictEqual(
-      messages[0].fix.text,
-      '<template></template><style></style>'
+      output,
+      `<template></template><style></style>
+    <!-- eslint-disable-next-line vue/component-tags-order -->
+    <script></script>`
     )
   })
 })


### PR DESCRIPTION
Fixes #1463.
This PR reflects the comments from @ota-meshi in #1512 . It yields a fix for each reported error, so eslint-disable comments work normally. Added a test case for eslint-disable comment.