### PR TITLE
Chore: fix typescript-eslint v4 test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,9 @@ jobs:
           command: npm version
       - checkout
       - run:
-          name: Install @typescript-eslint/parser@4 eslint@7
+          name: Install @typescript-eslint/parser@4 eslint@7 typescript@4.7
           command: |
-            npm install @typescript-eslint/parser@^4 eslint@7
+            npm install @typescript-eslint/parser@4 eslint@7 typescript@4.7 --save-exact
       - run:
           name: Install dependencies
           command: npm install


### PR DESCRIPTION
It seems that using typescript-eslint v4 and typescript v4.8 together breaks the AST due to incompatibility.

This PR changes typescript-eslint v4 tests to use typescript v4.7.