### PR TITLE
fix(prefer-import-from-vue): skip side-effect import in `.d.ts` files

### DIFF
--- a/lib/rules/prefer-import-from-vue.js
+++ b/lib/rules/prefer-import-from-vue.js
@@ -94,8 +94,12 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        // Skip imports without specifiers (probably relying on side-effects)
-        if (node.specifiers.length === 0) return
+        // Skip imports without specifiers in `.d.ts` files
+        if (
+          node.specifiers.length === 0 &&
+          context.getFilename().endsWith('.d.ts')
+        )
+          return
 
         verifySource(node.source, () => {
           if (SUBSET_AT_VUE_MODULES.has(node.source.value)) {

--- a/lib/rules/prefer-import-from-vue.js
+++ b/lib/rules/prefer-import-from-vue.js
@@ -94,6 +94,9 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
+        // Skip imports without specifiers (probably relying on side-effects)
+        if (node.specifiers.length === 0) return
+
         verifySource(node.source, () => {
           if (SUBSET_AT_VUE_MODULES.has(node.source.value)) {
             // If the module is a subset of 'vue', we can safely change it to 'vue'.

--- a/tests/lib/rules/prefer-import-from-vue.js
+++ b/tests/lib/rules/prefer-import-from-vue.js
@@ -22,7 +22,8 @@ tester.run('prefer-import-from-vue', rule, {
     `export * from 'vue'`,
     `import Foo from 'foo'`,
     `import { createApp } from 'vue'
-    export { createApp }`
+    export { createApp }`,
+    `import '@vue/runtime-dom'`
   ],
   invalid: [
     {

--- a/tests/lib/rules/prefer-import-from-vue.js
+++ b/tests/lib/rules/prefer-import-from-vue.js
@@ -23,7 +23,10 @@ tester.run('prefer-import-from-vue', rule, {
     `import Foo from 'foo'`,
     `import { createApp } from 'vue'
     export { createApp }`,
-    `import '@vue/runtime-dom'`
+    {
+      filename: 'test.d.ts',
+      code: `import '@vue/runtime-dom'`
+    }
   ],
   invalid: [
     {


### PR DESCRIPTION
For example, in the dts generated by unplugin-vue-components, we use `import '@vue/runtime-core'` to let TypeScript aware of the context. I guess similar cases where ppl import without names, they are probably intentional to rely on its side-effects.

https://github.com/antfu/vitesse/blob/168fe3560999b1132f4b7a4ffa0a3a67859b0ca7/src/components.d.ts