### PR TITLE
Chore: ts-parser support in demo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,7 +132,6 @@ module.exports = {
     'unicorn/prefer-optional-catch-binding': 'off', // not supported by current ESLint parser version
     'unicorn/prefer-module': 'off',
     'unicorn/prevent-abbreviations': 'off',
-    'unicorn/no-nested-ternary': 'off' // conflicts with Prettier
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,7 +131,7 @@ module.exports = {
     'unicorn/no-useless-undefined': 'off',
     'unicorn/prefer-optional-catch-binding': 'off', // not supported by current ESLint parser version
     'unicorn/prefer-module': 'off',
-    'unicorn/prevent-abbreviations': 'off',
+    'unicorn/prevent-abbreviations': 'off'
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,7 +131,8 @@ module.exports = {
     'unicorn/no-useless-undefined': 'off',
     'unicorn/prefer-optional-catch-binding': 'off', // not supported by current ESLint parser version
     'unicorn/prefer-module': 'off',
-    'unicorn/prevent-abbreviations': 'off'
+    'unicorn/prevent-abbreviations': 'off',
+    'unicorn/no-nested-ternary': 'off' // conflicts with Prettier
   },
   overrides: [
     {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -132,7 +132,8 @@ module.exports = {
           '@eslint/eslintrc/universal': path.resolve(
             __dirname,
             '../../node_modules/@eslint/eslintrc/dist/eslintrc-universal.cjs'
-          )
+          ),
+          globby: require.resolve('./shim/globby')
         }
       }
     }

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -12,7 +12,7 @@ export default (
     window.process = new Proxy(
       {
         env: {},
-        cwd: () => undefined
+        cwd: () => ''
       },
       {
         get(target, name) {

--- a/docs/.vuepress/shim/globby.js
+++ b/docs/.vuepress/shim/globby.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/docs/.vuepress/shim/module.js
+++ b/docs/.vuepress/shim/module.js
@@ -1,3 +1,11 @@
 module.exports = {
-  createRequire: () => () => null
+  createRequire: () => (module) => {
+    if (module === 'espree') {
+      return require('espree')
+    }
+    if (module === 'eslint-scope') {
+      return require('eslint-scope')
+    }
+    throw new Error(`Not implemented: ${module}`)
+  }
 }

--- a/docs/rules/valid-define-emits.md
+++ b/docs/rules/valid-define-emits.md
@@ -45,12 +45,16 @@ This rule reports `defineEmits` compiler macros in the following cases:
 
 </eslint-code-block>
 
+<eslint-code-block :rules="{'vue/valid-define-emits': ['error']}">
+
 ```vue
 <script setup lang="ts">
   /* ✓ GOOD */
   defineEmits<(e: 'notify')=>void>()
 </script>
 ```
+
+</eslint-code-block>
 
 <eslint-code-block :rules="{'vue/valid-define-emits': ['error']}">
 
@@ -78,12 +82,16 @@ This rule reports `defineEmits` compiler macros in the following cases:
 
 </eslint-code-block>
 
+<eslint-code-block :rules="{'vue/valid-define-emits': ['error']}">
+
 ```vue
 <script setup lang="ts">
   /* ✗ BAD */
   defineEmits<(e: 'notify')=>void>({ submit: null })
 </script>
 ```
+
+</eslint-code-block>
 
 <eslint-code-block :rules="{'vue/valid-define-emits': ['error']}">
 

--- a/docs/rules/valid-define-props.md
+++ b/docs/rules/valid-define-props.md
@@ -45,12 +45,16 @@ This rule reports `defineProps` compiler macros in the following cases:
 
 </eslint-code-block>
 
+<eslint-code-block :rules="{'vue/valid-define-props': ['error']}">
+
 ```vue
 <script setup lang="ts">
   /* ✓ GOOD */
   defineProps<{ msg?:string }>()
 </script>
 ```
+
+</eslint-code-block>
 
 <eslint-code-block :rules="{'vue/valid-define-props': ['error']}">
 
@@ -78,12 +82,16 @@ This rule reports `defineProps` compiler macros in the following cases:
 
 </eslint-code-block>
 
+<eslint-code-block :rules="{'vue/valid-define-props': ['error']}">
+
 ```vue
 <script setup lang="ts">
   /* ✗ BAD */
   defineProps<{ msg?:string }>({ msg: String })
 </script>
 ```
+
+</eslint-code-block>
 
 <eslint-code-block :rules="{'vue/valid-define-props': ['error']}">
 


### PR DESCRIPTION
This PR modifies the documentation site demo so that it parses well using typescript.

https://deploy-preview-1972--eslint-plugin-vue.netlify.app/rules/valid-define-emits.html
https://deploy-preview-1972--eslint-plugin-vue.netlify.app/rules/valid-define-props.html

We'll need to clear the cache in netlify for this to take effect.

Related to https://github.com/vuejs/eslint-plugin-vue/pull/1968#issuecomment-1244839400