### PR TITLE
Improve warning wording in `vue/no-v-for-template-key-on-child` docs

### DIFF
--- a/docs/rules/no-v-for-template-key-on-child.md
+++ b/docs/rules/no-v-for-template-key-on-child.md
@@ -20,7 +20,7 @@ In Vue.js 3.x, with the support for fragments, the `<template v-for>` key can be
 See [Migration Guide - `key` attribute > With `<template v-for>`](https://v3-migration.vuejs.org/breaking-changes/key-attribute.html#with-template-v-for) for more details.
 
 ::: warning Note
-Do not use with the [vue/no-v-for-template-key] rule for Vue.js 2.x.  
+Do not use with the [vue/no-v-for-template-key-on-child] rule for Vue.js 2.x.  
 This rule conflicts with the [vue/no-v-for-template-key] rule.
 :::
 

--- a/docs/rules/no-v-for-template-key-on-child.md
+++ b/docs/rules/no-v-for-template-key-on-child.md
@@ -20,8 +20,8 @@ In Vue.js 3.x, with the support for fragments, the `<template v-for>` key can be
 See [Migration Guide - `key` attribute > With `<template v-for>`](https://v3-migration.vuejs.org/breaking-changes/key-attribute.html#with-template-v-for) for more details.
 
 ::: warning Note
-Do not use with the [vue/no-v-for-template-key-on-child] rule for Vue.js 2.x.  
-This rule conflicts with the [vue/no-v-for-template-key] rule.
+This rule is targeted at Vue.js 3.x.
+If you are using Vue.js 2.x, enable the [vue/no-v-for-template-key] rule instead. Don't enable both rules together; they are conflicting.
 :::
 
 <eslint-code-block :rules="{'vue/no-v-for-template-key-on-child': ['error']}">


### PR DESCRIPTION
fix the warning note on rule conflicts between vue/no-v-for-template-key and vue/no-v-for-template-key-on-child