### PR TITLE
Enable `vue/html-closing-bracket-*` for top-level tags

### DIFF
--- a/lib/rules/block-tag-newline.js
+++ b/lib/rules/block-tag-newline.js
@@ -347,13 +347,6 @@ module.exports = {
 
     const verify = normalizeOptionValue(context.options[0])
 
-    /**
-     * @returns {VElement[]}
-     */
-    function getTopLevelHTMLElements() {
-      return documentFragment.children.filter(utils.isVElement)
-    }
-
     return utils.defineTemplateBodyVisitor(
       context,
       {},
@@ -364,8 +357,10 @@ module.exports = {
             return
           }
 
-          for (const element of getTopLevelHTMLElements()) {
-            verify(element)
+          for (const element of documentFragment.children) {
+            if (utils.isVElement(element)) {
+              verify(element)
+            }
           }
         }
       }

--- a/lib/rules/html-closing-bracket-newline.js
+++ b/lib/rules/html-closing-bracket-newline.js
@@ -56,13 +56,6 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
-    const df =
-      context.parserServices.getDocumentFragment &&
-      context.parserServices.getDocumentFragment()
-    if (!df) {
-      return {}
-    }
-
     const options = Object.assign(
       {},
       {
@@ -75,76 +68,48 @@ module.exports = {
       context.parserServices.getTemplateBodyTokenStore &&
       context.parserServices.getTemplateBodyTokenStore()
 
-    /** @param {VStartTag | VEndTag} node */
-    function verify(node) {
-      const closingBracketToken = template.getLastToken(node)
-      if (
-        closingBracketToken.type !== 'HTMLSelfClosingTagClose' &&
-        closingBracketToken.type !== 'HTMLTagClose'
-      ) {
-        return
-      }
+    return utils.defineDocumentVisitor(context, {
+      /** @param {VStartTag | VEndTag} node */
+      'VStartTag, VEndTag'(node) {
+        const closingBracketToken = template.getLastToken(node)
+        if (
+          closingBracketToken.type !== 'HTMLSelfClosingTagClose' &&
+          closingBracketToken.type !== 'HTMLTagClose'
+        ) {
+          return
+        }
 
-      const prevToken = template.getTokenBefore(closingBracketToken)
-      const type =
-        node.loc.start.line === prevToken.loc.end.line
-          ? 'singleline'
-          : 'multiline'
-      const expectedLineBreaks = options[type] === 'always' ? 1 : 0
-      const actualLineBreaks =
-        closingBracketToken.loc.start.line - prevToken.loc.end.line
+        const prevToken = template.getTokenBefore(closingBracketToken)
+        const type =
+          node.loc.start.line === prevToken.loc.end.line
+            ? 'singleline'
+            : 'multiline'
+        const expectedLineBreaks = options[type] === 'always' ? 1 : 0
+        const actualLineBreaks =
+          closingBracketToken.loc.start.line - prevToken.loc.end.line
 
-      if (actualLineBreaks !== expectedLineBreaks) {
-        context.report({
-          node,
-          loc: {
-            start: prevToken.loc.end,
-            end: closingBracketToken.loc.start
-          },
-          message:
-            'Expected {{expected}} before closing bracket, but {{actual}} found.',
-          data: {
-            expected: getPhrase(expectedLineBreaks),
-            actual: getPhrase(actualLineBreaks)
-          },
-          fix(fixer) {
-            /** @type {Range} */
-            const range = [prevToken.range[1], closingBracketToken.range[0]]
-            const text = '\n'.repeat(expectedLineBreaks)
-            return fixer.replaceTextRange(range, text)
-          }
-        })
-      }
-    }
-
-    const documentFragment = df
-
-    return utils.defineTemplateBodyVisitor(
-      context,
-      {
-        /** @param {VStartTag | VEndTag} node */
-        'VStartTag, VEndTag': verify
-      },
-      {
-        /** @param {Program} node */
-        Program(node) {
-          if (utils.hasInvalidEOF(node)) {
-            return
-          }
-
-          for (const element of documentFragment.children) {
-            if (!utils.isVElement(element) || element.name === 'template') {
-              continue
+        if (actualLineBreaks !== expectedLineBreaks) {
+          context.report({
+            node,
+            loc: {
+              start: prevToken.loc.end,
+              end: closingBracketToken.loc.start
+            },
+            message:
+              'Expected {{expected}} before closing bracket, but {{actual}} found.',
+            data: {
+              expected: getPhrase(expectedLineBreaks),
+              actual: getPhrase(actualLineBreaks)
+            },
+            fix(fixer) {
+              /** @type {Range} */
+              const range = [prevToken.range[1], closingBracketToken.range[0]]
+              const text = '\n'.repeat(expectedLineBreaks)
+              return fixer.replaceTextRange(range, text)
             }
-
-            verify(element.startTag)
-
-            if (element.endTag !== null) {
-              verify(element.endTag)
-            }
-          }
+          })
         }
       }
-    )
+    })
   }
 }

--- a/lib/rules/html-closing-bracket-newline.js
+++ b/lib/rules/html-closing-bracket-newline.js
@@ -56,6 +56,13 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
+    const df =
+      context.parserServices.getDocumentFragment &&
+      context.parserServices.getDocumentFragment()
+    if (!df) {
+      return {}
+    }
+
     const options = Object.assign(
       {},
       {
@@ -68,48 +75,76 @@ module.exports = {
       context.parserServices.getTemplateBodyTokenStore &&
       context.parserServices.getTemplateBodyTokenStore()
 
-    return utils.defineTemplateBodyVisitor(context, {
-      /** @param {VStartTag | VEndTag} node */
-      'VStartTag, VEndTag'(node) {
-        const closingBracketToken = template.getLastToken(node)
-        if (
-          closingBracketToken.type !== 'HTMLSelfClosingTagClose' &&
-          closingBracketToken.type !== 'HTMLTagClose'
-        ) {
-          return
-        }
+    /** @param {VStartTag | VEndTag} node */
+    function verify(node) {
+      const closingBracketToken = template.getLastToken(node)
+      if (
+        closingBracketToken.type !== 'HTMLSelfClosingTagClose' &&
+        closingBracketToken.type !== 'HTMLTagClose'
+      ) {
+        return
+      }
 
-        const prevToken = template.getTokenBefore(closingBracketToken)
-        const type =
-          node.loc.start.line === prevToken.loc.end.line
-            ? 'singleline'
-            : 'multiline'
-        const expectedLineBreaks = options[type] === 'always' ? 1 : 0
-        const actualLineBreaks =
-          closingBracketToken.loc.start.line - prevToken.loc.end.line
+      const prevToken = template.getTokenBefore(closingBracketToken)
+      const type =
+        node.loc.start.line === prevToken.loc.end.line
+          ? 'singleline'
+          : 'multiline'
+      const expectedLineBreaks = options[type] === 'always' ? 1 : 0
+      const actualLineBreaks =
+        closingBracketToken.loc.start.line - prevToken.loc.end.line
 
-        if (actualLineBreaks !== expectedLineBreaks) {
-          context.report({
-            node,
-            loc: {
-              start: prevToken.loc.end,
-              end: closingBracketToken.loc.start
-            },
-            message:
-              'Expected {{expected}} before closing bracket, but {{actual}} found.',
-            data: {
-              expected: getPhrase(expectedLineBreaks),
-              actual: getPhrase(actualLineBreaks)
-            },
-            fix(fixer) {
-              /** @type {Range} */
-              const range = [prevToken.range[1], closingBracketToken.range[0]]
-              const text = '\n'.repeat(expectedLineBreaks)
-              return fixer.replaceTextRange(range, text)
+      if (actualLineBreaks !== expectedLineBreaks) {
+        context.report({
+          node,
+          loc: {
+            start: prevToken.loc.end,
+            end: closingBracketToken.loc.start
+          },
+          message:
+            'Expected {{expected}} before closing bracket, but {{actual}} found.',
+          data: {
+            expected: getPhrase(expectedLineBreaks),
+            actual: getPhrase(actualLineBreaks)
+          },
+          fix(fixer) {
+            /** @type {Range} */
+            const range = [prevToken.range[1], closingBracketToken.range[0]]
+            const text = '\n'.repeat(expectedLineBreaks)
+            return fixer.replaceTextRange(range, text)
+          }
+        })
+      }
+    }
+
+    const documentFragment = df
+
+    return utils.defineTemplateBodyVisitor(
+      context,
+      {
+        /** @param {VStartTag | VEndTag} node */
+        'VStartTag, VEndTag': verify
+      },
+      {
+        /** @param {Program} node */
+        Program(node) {
+          if (utils.hasInvalidEOF(node)) {
+            return
+          }
+
+          for (const element of documentFragment.children) {
+            if (!utils.isVElement(element) || element.name === 'template') {
+              continue
             }
-          })
+
+            verify(element.startTag)
+
+            if (element.endTag !== null) {
+              verify(element.endTag)
+            }
+          }
         }
       }
-    })
+    )
   }
 }

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -93,6 +93,7 @@ module.exports = {
     const options = parseOptions(context.options[0], tokens)
 
     return utils.defineDocumentVisitor(context, {
+      /** @param {VStartTag | VEndTag} node */
       'VStartTag, VEndTag'(node) {
         const type = options.detectType(node)
         const lastToken = tokens.getLastToken(node)

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -86,52 +86,86 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
+    const df =
+      context.parserServices.getDocumentFragment &&
+      context.parserServices.getDocumentFragment()
+    if (!df) {
+      return {}
+    }
+
     const sourceCode = context.getSourceCode()
     const tokens =
       context.parserServices.getTemplateBodyTokenStore &&
       context.parserServices.getTemplateBodyTokenStore()
     const options = parseOptions(context.options[0], tokens)
 
-    return utils.defineTemplateBodyVisitor(context, {
-      /** @param {VStartTag | VEndTag} node */
-      'VStartTag, VEndTag'(node) {
-        const type = options.detectType(node)
-        const lastToken = tokens.getLastToken(node)
-        const prevToken = tokens.getLastToken(node, 1)
+    /** @param {VStartTag | VEndTag} node */
+    function verify(node) {
+      const type = options.detectType(node)
+      const lastToken = tokens.getLastToken(node)
+      const prevToken = tokens.getLastToken(node, 1)
 
-        // Skip if EOF exists in the tag or linebreak exists before `>`.
-        if (
-          type == null ||
-          prevToken == null ||
-          prevToken.loc.end.line !== lastToken.loc.start.line
-        ) {
-          return
-        }
+      // Skip if EOF exists in the tag or linebreak exists before `>`.
+      if (
+        type == null ||
+        prevToken == null ||
+        prevToken.loc.end.line !== lastToken.loc.start.line
+      ) {
+        return
+      }
 
-        // Check and report.
-        const hasSpace = prevToken.range[1] !== lastToken.range[0]
-        if (type === 'always' && !hasSpace) {
-          context.report({
-            node,
-            loc: lastToken.loc,
-            message: "Expected a space before '{{bracket}}', but not found.",
-            data: { bracket: sourceCode.getText(lastToken) },
-            fix: (fixer) => fixer.insertTextBefore(lastToken, ' ')
-          })
-        } else if (type === 'never' && hasSpace) {
-          context.report({
-            node,
-            loc: {
-              start: prevToken.loc.end,
-              end: lastToken.loc.end
-            },
-            message: "Expected no space before '{{bracket}}', but found.",
-            data: { bracket: sourceCode.getText(lastToken) },
-            fix: (fixer) =>
-              fixer.removeRange([prevToken.range[1], lastToken.range[0]])
-          })
+      // Check and report.
+      const hasSpace = prevToken.range[1] !== lastToken.range[0]
+      if (type === 'always' && !hasSpace) {
+        context.report({
+          node,
+          loc: lastToken.loc,
+          message: "Expected a space before '{{bracket}}', but not found.",
+          data: { bracket: sourceCode.getText(lastToken) },
+          fix: (fixer) => fixer.insertTextBefore(lastToken, ' ')
+        })
+      } else if (type === 'never' && hasSpace) {
+        context.report({
+          node,
+          loc: {
+            start: prevToken.loc.end,
+            end: lastToken.loc.end
+          },
+          message: "Expected no space before '{{bracket}}', but found.",
+          data: { bracket: sourceCode.getText(lastToken) },
+          fix: (fixer) =>
+            fixer.removeRange([prevToken.range[1], lastToken.range[0]])
+        })
+      }
+    }
+
+    const documentFragment = df
+
+    return utils.defineTemplateBodyVisitor(
+      context,
+      {
+        'VStartTag, VEndTag': verify
+      },
+      {
+        /** @param {Program} node */
+        Program(node) {
+          if (utils.hasInvalidEOF(node)) {
+            return
+          }
+
+          for (const element of documentFragment.children) {
+            if (!utils.isVElement(element) || element.name === 'template') {
+              continue
+            }
+
+            verify(element.startTag)
+
+            if (element.endTag !== null) {
+              verify(element.endTag)
+            }
+          }
         }
       }
-    })
+    )
   }
 }

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -86,86 +86,51 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
-    const df =
-      context.parserServices.getDocumentFragment &&
-      context.parserServices.getDocumentFragment()
-    if (!df) {
-      return {}
-    }
-
     const sourceCode = context.getSourceCode()
     const tokens =
       context.parserServices.getTemplateBodyTokenStore &&
       context.parserServices.getTemplateBodyTokenStore()
     const options = parseOptions(context.options[0], tokens)
 
-    /** @param {VStartTag | VEndTag} node */
-    function verify(node) {
-      const type = options.detectType(node)
-      const lastToken = tokens.getLastToken(node)
-      const prevToken = tokens.getLastToken(node, 1)
+    return utils.defineDocumentVisitor(context, {
+      'VStartTag, VEndTag'(node) {
+        const type = options.detectType(node)
+        const lastToken = tokens.getLastToken(node)
+        const prevToken = tokens.getLastToken(node, 1)
 
-      // Skip if EOF exists in the tag or linebreak exists before `>`.
-      if (
-        type == null ||
-        prevToken == null ||
-        prevToken.loc.end.line !== lastToken.loc.start.line
-      ) {
-        return
-      }
+        // Skip if EOF exists in the tag or linebreak exists before `>`.
+        if (
+          type == null ||
+          prevToken == null ||
+          prevToken.loc.end.line !== lastToken.loc.start.line
+        ) {
+          return
+        }
 
-      // Check and report.
-      const hasSpace = prevToken.range[1] !== lastToken.range[0]
-      if (type === 'always' && !hasSpace) {
-        context.report({
-          node,
-          loc: lastToken.loc,
-          message: "Expected a space before '{{bracket}}', but not found.",
-          data: { bracket: sourceCode.getText(lastToken) },
-          fix: (fixer) => fixer.insertTextBefore(lastToken, ' ')
-        })
-      } else if (type === 'never' && hasSpace) {
-        context.report({
-          node,
-          loc: {
-            start: prevToken.loc.end,
-            end: lastToken.loc.end
-          },
-          message: "Expected no space before '{{bracket}}', but found.",
-          data: { bracket: sourceCode.getText(lastToken) },
-          fix: (fixer) =>
-            fixer.removeRange([prevToken.range[1], lastToken.range[0]])
-        })
-      }
-    }
-
-    const documentFragment = df
-
-    return utils.defineTemplateBodyVisitor(
-      context,
-      {
-        'VStartTag, VEndTag': verify
-      },
-      {
-        /** @param {Program} node */
-        Program(node) {
-          if (utils.hasInvalidEOF(node)) {
-            return
-          }
-
-          for (const element of documentFragment.children) {
-            if (!utils.isVElement(element) || element.name === 'template') {
-              continue
-            }
-
-            verify(element.startTag)
-
-            if (element.endTag !== null) {
-              verify(element.endTag)
-            }
-          }
+        // Check and report.
+        const hasSpace = prevToken.range[1] !== lastToken.range[0]
+        if (type === 'always' && !hasSpace) {
+          context.report({
+            node,
+            loc: lastToken.loc,
+            message: "Expected a space before '{{bracket}}', but not found.",
+            data: { bracket: sourceCode.getText(lastToken) },
+            fix: (fixer) => fixer.insertTextBefore(lastToken, ' ')
+          })
+        } else if (type === 'never' && hasSpace) {
+          context.report({
+            node,
+            loc: {
+              start: prevToken.loc.end,
+              end: lastToken.loc.end
+            },
+            message: "Expected no space before '{{bracket}}', but found.",
+            data: { bracket: sourceCode.getText(lastToken) },
+            fix: (fixer) =>
+              fixer.removeRange([prevToken.range[1], lastToken.range[0]])
+          })
         }
       }
-    )
+    })
   }
 }

--- a/tests/lib/rules/html-closing-bracket-newline.js
+++ b/tests/lib/rules/html-closing-bracket-newline.js
@@ -337,6 +337,156 @@ tester.run('html-closing-bracket-newline', rule, {
         'Expected 1 line break before closing bracket, but no line breaks found.',
         'Expected 1 line break before closing bracket, but no line breaks found.'
       ]
+    },
+    {
+      code: `
+        <template
+        >
+        </template
+        >
+        <script
+        >
+        </script
+        >
+        <style
+        ></style
+        >
+      `,
+      output: `
+        <template>
+        </template>
+        <script>
+        </script>
+        <style></style>
+      `,
+      options: [
+        {
+          singleline: 'never',
+          multiline: 'never'
+        }
+      ],
+      errors: [
+        {
+          message:
+            'Expected no line breaks before closing bracket, but 1 line break found.',
+          line: 2,
+          column: 18,
+          endLine: 3,
+          endColumn: 9
+        },
+        {
+          message:
+            'Expected no line breaks before closing bracket, but 1 line break found.',
+          line: 4,
+          column: 19,
+          endLine: 5,
+          endColumn: 9
+        },
+        {
+          message:
+            'Expected no line breaks before closing bracket, but 1 line break found.',
+          line: 6,
+          column: 16,
+          endLine: 7,
+          endColumn: 9
+        },
+        {
+          message:
+            'Expected no line breaks before closing bracket, but 1 line break found.',
+          line: 8,
+          column: 17,
+          endLine: 9,
+          endColumn: 9
+        },
+        {
+          message:
+            'Expected no line breaks before closing bracket, but 1 line break found.',
+          line: 10,
+          column: 15,
+          endLine: 11,
+          endColumn: 9
+        },
+        {
+          message:
+            'Expected no line breaks before closing bracket, but 1 line break found.',
+          line: 11,
+          column: 17,
+          endLine: 12,
+          endColumn: 9
+        }
+      ]
+    },
+    {
+      code: `
+        <template>
+        </template>
+        <script>
+        </script>
+        <style></style>
+      `,
+      output: `
+        <template
+>
+        </template
+>
+        <script
+>
+        </script
+>
+        <style
+></style
+>
+      `,
+      options: [
+        {
+          singleline: 'always',
+          multiline: 'always'
+        }
+      ],
+      errors: [
+        {
+          message:
+            'Expected 1 line break before closing bracket, but no line breaks found.',
+          line: 2,
+          column: 18,
+          endColumn: 18
+        },
+        {
+          message:
+            'Expected 1 line break before closing bracket, but no line breaks found.',
+          line: 3,
+          column: 19,
+          endColumn: 19
+        },
+        {
+          message:
+            'Expected 1 line break before closing bracket, but no line breaks found.',
+          line: 4,
+          column: 16,
+          endColumn: 16
+        },
+        {
+          message:
+            'Expected 1 line break before closing bracket, but no line breaks found.',
+          line: 5,
+          column: 17,
+          endColumn: 17
+        },
+        {
+          message:
+            'Expected 1 line break before closing bracket, but no line breaks found.',
+          line: 6,
+          column: 15,
+          endColumn: 15
+        },
+        {
+          message:
+            'Expected 1 line break before closing bracket, but no line breaks found.',
+          line: 6,
+          column: 23,
+          endColumn: 23
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/html-closing-bracket-spacing.js
+++ b/tests/lib/rules/html-closing-bracket-spacing.js
@@ -115,6 +115,56 @@ ruleTester.run('html-closing-bracket-spacing', rule, {
       ]
     },
     {
+      code: `
+        <template ></template >
+        <script ></script >
+        <style ></style >
+      `,
+      output: `
+        <template></template>
+        <script></script>
+        <style></style>
+      `,
+      errors: [
+        {
+          message: "Expected no space before '>', but found.",
+          line: 2,
+          column: 18,
+          endColumn: 20
+        },
+        {
+          message: "Expected no space before '>', but found.",
+          line: 2,
+          column: 30,
+          endColumn: 32
+        },
+        {
+          message: "Expected no space before '>', but found.",
+          line: 3,
+          column: 16,
+          endColumn: 18
+        },
+        {
+          message: "Expected no space before '>', but found.",
+          line: 3,
+          column: 26,
+          endColumn: 28
+        },
+        {
+          message: "Expected no space before '>', but found.",
+          line: 4,
+          column: 15,
+          endColumn: 17
+        },
+        {
+          message: "Expected no space before '>', but found.",
+          line: 4,
+          column: 24,
+          endColumn: 26
+        }
+      ]
+    },
+    {
       code: '<template >\n  <div>\n  </div>\n  <div />\n</template >',
       output: '<template >\n  <div >\n  </div >\n  <div/>\n</template >',
       options: [
@@ -142,6 +192,63 @@ ruleTester.run('html-closing-bracket-spacing', rule, {
           line: 4,
           column: 7,
           endColumn: 10
+        }
+      ]
+    },
+    {
+      code: `
+        <template></template>
+        <script></script>
+        <style></style>
+      `,
+      output: `
+        <template ></template >
+        <script ></script >
+        <style ></style >
+      `,
+      options: [
+        {
+          startTag: 'always',
+          endTag: 'always',
+          selfClosingTag: 'never'
+        }
+      ],
+      errors: [
+        {
+          message: "Expected a space before '>', but not found.",
+          line: 2,
+          column: 18,
+          endColumn: 19
+        },
+        {
+          message: "Expected a space before '>', but not found.",
+          line: 2,
+          column: 29,
+          endColumn: 30
+        },
+        {
+          message: "Expected a space before '>', but not found.",
+          line: 3,
+          column: 16,
+          endColumn: 17
+        },
+        {
+          message: "Expected a space before '>', but not found.",
+          line: 3,
+          column: 25,
+          endColumn: 26
+        },
+        {
+          message: "Expected a space before '>', but not found.",
+          line: 4,
+          column: 15,
+          endColumn: 16
+        },
+        {
+          message: "Expected a space before '>', but not found.",
+          line: 4,
+          column: 23,
+          endColumn: 24
         }
       ]
     }


### PR DESCRIPTION
Fixes #1879.

This should be released in the next major version since the bug fix could also be considered a breaking change.