### PR TITLE
Add `globals` option to `component-name-in-template-casing`

### DIFF
--- a/docs/rules/component-name-in-template-casing.md
+++ b/docs/rules/component-name-in-template-casing.md
@@ -33,6 +33,7 @@ This rule aims to warn the tag names other than the configured casing in Vue.js 
 - `registeredComponentsOnly` ... If `true`, only registered components (in PascalCase) are checked. If `false`, check all.
     default `true`
 - `ignores` (`string[]`) ... The element names to ignore. Sets the element name to allow. For example, custom elements or Vue components with special name. You can set the regexp by writing it like `"/^name/"`.
+- `globals` (`string[]`) ... Globally registered component names to check. For example, `RouterView` and `RouterLink` are globally registered by `vue-router` and can't be detected as registered in a SFC file.
 
 ### `"PascalCase", { registeredComponentsOnly: true }` (default)
 

--- a/docs/rules/component-name-in-template-casing.md
+++ b/docs/rules/component-name-in-template-casing.md
@@ -142,6 +142,22 @@ export default {
 
 </eslint-code-block>
 
+### `"PascalCase", { globals: ["RouterView"] }`
+
+<eslint-code-block fix :rules="{'vue/component-name-in-template-casing': ['error', 'PascalCase', {globals: ['RouterView']}]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <RouterView></RouterView>
+  
+  <!-- ✗ BAD -->
+  <router-view></router-view>
+</template>
+```
+
+</eslint-code-block>
+
 ## :books: Further Reading
 
 - [Style guide - Component name casing in templates](https://vuejs.org/style-guide/rules-strongly-recommended.html#component-name-casing-in-templates)

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -40,6 +40,11 @@ module.exports = {
       {
         type: 'object',
         properties: {
+          globals: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true
+          },
           ignores: {
             type: 'array',
             items: { type: 'string' },
@@ -63,13 +68,15 @@ module.exports = {
       : defaultCase
     /** @type {RegExp[]} */
     const ignores = (options.ignores || []).map(toRegExp)
+    /** @type {string[]} */
+    const globals = (options.globals || []).map(casing.pascalCase)
     const registeredComponentsOnly = options.registeredComponentsOnly !== false
     const tokens =
       context.parserServices.getTemplateBodyTokenStore &&
       context.parserServices.getTemplateBodyTokenStore()
 
     /** @type { Set<string> } */
-    const registeredComponents = new Set()
+    const registeredComponents = new Set(globals)
 
     if (utils.isScriptSetup(context)) {
       // For <script setup>
@@ -106,15 +113,8 @@ module.exports = {
         }
         return true
       }
-      // We only verify the components registered in the component.
-      if (
-        [...registeredComponents]
-          .filter((name) => casing.isPascalCase(name)) // When defining a component with PascalCase, you can use either case
-          .some(
-            (name) =>
-              node.rawName === name || casing.pascalCase(node.rawName) === name
-          )
-      ) {
+      // We only verify the registered components.
+      if (registeredComponents.has(casing.pascalCase(node.rawName))) {
         return true
       }
 

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -901,7 +901,13 @@ tester.run('component-name-in-template-casing', rule, {
           <RouterView />
         </template>
       `,
-      errors: ['Component name "router-view" is not PascalCase.']
+      errors: [
+        {
+          message: 'Component name "router-view" is not PascalCase.',
+          line: 3,
+          column: 11
+        }
+      ]
     },
     {
       code: `
@@ -915,7 +921,13 @@ tester.run('component-name-in-template-casing', rule, {
           <router-view />
         </template>
       `,
-      errors: ['Component name "RouterView" is not kebab-case.']
+      errors: [
+        {
+          message: 'Component name "RouterView" is not kebab-case.',
+          line: 3,
+          column: 11
+        }
+      ]
     },
     {
       code: `
@@ -929,7 +941,13 @@ tester.run('component-name-in-template-casing', rule, {
           <router-view />
         </template>
       `,
-      errors: ['Component name "RouterView" is not kebab-case.']
+      errors: [
+        {
+          message: 'Component name "RouterView" is not kebab-case.',
+          line: 3,
+          column: 11
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -174,34 +174,24 @@ tester.run('component-name-in-template-casing', rule, {
     {
       code: `
         <template>
-          <RouterView />
+          <div>
+            <RouterView />
+            <RouterLink />
+          </div>
         </template>
       `,
-      options: ['PascalCase', { globals: ['RouterView'] }]
+      options: ['PascalCase', { globals: ['RouterView', 'router-link'] }]
     },
     {
       code: `
         <template>
-          <RouterView />
+          <div>
+            <router-view />
+            <router-link />
+          </div>
         </template>
       `,
-      options: ['PascalCase', { globals: ['router-view'] }]
-    },
-    {
-      code: `
-        <template>
-          <router-view />
-        </template>
-      `,
-      options: ['kebab-case', { globals: ['RouterView'] }]
-    },
-    {
-      code: `
-        <template>
-          <router-view />
-        </template>
-      `,
-      options: ['kebab-case', { globals: ['router-view'] }]
+      options: ['kebab-case', { globals: ['RouterView', 'router-link'] }]
     }
   ],
   invalid: [

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -168,6 +168,24 @@ tester.run('component-name-in-template-casing', rule, {
           <keep-alive />
         </template>
       `
+    },
+
+    // globals
+    {
+      code: `
+        <template>
+          <RouterView />
+        </template>
+      `,
+      options: ['PascalCase', { globals: ['RouterView'] }]
+    },
+    {
+      code: `
+        <template>
+          <RouterView />
+        </template>
+      `,
+      options: ['PascalCase', { globals: ['router-view'] }]
     }
   ],
   invalid: [
@@ -854,6 +872,39 @@ tester.run('component-name-in-template-casing', rule, {
         </script>
       `,
       errors: ['Component name "TheComponent" is not kebab-case.']
+    },
+    {
+      code: `
+        <template>
+          <router-view />
+        </template>
+      `,
+      options: ['PascalCase', { globals: ['RouterView'] }],
+      output:
+        '\n        <template>\n          <RouterView />\n        </template>\n      ',
+      errors: ['Component name "router-view" is not PascalCase.']
+    },
+    {
+      code: `
+        <template>
+          <RouterView />
+        </template>
+      `,
+      options: ['kebab-case', { globals: ['RouterView'] }],
+      output:
+        '\n        <template>\n          <router-view />\n        </template>\n      ',
+      errors: ['Component name "RouterView" is not kebab-case.']
+    },
+    {
+      code: `
+        <template>
+          <RouterView />
+        </template>
+      `,
+      options: ['kebab-case', { globals: ['router-view'] }],
+      output:
+        '\n        <template>\n          <router-view />\n        </template>\n      ',
+      errors: ['Component name "RouterView" is not kebab-case.']
     }
   ]
 })

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -186,6 +186,22 @@ tester.run('component-name-in-template-casing', rule, {
         </template>
       `,
       options: ['PascalCase', { globals: ['router-view'] }]
+    },
+    {
+      code: `
+        <template>
+          <router-view />
+        </template>
+      `,
+      options: ['kebab-case', { globals: ['RouterView'] }]
+    },
+    {
+      code: `
+        <template>
+          <router-view />
+        </template>
+      `,
+      options: ['kebab-case', { globals: ['router-view'] }]
     }
   ],
   invalid: [
@@ -880,8 +896,11 @@ tester.run('component-name-in-template-casing', rule, {
         </template>
       `,
       options: ['PascalCase', { globals: ['RouterView'] }],
-      output:
-        '\n        <template>\n          <RouterView />\n        </template>\n      ',
+      output: `
+        <template>
+          <RouterView />
+        </template>
+      `,
       errors: ['Component name "router-view" is not PascalCase.']
     },
     {
@@ -891,8 +910,11 @@ tester.run('component-name-in-template-casing', rule, {
         </template>
       `,
       options: ['kebab-case', { globals: ['RouterView'] }],
-      output:
-        '\n        <template>\n          <router-view />\n        </template>\n      ',
+      output: `
+        <template>
+          <router-view />
+        </template>
+      `,
       errors: ['Component name "RouterView" is not kebab-case.']
     },
     {
@@ -902,8 +924,11 @@ tester.run('component-name-in-template-casing', rule, {
         </template>
       `,
       options: ['kebab-case', { globals: ['router-view'] }],
-      output:
-        '\n        <template>\n          <router-view />\n        </template>\n      ',
+      output: `
+        <template>
+          <router-view />
+        </template>
+      `,
       errors: ['Component name "RouterView" is not kebab-case.']
     }
   ]


### PR DESCRIPTION
Currently the `component-name-in-template-casing` can't check globally registered components. This PR adds an option to explicitly list global components to check.