### PR TITLE
Bump devDependencies to their newest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "markdownlint-cli": "^0.31.1",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
-    "prettier": "^2.4.1",
+    "prettier": "^2.6.2",
     "typescript": "^4.5.0",
     "vue-eslint-editor": "^1.1.0",
     "vuepress": "^1.8.2"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/natural-compare": "^1.4.0",
     "@types/node": "^13.13.5",
     "@types/semver": "^7.2.0",
-    "@typescript-eslint/parser": "^5.5.0",
+    "@typescript-eslint/parser": "^5.23.0",
     "@vuepress/plugin-pwa": "^1.4.1",
     "acorn": "^8.5.0",
     "env-cmd": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "acorn": "^8.5.0",
     "env-cmd": "^10.1.0",
     "eslint": "^8.0.0",
-    "eslint-config-prettier": "^6.11.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-plugin": "^3.5.3",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsonc": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-jsonc": "^2.2.1",
     "eslint-plugin-node-dependencies": ">=0.5.0 <1.0.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-unicorn": "^40.1.0",
+    "eslint-plugin-unicorn": "^42.0.0",
     "eslint-plugin-vue": "file:.",
     "espree": "^9.0.0",
     "markdownlint-cli": "^0.31.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.6.2",
-    "typescript": "^4.5.0",
+    "typescript": "^4.6.4",
     "vue-eslint-editor": "^1.1.0",
     "vuepress": "^1.8.2"
   }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@types/eslint": "^8.4.2",
     "@types/eslint-visitor-keys": "^1.0.0",
-    "@types/natural-compare": "^1.4.0",
+    "@types/natural-compare": "^1.4.1",
     "@types/node": "^13.13.5",
     "@types/semver": "^7.2.0",
     "@typescript-eslint/parser": "^5.23.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsonc": "^2.2.1",
     "eslint-plugin-node-dependencies": ">=0.5.0 <1.0.0",
-    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^40.1.0",
     "eslint-plugin-vue": "file:.",
     "espree": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-eslint-plugin": "^3.5.3",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsonc": "^1.4.0",
     "eslint-plugin-node-dependencies": ">=0.5.0 <1.0.0",
     "eslint-plugin-prettier": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
     "prettier": "^2.6.2",
     "typescript": "^4.6.4",
     "vue-eslint-editor": "^1.1.0",
-    "vuepress": "^1.8.2"
+    "vuepress": "^1.9.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/eslint-visitor-keys": "^1.0.0",
     "@types/natural-compare": "^1.4.1",
     "@types/node": "^13.13.5",
-    "@types/semver": "^7.2.0",
+    "@types/semver": "^7.3.9",
     "@typescript-eslint/parser": "^5.23.0",
     "@vuepress/plugin-pwa": "^1.4.1",
     "acorn": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vue-eslint-parser": "^9.0.1"
   },
   "devDependencies": {
-    "@types/eslint": "^7.28.1",
+    "@types/eslint": "^8.4.2",
     "@types/eslint-visitor-keys": "^1.0.0",
     "@types/natural-compare": "^1.4.0",
     "@types/node": "^13.13.5",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-vue": "file:.",
     "espree": "^9.3.2",
     "markdownlint-cli": "^0.31.1",
-    "mocha": "^9.2.2",
+    "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.4.1",
     "typescript": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/semver": "^7.3.9",
     "@typescript-eslint/parser": "^5.23.0",
     "@vuepress/plugin-pwa": "^1.9.7",
-    "acorn": "^8.5.0",
+    "acorn": "^8.7.1",
     "env-cmd": "^10.1.0",
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^42.0.0",
     "eslint-plugin-vue": "file:.",
-    "espree": "^9.0.0",
+    "espree": "^9.3.2",
     "markdownlint-cli": "^0.31.1",
     "mocha": "^7.1.2",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@vuepress/plugin-pwa": "^1.4.1",
     "acorn": "^8.5.0",
     "env-cmd": "^10.1.0",
-    "eslint": "^8.0.0",
+    "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-plugin": "^3.5.3",
     "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/node": "^13.13.5",
     "@types/semver": "^7.3.9",
     "@typescript-eslint/parser": "^5.23.0",
-    "@vuepress/plugin-pwa": "^1.4.1",
+    "@vuepress/plugin-pwa": "^1.9.7",
     "acorn": "^8.5.0",
     "env-cmd": "^10.1.0",
     "eslint": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-vue": "file:.",
     "espree": "^9.3.2",
     "markdownlint-cli": "^0.31.1",
-    "mocha": "^8.4.0",
+    "mocha": "^9.2.2",
     "nyc": "^15.1.0",
     "prettier": "^2.4.1",
     "typescript": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-vue": "file:.",
     "espree": "^9.3.2",
     "markdownlint-cli": "^0.31.1",
-    "mocha": "^7.1.2",
+    "mocha": "^8.4.0",
     "nyc": "^15.1.0",
     "prettier": "^2.4.1",
     "typescript": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-eslint-plugin": "^3.5.3",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsonc": "^1.4.0",
+    "eslint-plugin-jsonc": "^2.2.1",
     "eslint-plugin-node-dependencies": ">=0.5.0 <1.0.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-unicorn": "^40.1.0",


### PR DESCRIPTION
Note that [eslint-plugin-eslint-plugin](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/) was not updated because v4.x doesn't seem to recognize ESLint rules in our codebase.