### PR TITLE
Chore: remove from docs how to install via VueCLI

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -2,12 +2,6 @@
 
 ## :cd: Installation
 
-Via `vue-cli` (**Recommended**):
-
-```bash
-vue add @vue/cli-plugin-eslint
-```
-
 Via [npm](https://www.npmjs.com/):
 
 ```bash


### PR DESCRIPTION
I noticed that VueCLI is in maintenance mode.

https://cli.vuejs.org/

So remove the way to install plugin via VueCLI.

close #1999