### PR TITLE
Remove unused code

### DIFF
--- a/lib/rules/no-expose-after-await.js
+++ b/lib/rules/no-expose-after-await.js
@@ -161,9 +161,6 @@ module.exports = {
            * @param {Program} node
            */
           Program(node) {
-            context
-              .getScope()
-              .references.find((ref) => ref.identifier.name === 'defineExpose')
             setupScopes.set(node, {
               afterAwait: false,
               range: scriptSetup.range,


### PR DESCRIPTION
I re-checked the no-expose-after-await code and noticed that there was unused source code. This PR removes it.