### PR TITLE
Add runOutsideVue option to vue/sort-keys

### DIFF
--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -79,7 +79,8 @@ export default {
         "ignoreChildrenOf": ["model"],
         "ignoreGrandchildrenOf": ["computed", "directives", "inject", "props", "watch"],
         "minKeys": 2,
-        "natural": false
+        "natural": false,
+        "runOutsideVue": true,
   }]
 }
 ```
@@ -96,6 +97,7 @@ The 2nd option is an object which has 5 properties.
 - `ignoreGrandchildrenOf` - an array of properties to ignore the grandchildren sort order. Default is `["computed", "directives", "inject", "props", "watch"]`
 - `minKeys` - Specifies the minimum number of keys that an object should have in order for the object's unsorted keys to produce an error. Default is `2`, which means by default all objects with unsorted keys will result in lint errors.
 - `natural` - if `true`, enforce properties to be in natural order. Default is `false`. Natural Order compares strings containing combination of letters and numbers in the way a human being would sort. It basically sorts numerically, instead of sorting alphabetically. So the number 10 comes after the number 3 in Natural Sorting.
+- `runOutsideVue` - if `false`, this rule will ignore all keys outside of Vue. Default is `true`. Any child keys of a Vue instance are considered to be inside Vue.
 
 While using this rule, you may disable the normal `sort-keys` rule.  This rule will apply to plain js files as well as Vue component scripts.
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -38,6 +38,17 @@ function getPropertyName(node) {
 }
 
 /**
+ * Checks if the given property is a method named data.
+ *
+ * @param {Property} node The `Property` node to get.
+ * @returns {Boolean}
+ * @private
+ */
+function isDataMethod(node) {
+  return node.method && getPropertyName(node) === 'data'
+}
+
+/**
  * Functions which check that the given 2 names are in specific order.
  *
  * Postfix `I` is meant insensitive.
@@ -162,6 +173,7 @@ module.exports = {
      * @property {string | null} ObjectStack.prevName
      * @property {number} ObjectStack.numKeys
      * @property {VueState} ObjectStack.vueState
+     * @property {boolean} ObjectStack.withinVueData
      *
      * @typedef {object} VueState
      * @property {Property} [VueState.currentProperty]
@@ -187,7 +199,8 @@ module.exports = {
           upper: objectStack,
           prevName: null,
           numKeys: node.properties.length,
-          vueState
+          vueState,
+          withinVueData: !!objectStack && objectStack.withinVueData
         }
 
         vueState.isVueObject = utils.getVueObjectType(context, node) != null
@@ -247,10 +260,17 @@ module.exports = {
         if (!objectStack) {
           return
         }
+
+        if (objectStack.vueState.isVueObject && isDataMethod(node)) {
+          objectStack.withinVueData = true
+        }
+
         objectStack.vueState.currentProperty = node
         if (
           objectStack.vueState.ignore ||
-          (onlyInsideVue && !objectStack.vueState.within)
+          (onlyInsideVue &&
+            !objectStack.vueState.within &&
+            !objectStack.withinVueData)
         ) {
           return
         }

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -152,6 +152,7 @@ module.exports = {
     const insensitive = options && options.caseSensitive === false
     const minKeys = options && options.minKeys
     const natural = options && options.natural
+    const onlyInsideVue = options && options.runOutsideVue === false
     const isValidOrder =
       isValidOrders[order + (insensitive ? 'I' : '') + (natural ? 'N' : '')]
 
@@ -247,7 +248,10 @@ module.exports = {
           return
         }
         objectStack.vueState.currentProperty = node
-        if (objectStack.vueState.ignore) {
+        if (
+          objectStack.vueState.ignore ||
+          (onlyInsideVue && !objectStack.vueState.within)
+        ) {
           return
         }
         const prevName = objectStack.prevName

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -510,7 +510,7 @@ ruleTester.run('sort-keys', rule, {
 
     // runOutsideVue (false) should ignore unsorted keys outside of vue
     {
-      code: 'var obj = { c:3, a:1, b:2}',
+      code: 'var obj = {c:3, a:1, b:2}',
       options: ['asc', { runOutsideVue: false }]
     },
     {

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -506,6 +506,50 @@ ruleTester.run('sort-keys', rule, {
     {
       code: 'var obj = {a:1, _:2, b:3}',
       options: ['desc', { natural: true, caseSensitive: false, minKeys: 4 }]
+    },
+
+    // runOutsideVue (false) should ignore unsorted keys outside of vue
+    {
+      code: 'var obj = { c:3, a:1, b:2}',
+      options: ['asc', { runOutsideVue: false }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { component } = Vue;
+        component('test', {
+          name: 'app',
+          data () {
+            return {
+              c: 3,
+              a: 1,
+              b: 2
+            }
+          }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      options: ['asc', { runOutsideVue: false }]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { component } = Vue;
+        component('test', {
+          name: 'app',
+          computed: {
+            test () {
+              return {
+                c: 3,
+                a: 1,
+                b: 2
+              }
+            }
+          }
+        })
+      `,
+      parserOptions: { ecmaVersion: 6 },
+      options: ['asc', { runOutsideVue: false }]
     }
   ],
 
