### PR TITLE
Fix regression on no-unused-components rule

### DIFF
--- a/lib/rules/no-unused-components.js
+++ b/lib/rules/no-unused-components.js
@@ -120,13 +120,13 @@ module.exports = {
                       name === casing.camelCase(n))
                 )
               ) {
-                return
+                continue
               }
             } else {
               // In any other case the used component name must exactly match
               // the registered name
               if (usedComponents.has(name)) {
-                return
+                continue
               }
             }
 

--- a/tests/lib/rules/no-unused-components.js
+++ b/tests/lib/rules/no-unused-components.js
@@ -695,6 +695,36 @@ tester.run('no-unused-components', rule, {
           line: 13
         }
       ]
+    },
+
+    // Many components and one in middle is no present
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div>
+            <Foo />
+            <fio.fio />
+            <baz />
+          </div>
+        </template>
+        <script>
+          export default {
+            components: {
+              Foo,
+              'fio.fio': FioFio,
+              Bar,
+              Baz
+            },
+          }
+        </script>
+      `,
+      errors: [
+        {
+          message: 'The "Bar" component has been registered but not used.',
+          line: 14
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Hi,

I just saw that ES Lint no longer detects unused components in Vue. So I checked in the no-unused-components rule and noticed a change [here](https://github.com/vuejs/eslint-plugin-vue/commit/ba2911413acd6c61cd966ab8471037ea4563451e#diff-431a19a18ef6f160af08eeb4967020d8d755928dd7091471ea32754aa419d684).

Before, a filter was applied to get all unused components and throw an error in context for everyone.

But after PR, return stop for and check only first component if it is used. Rule stop and is useless at the moment. I think we want to continue in for for all registered components.