### PR TITLE
fix: allow :onUpdate:modelValue props

### DIFF
--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -89,6 +89,8 @@ module.exports = {
     function reportIssue(node, name) {
       const text = sourceCode.getText(node.key)
 
+      const fixed = name.split(':').map(caseConverter).join(':')
+
       context.report({
         node: node.key,
         loc: node.loc,
@@ -98,8 +100,7 @@ module.exports = {
         data: {
           text
         },
-        fix: (fixer) =>
-          fixer.replaceText(node.key, text.replace(name, caseConverter(name)))
+        fix: (fixer) => fixer.replaceText(node.key, text.replace(name, fixed))
       })
     }
 

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -31,10 +31,14 @@ function create(context) {
   function processProps(props) {
     for (const item of props) {
       const propName = item.propName
+
       if (propName == null) {
         continue
       }
-      if (!checker(propName)) {
+
+      const isValid = propName.split(':').every(checker)
+
+      if (!isValid) {
         context.report({
           node: item.node,
           message: 'Prop "{{name}}" is not in {{caseType}}.',

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -66,6 +66,16 @@ ruleTester.run('attribute-hyphenation', rule, {
       filename: 'test.vue',
       code: '<template><div><slot myProp></slot></div></template>',
       options: ['never']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><custom :onUpdate:modelValue></custom></template>',
+      options: ['never']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><custom :on-update:model-value></custom></template>',
+      options: ['always']
     }
   ],
 
@@ -285,6 +295,32 @@ ruleTester.run('attribute-hyphenation', rule, {
         {
           message: "Attribute 'MyProp' must be hyphenated.",
           type: 'VIdentifier',
+          line: 1
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><custom :onUpdate:modelValue></custom></template>',
+      output: '<template><custom :on-update:model-value></custom></template>',
+      options: ['always'],
+      errors: [
+        {
+          message: "Attribute ':onUpdate:modelValue' must be hyphenated.",
+          type: 'VDirectiveKey',
+          line: 1
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><custom :on-update:model-value></custom></template>',
+      output: '<template><custom :onUpdate:modelValue></custom></template>',
+      options: ['never'],
+      errors: [
+        {
+          message: "Attribute ':on-update:model-value' can't be hyphenated.",
+          type: 'VDirectiveKey',
           line: 1
         }
       ]

--- a/tests/lib/rules/prop-name-casing.js
+++ b/tests/lib/rules/prop-name-casing.js
@@ -28,6 +28,26 @@ ruleTester.run('prop-name-casing', rule, {
       filename: 'test.vue',
       code: `
         export default {
+          props: ['onUpdate:modelValue']
+        }
+      `,
+      options: ['camelCase'],
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          props: ['on_update:model_value']
+        }
+      `,
+      options: ['snake_case'],
+      parserOptions
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
           props: ['greetingText']
         }
       `,


### PR DESCRIPTION
This PR aims to resolve https://github.com/vuejs/eslint-plugin-vue/issues/1911

It allows props in the form of `:onUpdate:modelValue` to be correctly linted as camelCase.
The rules affected are "prop-name-casing" (is now laxer)  and "attribute-hyphenation" (this rule autofixes those props correctly now)