### PR TITLE
first-attribute-linebreak is not included in plugin:vue/recommended

### DIFF
--- a/docs/rules/first-attribute-linebreak.md
+++ b/docs/rules/first-attribute-linebreak.md
@@ -9,7 +9,7 @@ since: v8.0.0
 
 > enforce the location of first attribute
 
-- :gear: This rule is included in all of `"plugin:vue/vue3-strongly-recommended"`, `"plugin:vue/strongly-recommended"`, `"plugin:vue/vue3-recommended"` and `"plugin:vue/recommended"`.
+- :gear: This rule is included in all of `"plugin:vue/vue3-strongly-recommended"`, `"plugin:vue/strongly-recommended"` and `"plugin:vue/vue3-recommended"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details


### PR DESCRIPTION
See [eslint rules](https://eslint.vuejs.org/rules/#priority-c-recommended-minimizing-arbitrary-choices-and-cognitive-overhead-for-vue-js-2-x) and [the repo search](https://github.com/vuejs/eslint-plugin-vue/search?q=first-attribute-linebreak). This attribute is not included in vue/recommended.

Also when [this rule was added](https://github.com/vuejs/eslint-plugin-vue/pull/1587), wasn't suggested to be part of the vue/recommended 