@@ -1493,6 +1537,58 @@ ruleTester.run('sort-keys', rule, {
           message:
             "Expected object keys to be in ascending order. 'a' should be before 'b'.",
           line: 7
+        }
+      ]
+    },
+
+    // runOutsideVue (false)
+    {
+      filename: 'test.js',
+      code: `
+        const { component } = Vue;
+        component('test', {
+          name: 'app',
+          computed: {
+            b () {
+              return true
+            },
+            a () {
+              return true
+            }
+          }
+        })
+      `,
+      parserOptions,
+      options: ['asc', { runOutsideVue: false }],
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'b'.",
+          line: 9
+        }
+      ]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { component } = Vue;
+        component('test', {
+          name: 'app',
+          props: {
+            a: {
+              type: Boolean,
+              default: true
+            },
+          }
+        })
+      `,
+      parserOptions,
+      options: ['asc', { ignoreGrandchildrenOf: [], runOutsideVue: false }],
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'default' should be before 'type'.",
+          line: 8
         }
       ]
     }

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -519,11 +519,13 @@ ruleTester.run('sort-keys', rule, {
         const { component } = Vue;
         component('test', {
           name: 'app',
-          data () {
-            return {
-              c: 3,
-              a: 1,
-              b: 2
+          computed: {
+            test () {
+              return {
+                c: 3,
+                a: 1,
+                b: 2
+              }
             }
           }
         })
@@ -531,6 +533,7 @@ ruleTester.run('sort-keys', rule, {
       parserOptions: { ecmaVersion: 6 },
       options: ['asc', { runOutsideVue: false }]
     },
+    // runOutsideVue (false) should ignore unsorted keys of data methods that are not the vue data method.
     {
       filename: 'test.js',
       code: `
@@ -538,7 +541,7 @@ ruleTester.run('sort-keys', rule, {
         component('test', {
           name: 'app',
           computed: {
-            test () {
+            data () {
               return {
                 c: 3,
                 a: 1,
@@ -1589,6 +1592,57 @@ ruleTester.run('sort-keys', rule, {
           message:
             "Expected object keys to be in ascending order. 'default' should be before 'type'.",
           line: 8
+        }
+      ]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { component } = Vue;
+        component('test', {
+          name: 'app',
+          data () {
+            return {
+              c: null,
+              a: null,
+              b: null,
+            }
+          }
+        })
+      `,
+      parserOptions,
+      options: ['asc', { runOutsideVue: false }],
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'c'.",
+          line: 8
+        }
+      ]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { component } = Vue;
+        component('test', {
+          name: 'app',
+          data () {
+            return {
+              a: {
+                c: null,
+                b: null,
+              },
+            }
+          }
+        })
+      `,
+      parserOptions,
+      options: ['asc', { runOutsideVue: false }],
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'b' should be before 'c'.",
+          line: 9
         }
       ]
     }


### PR DESCRIPTION
Address issue raised here https://github.com/vuejs/eslint-plugin-vue/issues/1865

Update `vue/sort-keys` to use existing `options.runOutsideVue` option, it seems like previously this option did not do anything.

If this change gets accepted we should update the docs to state which version this option will be available from 😄 