### PR TITLE
Create `vue/multiline-ternary` extension rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -292,6 +292,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/key-spacing](./key-spacing.md) | Enforce consistent spacing between keys and values in object literal properties in `<template>` | :wrench: | :lipstick: |
 | [vue/keyword-spacing](./keyword-spacing.md) | Enforce consistent spacing before and after keywords in `<template>` | :wrench: | :lipstick: |
 | [vue/max-len](./max-len.md) | enforce a maximum line length in `.vue` files |  | :lipstick: |
+| [vue/multiline-ternary](./multiline-ternary.md) | Enforce newlines between operands of ternary expressions in `<template>` | :wrench: | :lipstick: |
 | [vue/no-constant-condition](./no-constant-condition.md) | Disallow constant expressions in conditions in `<template>` |  | :warning: |
 | [vue/no-empty-pattern](./no-empty-pattern.md) | Disallow empty destructuring patterns in `<template>` |  | :warning: |
 | [vue/no-extra-parens](./no-extra-parens.md) | Disallow unnecessary parentheses in `<template>` | :wrench: | :lipstick: |

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -2,16 +2,48 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/multiline-ternary
-description: Enforce newlines between operands of ternary expressions in `<template>` and `<style>`
+description: Enforce newlines between operands of ternary expressions in `<template>`
 ---
 # vue/multiline-ternary
 
-> Enforce newlines between operands of ternary expressions in `<template>` and `<style>`
+> Enforce newlines between operands of ternary expressions in `<template>`
 
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 This rule is the same rule as core [multiline-ternary] rule but it applies to the expressions in `<template>` and `<style>`.
+
+## :book: Rule Details
+
+<eslint-code-block fix :rules="{'vue/multiline-ternary': ['error']}">
+
+```vue
+<template>
+  <div>
+    <!-- ✓ GOOD -->
+    <div :class="isEnabled
+      ? 'check'
+      : 'stop'" />
+
+    <!-- ✗ BAD -->
+    <div :class="isEnabled ? 'check' : 'stop'" />
+  </div>
+</template>
+
+<style>
+div {
+  /* ✓ GOOD */
+  color: v-bind('myFlag
+    ? foo
+    : bar');
+
+  /* ✗ BAD */
+  color: v-bind('myFlag ? foo : bar');
+}
+</style>
+```
+
+</eslint-code-block>
 
 ## :books: Further Reading
 

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -2,29 +2,17 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/multiline-ternary
-description: xxx
+description: Enforce newlines between operands of ternary expressions in `<template>` 
 ---
 # vue/multiline-ternary
 
-> xxx
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
 
-## :book: Rule Details
+This rule is the same rule as core [multiline-ternary] rule but it applies to the expressions in `<template>`.
+## :books: Further Reading
 
-This rule ....
+- [multiline-ternary]
 
-<eslint-code-block :rules="{'vue/multiline-ternary': ['error']}">
-
-```vue
-<template>
-
-</template>
-```
-
-</eslint-code-block>
-
-## :wrench: Options
-
-Nothing.
-
+[multiline-ternary]: https://eslint.org/docs/rules/multiline-ternary

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -2,16 +2,16 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/multiline-ternary
-description: Enforce newlines between operands of ternary expressions in `<template>`
+description: Enforce newlines between operands of ternary expressions in `<template>` and `<style>`
 ---
 # vue/multiline-ternary
 
-> Enforce newlines between operands of ternary expressions in `<template>`
+> Enforce newlines between operands of ternary expressions in `<template>` and `<style>`
 
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-This rule is the same rule as core [multiline-ternary] rule but it applies to the expressions in `<template>`.
+This rule is the same rule as core [multiline-ternary] rule but it applies to the expressions in `<template>` and `<style>`.
 
 ## :books: Further Reading
 

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -11,6 +11,7 @@ description: Enforce newlines between operands of ternary expressions in `<templ
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
 
 This rule is the same rule as core [multiline-ternary] rule but it applies to the expressions in `<template>`.
+
 ## :books: Further Reading
 
 - [multiline-ternary]

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -1,0 +1,30 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/multiline-ternary
+description: xxx
+---
+# vue/multiline-ternary
+
+> xxx
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+
+## :book: Rule Details
+
+This rule ....
+
+<eslint-code-block :rules="{'vue/multiline-ternary': ['error']}">
+
+```vue
+<template>
+
+</template>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -2,13 +2,14 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/multiline-ternary
-description: Enforce newlines between operands of ternary expressions in `<template>` 
+description: Enforce newlines between operands of ternary expressions in `<template>`
 ---
 # vue/multiline-ternary
 
-- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+> Enforce newlines between operands of ternary expressions in `<template>`
 
 - :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 This rule is the same rule as core [multiline-ternary] rule but it applies to the expressions in `<template>`.
 
@@ -17,3 +18,10 @@ This rule is the same rule as core [multiline-ternary] rule but it applies to th
 - [multiline-ternary]
 
 [multiline-ternary]: https://eslint.org/docs/rules/multiline-ternary
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/multiline-ternary.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/multiline-ternary.js)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/multiline-ternary)</sup>

--- a/docs/rules/no-required-prop-with-default.md
+++ b/docs/rules/no-required-prop-with-default.md
@@ -60,7 +60,16 @@ This rule enforces all props with default values to be optional.
         default: 'Hello'
       }
     }
+</script>
+```
 
+</eslint-code-block>
+
+<eslint-code-block fix :rules="{'vue/no-required-prop-with-default': ['error', { autoFix: true }]}">
+
+```vue
+<script>
+  export default {
     /* ✗ BAD */
     props: {
       name: {

--- a/lib/configs/no-layout-rules.js
+++ b/lib/configs/no-layout-rules.js
@@ -31,6 +31,7 @@ module.exports = {
     'vue/max-attributes-per-line': 'off',
     'vue/max-len': 'off',
     'vue/multiline-html-element-content-newline': 'off',
+    'vue/multiline-ternary': 'off',
     'vue/mustache-interpolation-spacing': 'off',
     'vue/new-line-between-multi-line-property': 'off',
     'vue/no-extra-parens': 'off',

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ module.exports = {
     'max-len': require('./rules/max-len'),
     'multi-word-component-names': require('./rules/multi-word-component-names'),
     'multiline-html-element-content-newline': require('./rules/multiline-html-element-content-newline'),
+    'multiline-ternary': require('./rules/multiline-ternary'),
     'mustache-interpolation-spacing': require('./rules/mustache-interpolation-spacing'),
     'new-line-between-multi-line-property': require('./rules/new-line-between-multi-line-property'),
     'next-tick-style': require('./rules/next-tick-style'),

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -1,5 +1,5 @@
 /**
- * @author *****your name*****
+ * @author dev1437
  * See LICENSE file in root directory for full license.
  */
 'use strict'

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -12,5 +12,6 @@ const { wrapCoreRule } = require('../utils')
 
 // eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
 module.exports = wrapCoreRule('multiline-ternary', {
-  skipDynamicArguments: true
+  skipDynamicArguments: true,
+  applyDocument: true
 })

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -1,0 +1,16 @@
+/**
+ * @author *****your name*****
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { wrapCoreRule } = require('../utils')
+
+// eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
+module.exports = wrapCoreRule('multiline-ternary', {
+  skipDynamicArguments: true
+})

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -242,7 +242,7 @@ tester.run('multiline-ternary', rule, {
                 message:
                   'Expected newline between consequent and alternate of ternary expression.',
                 line: 4,
-                column: 45
+                column: 47
               }
             ]
           },
@@ -267,7 +267,7 @@ tester.run('multiline-ternary', rule, {
                 message:
                   'Expected newline between consequent and alternate of ternary expression.',
                 line: 4,
-                column: 45
+                column: 47
               }
             ]
           }

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -1,5 +1,5 @@
 /**
- * @author *****your name*****
+ * @author dev1437
  * See LICENSE file in root directory for full license.
  */
 'use strict'
@@ -40,7 +40,7 @@ tester.run('multiline-ternary', rule, {
         </div>
       </template>
       `,
-      options: ["never"]
+      options: ['never']
     }
   ],
   invalid: [
@@ -67,12 +67,13 @@ tester.run('multiline-ternary', rule, {
       `,
       errors: [
         {
-          message: 'Expected newline between consequent and alternate of ternary expression.',
+          message:
+            'Expected newline between consequent and alternate of ternary expression.',
           line: 5,
           column: 13
-        },
+        }
       ],
-      options: ["always-multiline"]
+      options: ['always-multiline']
     },
     {
       filename: 'test.vue',
@@ -95,12 +96,13 @@ tester.run('multiline-ternary', rule, {
       `,
       errors: [
         {
-          message: 'Unexpected newline between test and consequent of ternary expression.',
+          message:
+            'Unexpected newline between test and consequent of ternary expression.',
           line: 4,
           column: 19
-        },
+        }
       ],
-      options: ["never"]
+      options: ['never']
     },
     {
       filename: 'test.vue',
@@ -124,12 +126,14 @@ tester.run('multiline-ternary', rule, {
       `,
       errors: [
         {
-          message: 'Expected newline between test and consequent of ternary expression.',
+          message:
+            'Expected newline between test and consequent of ternary expression.',
           line: 4,
           column: 19
         },
         {
-          message: 'Expected newline between consequent and alternate of ternary expression.',
+          message:
+            'Expected newline between consequent and alternate of ternary expression.',
           line: 4,
           column: 45
         }

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const { RuleTester, ESLint } = require('eslint')
+const { RuleTester, ESLint } = require('../../eslint-compat')
 const rule = require('../../../lib/rules/multiline-ternary')
 const semver = require('semver')
 

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -4,8 +4,9 @@
  */
 'use strict'
 
-const RuleTester = require('eslint').RuleTester
+const { RuleTester, ESLint } = require('eslint')
 const rule = require('../../../lib/rules/multiline-ternary')
+const semver = require('semver')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
@@ -44,9 +45,11 @@ tester.run('multiline-ternary', rule, {
     }
   ],
   invalid: [
-    {
-      filename: 'test.vue',
-      code: `
+    ...(semver.gte(ESLint.version, '7.1.0')
+      ? [
+          {
+            filename: 'test.vue',
+            code: `
       <template>
         <div :class="{
           'test': someReallyLongCondition ?
@@ -55,7 +58,7 @@ tester.run('multiline-ternary', rule, {
         </div>
       </template>
       `,
-      output: `
+            output: `
       <template>
         <div :class="{
           'test': someReallyLongCondition ?
@@ -65,19 +68,19 @@ tester.run('multiline-ternary', rule, {
         </div>
       </template>
       `,
-      errors: [
-        {
-          message:
-            'Expected newline between consequent and alternate of ternary expression.',
-          line: 5,
-          column: 13
-        }
-      ],
-      options: ['always-multiline']
-    },
-    {
-      filename: 'test.vue',
-      code: `
+            errors: [
+              {
+                message:
+                  'Expected newline between consequent and alternate of ternary expression.',
+                line: 5,
+                column: 13
+              }
+            ],
+            options: ['always-multiline']
+          },
+          {
+            filename: 'test.vue',
+            code: `
       <template>
         <div :class="{
           'test': someReallyLongCondition ?
@@ -86,7 +89,7 @@ tester.run('multiline-ternary', rule, {
         </div>
       </template>
       `,
-      output: `
+            output: `
       <template>
         <div :class="{
           'test': someReallyLongCondition ?aVeryLongOutput : thisCantFitOnASingleLine
@@ -94,19 +97,19 @@ tester.run('multiline-ternary', rule, {
         </div>
       </template>
       `,
-      errors: [
-        {
-          message:
-            'Unexpected newline between test and consequent of ternary expression.',
-          line: 4,
-          column: 19
-        }
-      ],
-      options: ['never']
-    },
-    {
-      filename: 'test.vue',
-      code: `
+            errors: [
+              {
+                message:
+                  'Unexpected newline between test and consequent of ternary expression.',
+                line: 4,
+                column: 19
+              }
+            ],
+            options: ['never']
+          },
+          {
+            filename: 'test.vue',
+            code: `
       <template>
         <div :class="{
           'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
@@ -114,7 +117,7 @@ tester.run('multiline-ternary', rule, {
         </div>
       </template>
       `,
-      output: `
+            output: `
       <template>
         <div :class="{
           'test': someReallyLongCondition
@@ -124,20 +127,150 @@ tester.run('multiline-ternary', rule, {
         </div>
       </template>
       `,
-      errors: [
-        {
-          message:
-            'Expected newline between test and consequent of ternary expression.',
-          line: 4,
-          column: 19
-        },
-        {
-          message:
-            'Expected newline between consequent and alternate of ternary expression.',
-          line: 4,
-          column: 45
-        }
-      ]
-    }
+            errors: [
+              {
+                message:
+                  'Expected newline between test and consequent of ternary expression.',
+                line: 4,
+                column: 19
+              },
+              {
+                message:
+                  'Expected newline between consequent and alternate of ternary expression.',
+                line: 4,
+                column: 45
+              }
+            ]
+          },
+          {
+            filename: 'test.vue',
+            code: `
+      <template>
+        <div :style="{
+          'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+         }">
+        </div>
+      </template>
+      `,
+            output: `
+      <template>
+        <div :style="{
+          'test': someReallyLongCondition
+? aVeryLongOutput
+: thisCantFitOnASingleLine
+         }">
+        </div>
+      </template>
+      `,
+            errors: [
+              {
+                message:
+                  'Expected newline between test and consequent of ternary expression.',
+                line: 4,
+                column: 19
+              },
+              {
+                message:
+                  'Expected newline between consequent and alternate of ternary expression.',
+                line: 4,
+                column: 45
+              }
+            ]
+          }
+        ]
+      : [
+          {
+            filename: 'test.vue',
+            code: `
+        <template>
+          <div :class="{
+            'test': someReallyLongCondition ?
+              aVeryLongOutput : thisCantFitOnASingleLine
+          }">
+          </div>
+        </template>
+        `,
+            errors: [
+              {
+                message:
+                  'Expected newline between consequent and alternate of ternary expression.',
+                line: 5,
+                column: 13
+              }
+            ],
+            options: ['always-multiline']
+          },
+          {
+            filename: 'test.vue',
+            code: `
+        <template>
+          <div :class="{
+            'test': someReallyLongCondition ?
+              aVeryLongOutput : thisCantFitOnASingleLine
+          }">
+          </div>
+        </template>
+        `,
+            errors: [
+              {
+                message:
+                  'Unexpected newline between test and consequent of ternary expression.',
+                line: 4,
+                column: 19
+              }
+            ],
+            options: ['never']
+          },
+          {
+            filename: 'test.vue',
+            code: `
+        <template>
+          <div :class="{
+            'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+           }">
+          </div>
+        </template>
+        `,
+            errors: [
+              {
+                message:
+                  'Expected newline between test and consequent of ternary expression.',
+                line: 4,
+                column: 19
+              },
+              {
+                message:
+                  'Expected newline between consequent and alternate of ternary expression.',
+                line: 4,
+                column: 45
+              }
+            ]
+          },
+          {
+            filename: 'test.vue',
+            code: `
+        <template>
+          <div :style="{
+            'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+           }">
+          </div>
+        </template>
+        `,
+            errors: [
+              {
+                message:
+                  'Expected newline between test and consequent of ternary expression.',
+                line: 4,
+                column: 19
+              },
+              {
+                message:
+                  'Expected newline between consequent and alternate of ternary expression.',
+                line: 4,
+                column: 45
+              }
+            ]
+          }
+        ])
   ]
 })

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -60,9 +60,9 @@ tester.run('multiline-ternary', rule, {
     }
   ],
   invalid: [
-      {
-        filename: 'test.vue',
-        code: `
+    {
+      filename: 'test.vue',
+      code: `
         <template>
           <div :class="{
             'test': someReallyLongCondition ?
@@ -71,7 +71,8 @@ tester.run('multiline-ternary', rule, {
           </div>
         </template>
         `,
-        output: (semver.gte(ESLint.version, '7.1.0') ? `
+      output: semver.gte(ESLint.version, '7.1.0')
+        ? `
         <template>
           <div :class="{
             'test': someReallyLongCondition ?
@@ -80,20 +81,21 @@ tester.run('multiline-ternary', rule, {
           }">
           </div>
         </template>
-        ` : null),
-        errors: [
-          {
-            message:
-              'Expected newline between consequent and alternate of ternary expression.',
-            line: 5,
-            column: 15
-          }
-        ],
-        options: ['always-multiline']
-      },
-      {
-        filename: 'test.vue',
-        code: `
+        `
+        : null,
+      errors: [
+        {
+          message:
+            'Expected newline between consequent and alternate of ternary expression.',
+          line: 5,
+          column: 15
+        }
+      ],
+      options: ['always-multiline']
+    },
+    {
+      filename: 'test.vue',
+      code: `
         <template>
           <div :class="{
             'test': someReallyLongCondition ?
@@ -102,27 +104,29 @@ tester.run('multiline-ternary', rule, {
           </div>
         </template>
         `,
-        output: (semver.gte(ESLint.version, '7.1.0') ? `
+      output: semver.gte(ESLint.version, '7.1.0')
+        ? `
         <template>
           <div :class="{
             'test': someReallyLongCondition ?aVeryLongOutput : thisCantFitOnASingleLine
           }">
           </div>
         </template>
-        ` : null),
-        errors: [
-          {
-            message:
-              'Unexpected newline between test and consequent of ternary expression.',
-            line: 4,
-            column: 21
-          }
-        ],
-        options: ['never']
-      },
-      {
-        filename: 'test.vue',
-        code: `
+        `
+        : null,
+      errors: [
+        {
+          message:
+            'Unexpected newline between test and consequent of ternary expression.',
+          line: 4,
+          column: 21
+        }
+      ],
+      options: ['never']
+    },
+    {
+      filename: 'test.vue',
+      code: `
         <template>
           <div :class="{
             'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
@@ -130,7 +134,8 @@ tester.run('multiline-ternary', rule, {
           </div>
         </template>
         `,
-        output: (semver.gte(ESLint.version, '7.1.0') ? `
+      output: semver.gte(ESLint.version, '7.1.0')
+        ? `
         <template>
           <div :class="{
             'test': someReallyLongCondition
@@ -139,25 +144,26 @@ tester.run('multiline-ternary', rule, {
           }">
           </div>
         </template>
-        ` : null),
-        errors: [
-          {
-            message:
-              'Expected newline between test and consequent of ternary expression.',
-            line: 4,
-            column: 21
-          },
-          {
-            message:
-              'Expected newline between consequent and alternate of ternary expression.',
-            line: 4,
-            column: 47
-          }
-        ]
-      },
-      {
-        filename: 'test.vue',
-        code: `
+        `
+        : null,
+      errors: [
+        {
+          message:
+            'Expected newline between test and consequent of ternary expression.',
+          line: 4,
+          column: 21
+        },
+        {
+          message:
+            'Expected newline between consequent and alternate of ternary expression.',
+          line: 4,
+          column: 47
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
         <template>
           <div :style="{
             'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
@@ -165,7 +171,8 @@ tester.run('multiline-ternary', rule, {
           </div>
         </template>
         `,
-        output: (semver.gte(ESLint.version, '7.1.0') ? `
+      output: semver.gte(ESLint.version, '7.1.0')
+        ? `
         <template>
           <div :style="{
             'test': someReallyLongCondition
@@ -174,25 +181,26 @@ tester.run('multiline-ternary', rule, {
           }">
           </div>
         </template>
-        ` : null),
-        errors: [
-          {
-            message:
-              'Expected newline between test and consequent of ternary expression.',
-            line: 4,
-            column: 21
-          },
-          {
-            message:
-              'Expected newline between consequent and alternate of ternary expression.',
-            line: 4,
-            column: 47
-          }
-        ]
-      },
-      {
-        filename: 'test.vue',
-        code: `
+        `
+        : null,
+      errors: [
+        {
+          message:
+            'Expected newline between test and consequent of ternary expression.',
+          line: 4,
+          column: 21
+        },
+        {
+          message:
+            'Expected newline between consequent and alternate of ternary expression.',
+          line: 4,
+          column: 47
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
         <template>
           <div class="test">
           </div>
@@ -203,7 +211,8 @@ tester.run('multiline-ternary', rule, {
           }
         </style>
         `,
-        output: (semver.gte(ESLint.version, '7.1.0') ? `
+      output: semver.gte(ESLint.version, '7.1.0')
+        ? `
         <template>
           <div class="test">
           </div>
@@ -215,21 +224,22 @@ tester.run('multiline-ternary', rule, {
 : thisCantFitOnASingleLine')
           }
         </style>
-        ` : null),
-        errors: [
-          {
-            message:
-              'Expected newline between test and consequent of ternary expression.',
-            line: 8,
-            column: 30
-          },
-          {
-            message:
-              'Expected newline between consequent and alternate of ternary expression.',
-            line: 8,
-            column: 56
-          }
-        ]
-      }
+        `
+        : null,
+      errors: [
+        {
+          message:
+            'Expected newline between test and consequent of ternary expression.',
+          line: 8,
+          column: 30
+        },
+        {
+          message:
+            'Expected newline between consequent and alternate of ternary expression.',
+          line: 8,
+          column: 56
+        }
+      ]
+    }
   ]
 })

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -34,6 +34,14 @@ tester.run('multiline-ternary', rule, {
     {
       filename: 'test.vue',
       code: `
+      <script>
+        let test = someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
       <template>
         <div :class="{
           'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
@@ -240,6 +248,49 @@ tester.run('multiline-ternary', rule, {
           column: 56
         }
       ]
-    }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      <script>
+        let test = someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+      </script>
+      `,
+      output: semver.gte(ESLint.version, '7.1.0')
+        ? `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition
+? aVeryLongOutput
+: thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      <script>
+        let test = someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+      </script>
+      `
+        : null,
+      errors: [
+        {
+          message:
+            'Expected newline between test and consequent of ternary expression.',
+          line: 4,
+          column: 19
+        },
+        {
+          message:
+            'Expected newline between consequent and alternate of ternary expression.',
+          line: 4,
+          column: 45
+        }
+      ]
+    },
   ]
 })

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -1,0 +1,139 @@
+/**
+ * @author *****your name*****
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/multiline-ternary')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  }
+})
+
+tester.run('multiline-ternary', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ?
+            aVeryLongOutput :
+            thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      `,
+      options: ["never"]
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ?
+            aVeryLongOutput : thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      `,
+      output: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ?
+            aVeryLongOutput
+: thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Expected newline between consequent and alternate of ternary expression.',
+          line: 5,
+          column: 13
+        },
+      ],
+      options: ["always-multiline"]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ?
+            aVeryLongOutput : thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      `,
+      output: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ?aVeryLongOutput : thisCantFitOnASingleLine
+        }">
+        </div>
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Unexpected newline between test and consequent of ternary expression.',
+          line: 4,
+          column: 19
+        },
+      ],
+      options: ["never"]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
+         }">
+        </div>
+      </template>
+      `,
+      output: `
+      <template>
+        <div :class="{
+          'test': someReallyLongCondition
+? aVeryLongOutput
+: thisCantFitOnASingleLine
+         }">
+        </div>
+      </template>
+      `,
+      errors: [
+        {
+          message: 'Expected newline between test and consequent of ternary expression.',
+          line: 4,
+          column: 19
+        },
+        {
+          message: 'Expected newline between consequent and alternate of ternary expression.',
+          line: 4,
+          column: 45
+        }
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -42,146 +42,58 @@ tester.run('multiline-ternary', rule, {
       </template>
       `,
       options: ['never']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+          <div class="test">
+          </div>
+      </template>
+      <style>
+        .test {
+            color: v-bind('someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine')
+        }
+      </style>
+      `,
+      options: ['never']
     }
   ],
   invalid: [
-    ...(semver.gte(ESLint.version, '7.1.0')
-      ? [
-          {
-            filename: 'test.vue',
-            code: `
-      <template>
-        <div :class="{
-          'test': someReallyLongCondition ?
-            aVeryLongOutput : thisCantFitOnASingleLine
-        }">
-        </div>
-      </template>
-      `,
-            output: `
-      <template>
-        <div :class="{
-          'test': someReallyLongCondition ?
-            aVeryLongOutput
+      {
+        filename: 'test.vue',
+        code: `
+        <template>
+          <div :class="{
+            'test': someReallyLongCondition ?
+              aVeryLongOutput : thisCantFitOnASingleLine
+          }">
+          </div>
+        </template>
+        `,
+        output: (semver.gte(ESLint.version, '7.1.0') ? `
+        <template>
+          <div :class="{
+            'test': someReallyLongCondition ?
+              aVeryLongOutput
 : thisCantFitOnASingleLine
-        }">
-        </div>
-      </template>
-      `,
-            errors: [
-              {
-                message:
-                  'Expected newline between consequent and alternate of ternary expression.',
-                line: 5,
-                column: 13
-              }
-            ],
-            options: ['always-multiline']
-          },
+          }">
+          </div>
+        </template>
+        ` : null),
+        errors: [
           {
-            filename: 'test.vue',
-            code: `
-      <template>
-        <div :class="{
-          'test': someReallyLongCondition ?
-            aVeryLongOutput : thisCantFitOnASingleLine
-        }">
-        </div>
-      </template>
-      `,
-            output: `
-      <template>
-        <div :class="{
-          'test': someReallyLongCondition ?aVeryLongOutput : thisCantFitOnASingleLine
-        }">
-        </div>
-      </template>
-      `,
-            errors: [
-              {
-                message:
-                  'Unexpected newline between test and consequent of ternary expression.',
-                line: 4,
-                column: 19
-              }
-            ],
-            options: ['never']
-          },
-          {
-            filename: 'test.vue',
-            code: `
-      <template>
-        <div :class="{
-          'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
-         }">
-        </div>
-      </template>
-      `,
-            output: `
-      <template>
-        <div :class="{
-          'test': someReallyLongCondition
-? aVeryLongOutput
-: thisCantFitOnASingleLine
-         }">
-        </div>
-      </template>
-      `,
-            errors: [
-              {
-                message:
-                  'Expected newline between test and consequent of ternary expression.',
-                line: 4,
-                column: 19
-              },
-              {
-                message:
-                  'Expected newline between consequent and alternate of ternary expression.',
-                line: 4,
-                column: 45
-              }
-            ]
-          },
-          {
-            filename: 'test.vue',
-            code: `
-      <template>
-        <div :style="{
-          'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
-         }">
-        </div>
-      </template>
-      `,
-            output: `
-      <template>
-        <div :style="{
-          'test': someReallyLongCondition
-? aVeryLongOutput
-: thisCantFitOnASingleLine
-         }">
-        </div>
-      </template>
-      `,
-            errors: [
-              {
-                message:
-                  'Expected newline between test and consequent of ternary expression.',
-                line: 4,
-                column: 19
-              },
-              {
-                message:
-                  'Expected newline between consequent and alternate of ternary expression.',
-                line: 4,
-                column: 45
-              }
-            ]
+            message:
+              'Expected newline between consequent and alternate of ternary expression.',
+            line: 5,
+            column: 15
           }
-        ]
-      : [
-          {
-            filename: 'test.vue',
-            code: `
+        ],
+        options: ['always-multiline']
+      },
+      {
+        filename: 'test.vue',
+        code: `
         <template>
           <div :class="{
             'test': someReallyLongCondition ?
@@ -190,87 +102,134 @@ tester.run('multiline-ternary', rule, {
           </div>
         </template>
         `,
-            errors: [
-              {
-                message:
-                  'Expected newline between consequent and alternate of ternary expression.',
-                line: 5,
-                column: 15
-              }
-            ],
-            options: ['always-multiline']
-          },
-          {
-            filename: 'test.vue',
-            code: `
+        output: (semver.gte(ESLint.version, '7.1.0') ? `
         <template>
           <div :class="{
-            'test': someReallyLongCondition ?
-              aVeryLongOutput : thisCantFitOnASingleLine
+            'test': someReallyLongCondition ?aVeryLongOutput : thisCantFitOnASingleLine
           }">
           </div>
         </template>
-        `,
-            errors: [
-              {
-                message:
-                  'Unexpected newline between test and consequent of ternary expression.',
-                line: 4,
-                column: 21
-              }
-            ],
-            options: ['never']
-          },
+        ` : null),
+        errors: [
           {
-            filename: 'test.vue',
-            code: `
+            message:
+              'Unexpected newline between test and consequent of ternary expression.',
+            line: 4,
+            column: 21
+          }
+        ],
+        options: ['never']
+      },
+      {
+        filename: 'test.vue',
+        code: `
         <template>
           <div :class="{
             'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
-           }">
+          }">
           </div>
         </template>
         `,
-            errors: [
-              {
-                message:
-                  'Expected newline between test and consequent of ternary expression.',
-                line: 4,
-                column: 21
-              },
-              {
-                message:
-                  'Expected newline between consequent and alternate of ternary expression.',
-                line: 4,
-                column: 47
-              }
-            ]
+        output: (semver.gte(ESLint.version, '7.1.0') ? `
+        <template>
+          <div :class="{
+            'test': someReallyLongCondition
+? aVeryLongOutput
+: thisCantFitOnASingleLine
+          }">
+          </div>
+        </template>
+        ` : null),
+        errors: [
+          {
+            message:
+              'Expected newline between test and consequent of ternary expression.',
+            line: 4,
+            column: 21
           },
           {
-            filename: 'test.vue',
-            code: `
+            message:
+              'Expected newline between consequent and alternate of ternary expression.',
+            line: 4,
+            column: 47
+          }
+        ]
+      },
+      {
+        filename: 'test.vue',
+        code: `
         <template>
           <div :style="{
             'test': someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine
-           }">
+          }">
           </div>
         </template>
         `,
-            errors: [
-              {
-                message:
-                  'Expected newline between test and consequent of ternary expression.',
-                line: 4,
-                column: 21
-              },
-              {
-                message:
-                  'Expected newline between consequent and alternate of ternary expression.',
-                line: 4,
-                column: 47
-              }
-            ]
+        output: (semver.gte(ESLint.version, '7.1.0') ? `
+        <template>
+          <div :style="{
+            'test': someReallyLongCondition
+? aVeryLongOutput
+: thisCantFitOnASingleLine
+          }">
+          </div>
+        </template>
+        ` : null),
+        errors: [
+          {
+            message:
+              'Expected newline between test and consequent of ternary expression.',
+            line: 4,
+            column: 21
+          },
+          {
+            message:
+              'Expected newline between consequent and alternate of ternary expression.',
+            line: 4,
+            column: 47
           }
-        ])
+        ]
+      },
+      {
+        filename: 'test.vue',
+        code: `
+        <template>
+          <div class="test">
+          </div>
+        </template>
+        <style>
+          .test {
+              color: v-bind('someReallyLongCondition ? aVeryLongOutput : thisCantFitOnASingleLine')
+          }
+        </style>
+        `,
+        output: (semver.gte(ESLint.version, '7.1.0') ? `
+        <template>
+          <div class="test">
+          </div>
+        </template>
+        <style>
+          .test {
+              color: v-bind('someReallyLongCondition
+? aVeryLongOutput
+: thisCantFitOnASingleLine')
+          }
+        </style>
+        ` : null),
+        errors: [
+          {
+            message:
+              'Expected newline between test and consequent of ternary expression.',
+            line: 8,
+            column: 30
+          },
+          {
+            message:
+              'Expected newline between consequent and alternate of ternary expression.',
+            line: 8,
+            column: 56
+          }
+        ]
+      }
   ]
 })

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -292,6 +292,6 @@ tester.run('multiline-ternary', rule, {
           column: 45
         }
       ]
-    },
+    }
   ]
 })

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -195,7 +195,7 @@ tester.run('multiline-ternary', rule, {
                 message:
                   'Expected newline between consequent and alternate of ternary expression.',
                 line: 5,
-                column: 13
+                column: 15
               }
             ],
             options: ['always-multiline']
@@ -216,7 +216,7 @@ tester.run('multiline-ternary', rule, {
                 message:
                   'Unexpected newline between test and consequent of ternary expression.',
                 line: 4,
-                column: 19
+                column: 21
               }
             ],
             options: ['never']
@@ -236,7 +236,7 @@ tester.run('multiline-ternary', rule, {
                 message:
                   'Expected newline between test and consequent of ternary expression.',
                 line: 4,
-                column: 19
+                column: 21
               },
               {
                 message:
@@ -261,7 +261,7 @@ tester.run('multiline-ternary', rule, {
                 message:
                   'Expected newline between test and consequent of ternary expression.',
                 line: 4,
-                column: 19
+                column: 21
               },
               {
                 message:


### PR DESCRIPTION
Wrap multiline ternary rule for vue.

Not sure about the indenting, maybe it is not an issue and would be handled by other rules. Looks strange.