### PR TITLE
fix: get the real filename to avoid rule invalidation

### DIFF
--- a/lib/rules/multi-word-component-names.js
+++ b/lib/rules/multi-word-component-names.js
@@ -111,7 +111,7 @@ module.exports = {
         'Program:exit'(node) {
           if (hasName) return
           if (!hasVue && node.body.length > 0) return
-          const fileName = context.getFilename()
+          const fileName = context.getPhysicalFilename()
           const componentName = path.basename(fileName, path.extname(fileName))
           if (
             utils.isVueFile(fileName) &&

--- a/lib/rules/multi-word-component-names.js
+++ b/lib/rules/multi-word-component-names.js
@@ -111,7 +111,7 @@ module.exports = {
         'Program:exit'(node) {
           if (hasName) return
           if (!hasVue && node.body.length > 0) return
-          const fileName = context.getPhysicalFilename()
+          const fileName = utils.getPhysicalFilename(context)
           const componentName = path.basename(fileName, path.extname(fileName))
           if (
             utils.isVueFile(fileName) &&

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -52,7 +52,7 @@ module.exports = {
     return {
       Program(node) {
         if (context.parserServices.getTemplateBodyTokenStore == null) {
-          const filename = context.getPhysicalFilename()
+          const filename = utils.getPhysicalFilename(context)
           if (utils.isVueFile(filename)) {
             context.report({
               loc: { line: 1, column: 0 },

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const path = require('path')
+const utils = require('../utils')
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -52,8 +52,8 @@ module.exports = {
     return {
       Program(node) {
         if (context.parserServices.getTemplateBodyTokenStore == null) {
-          const filename = context.getFilename()
-          if (path.extname(filename) === '.vue') {
+          const filename = context.getPhysicalFilename()
+          if (utils.isVueFile(filename)) {
             context.report({
               loc: { line: 1, column: 0 },
               message:

--- a/lib/rules/require-direct-export.js
+++ b/lib/rules/require-direct-export.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
-    const filePath = context.getFilename()
+    const filePath = context.getPhysicalFilename()
     if (!utils.isVueFile(filePath)) return {}
 
     const disallowFunctional = (context.options[0] || {})

--- a/lib/rules/require-direct-export.js
+++ b/lib/rules/require-direct-export.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
-    const filePath = context.getPhysicalFilename()
+    const filePath = utils.getPhysicalFilename(context)
     if (!utils.isVueFile(filePath)) return {}
 
     const disallowFunctional = (context.options[0] || {})

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -33,6 +33,7 @@ const {
   last
 } = require('./indent-utils')
 const { defineVisitor: tsDefineVisitor } = require('./indent-ts')
+const utils = require('../utils')
 
 /**
  * @typedef {import('../../typings/eslint-plugin-vue/util-types/node').HasLocation} HasLocation
@@ -205,7 +206,8 @@ module.exports.defineVisitor = function create(
   tokenStore,
   defaultOptions
 ) {
-  if (!context.getFilename().endsWith('.vue')) return {}
+  const filename = context.getPhysicalFilename()
+  if (!utils.isVueFile(filename)) return {}
 
   const options = parseOptions(
     context.options[0],

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -206,7 +206,7 @@ module.exports.defineVisitor = function create(
   tokenStore,
   defaultOptions
 ) {
-  const filename = context.getPhysicalFilename()
+  const filename = utils.getPhysicalFilename(context)
   if (!utils.isVueFile(filename)) return {}
 
   const options = parseOptions(

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1987,8 +1987,8 @@ function defineTemplateBodyVisitor(
   options
 ) {
   if (context.parserServices.defineTemplateBodyVisitor == null) {
-    const filename = context.getFilename()
-    if (path.extname(filename) === '.vue') {
+    const filename = context.getPhysicalFilename()
+    if (isVueFile(filename)) {
       context.report({
         loc: { line: 1, column: 0 },
         message:
@@ -2015,8 +2015,8 @@ function defineTemplateBodyVisitor(
  */
 function defineDocumentVisitor(context, documentVisitor, options) {
   if (context.parserServices.defineDocumentVisitor == null) {
-    const filename = context.getFilename()
-    if (path.extname(filename) === '.vue') {
+    const filename = context.getPhysicalFilename()
+    if (isVueFile(filename)) {
       context.report({
         loc: { line: 1, column: 0 },
         message:
@@ -2373,6 +2373,14 @@ function getVExpressionContainer(node) {
  * @param {string} path
  */
 function isVueFile(path) {
+  /**
+   * When `path` is `context.getFilename()`, it returns the filename associated with the source or `<input>` if not specified.
+   * When `path` is `context.getPhysicalFilename()`, it returns the full path of the file on disk or `<text>` if not specified.
+   * If filename is not specified, we assume it's a vue file.
+   */
+  if (['<input>', '<text>'].includes(path)) {
+    return true
+  }
   return path.endsWith('.vue') || path.endsWith('.jsx')
 }
 
@@ -2583,7 +2591,7 @@ function isSFCObject(context, node) {
   if (node.type !== 'ObjectExpression') {
     return false
   }
-  const filePath = context.getFilename()
+  const filePath = context.getPhysicalFilename()
   const ext = path.extname(filePath)
   if (ext !== '.vue' && ext) {
     return false

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -311,6 +311,18 @@ function wrapContextToOverrideReportMethodToSkipDynamicArgument(context) {
   })
 }
 
+/**
+ * Return the full path of the file on disk, if not set, it will fallback to `context.getFilename()`.
+ * @param {RuleContext} context The ESLint rule context.
+ * @returns {string}
+ */
+function getPhysicalFilename(context) {
+  if (context.getPhysicalFilename) {
+    return context.getPhysicalFilename()
+  }
+  return context.getFilename()
+}
+
 // ------------------------------------------------------------------------------
 // Exports
 // ------------------------------------------------------------------------------
@@ -1891,7 +1903,14 @@ module.exports = {
     }
 
     return true
-  }
+  },
+
+  /**
+   * Return the full path of the file on disk, if not set, it will fallback to `context.getFilename()`.
+   * @param {RuleContext} context The ESLint rule context.
+   * @returns {string}
+   */
+  getPhysicalFilename
 }
 
 // ------------------------------------------------------------------------------
@@ -1987,7 +2006,7 @@ function defineTemplateBodyVisitor(
   options
 ) {
   if (context.parserServices.defineTemplateBodyVisitor == null) {
-    const filename = context.getPhysicalFilename()
+    const filename = getPhysicalFilename(context)
     if (isVueFile(filename)) {
       context.report({
         loc: { line: 1, column: 0 },
@@ -2015,7 +2034,7 @@ function defineTemplateBodyVisitor(
  */
 function defineDocumentVisitor(context, documentVisitor, options) {
   if (context.parserServices.defineDocumentVisitor == null) {
-    const filename = context.getPhysicalFilename()
+    const filename = getPhysicalFilename(context)
     if (isVueFile(filename)) {
       context.report({
         loc: { line: 1, column: 0 },
@@ -2591,7 +2610,7 @@ function isSFCObject(context, node) {
   if (node.type !== 'ObjectExpression') {
     return false
   }
-  const filePath = context.getPhysicalFilename()
+  const filePath = getPhysicalFilename(context)
   const ext = path.extname(filePath)
   if (ext !== '.vue' && ext) {
     return false

--- a/typings/eslint/index.d.ts
+++ b/typings/eslint/index.d.ts
@@ -337,7 +337,7 @@ export namespace Rule {
      * This was added in eslint@7.28.0
      * @since 7.28.0
      */
-    getPhysicalFilename: () => string
+    getPhysicalFilename?: () => string
   }
 
   type ReportDescriptor =

--- a/typings/eslint/index.d.ts
+++ b/typings/eslint/index.d.ts
@@ -329,6 +329,15 @@ export namespace Rule {
 
     // eslint@6 does not have this method.
     getCwd?: () => string
+
+    /**
+     * When linting a file, it returns the full path of the file on disk without any code block information.
+     * When linting text, it returns the value passed to `—stdin-filename` or `<text>` if not specified.
+     * If not set, it will fallback to `getFilename()`
+     * This was added in eslint@7.28.0
+     * @since 7.28.0
+     */
+    getPhysicalFilename: () => string
   }
 
   type ReportDescriptor =


### PR DESCRIPTION
**Checklist**

- [x] I have tried restarting my IDE and the issue persists.
- [x] I have read the [FAQ](https://eslint.vuejs.org/user-guide/#faq) and my problem is not listed.

**Tell us about your environment**

- **ESLint version:** 8.12.0
- **eslint-plugin-vue version:** 8.6.0
- **Node version:** 16.13.2
- **Operating System:** MacBook Pro/12.3

**Please show your full configuration:**

```js
const { defineConfig } = require('eslint-define-config');

module.exports = defineConfig({
  root: true,
  env: {
    browser: true,
    node: true,
    es2021: true,
  },
  extends: [
    require.resolve('./es'),
    require.resolve('./vue'),
  ],
  plugins: [
    'vue',
    '@typescript-eslint',

    // This plugin is used to rename `.vue` file with `lang="js"` to `.jsvue` code-block through eslint plugin's `preprocess`
    'vue-lang',
  ],
  overrides: [
    {
      files: ['**/*.js', '**/*.jsx', '**/*.jsvue '],
      parser: 'vue-eslint-parser',
      parserOptions: {
        parser: 'espree',
        ecmaVersion: 'latest',
        sourceType: 'module',
        ecmaFeatures: {
          jsx: true,
        },
      },
    },
    {
      files: ['**/*.ts', '**/*.tsx', '**/*.vue'],
      parser: 'vue-eslint-parser',
      parserOptions: {
        parser: '@typescript-eslint/parser',
        project: './tsconfig.json',
        extraFileExtensions: ['.vue'],
        ecmaVersion: 'latest',
        sourceType: 'module',
        ecmaFeatures: {
          jsx: true,
        },
      },
      extends: [
        require.resolve('./typescript'),
      ],
    },
  ],
});
```

**What did you do?**	

Our projects are migrating from JS to TS in stages, at the stage where Vue files exist with both languages, it is difficult to set up an ESLint configuration that includes TS rules, so i rename `.vue` file with `lang="js"` to `.jsvue` code-block through the eslint-plugin's `preprocess` hook, then we can apply the rules separately.

**What did you expect to happen?**

I hope the `eslint-plugin-vue` can verify the `.jsvue` code-block normally, because i specified that the `.jsvue` code-block is parsed with the `vue-eslint-parser`.

**What actually happened?**

The following rules are invalid
- `vue/require-direct-export`
- `vue/multi-word-component-names`
- `vue/html-indent`

**Why this happened?**

> The above rules are invalid because they are not considered to be in the Vue file. 

Because the `eslint-plugin-vue` use the `context.getFilename()` to get the filename, and uses it as a condition for judging whether it is a Vue file, but exceptions may be caused in the following cases:
- Use the eslint-plugin's `preprocess` hook to rename the code-block:

  ```js
  const processor = {
    preprocess(text, filename) {
      // ...
      const isTSLang = false;
  
      if (isTSLang) {
        return vueProcessor.preprocess(text)
      }
  
      return [{
        text,
        filename: filename.replace(/\.vue$/, `.jsvue`), // change ext
      }];
    },
  };
  ```
  > In this case, the filename obtained by `context.getFilename()` is `**/*.jsvue`, which results in `eslint-plugin-vue` being judged as not a Vue file.

- Use the ESLint CLI to lint text, in this case, the filename obtained by `context.getFilename()` is `<input>` or `<text>`, if not specified.

**How to fix**

Since ESLint@7.28.0, the `context.getPhysicalFilename()` method is provided to the user to obtain t the full path of the file on disk without any code block information, we can use the `context.getPhysicalFilename()` method to avoid misjudging the file as not a Vue file.

**References**

- https://github.com/eslint/eslint/issues/11989
- https://github.com/import-js/eslint-plugin-import/pull/2160