### PR TITLE
Allow restricting classes by regexp in `vue/no-restricted-class`

### DIFF
--- a/docs/rules/no-restricted-class.md
+++ b/docs/rules/no-restricted-class.md
@@ -20,7 +20,7 @@ in the rule configuration.
 
 ```json
 {
-  "vue/no-restricted-class": ["error", "forbidden", "forbidden-two", "forbidden-three"]
+  "vue/no-restricted-class": ["error", "forbidden", "forbidden-two", "forbidden-three", "/^for(bidden|gotten)/"]
 }
 ```
 

--- a/lib/rules/no-restricted-class.js
+++ b/lib/rules/no-restricted-class.js
@@ -12,18 +12,20 @@ const regexp = require('../utils/regexp')
  * @param {string} className
  * @param {*} node
  * @param {RuleContext} context
- * @param {Array<string>} forbiddenClasses
+ * @param {Set<string>} forbiddenClasses
+ * @param {Array<RegExp>} forbiddenClassesRegexps
  */
-const reportForbiddenClass = (className, node, context, forbiddenClasses) => {
-  const isForbidden = forbiddenClasses.some((cl) => {
-    if (regexp.isRegExp(cl)) {
-      const re = regexp.toRegExp(cl)
-      return re.test(className)
-    } else {
-      return className.includes(cl)
-    }
-  })
-  if (isForbidden) {
+const reportForbiddenClass = (
+  className,
+  node,
+  context,
+  forbiddenClasses,
+  forbiddenClassesRegexps
+) => {
+  if (
+    forbiddenClasses.has(className) ||
+    forbiddenClassesRegexps.some((re) => re.test(className))
+  ) {
     const loc = node.value ? node.value.loc : node.loc
     context.report({
       node,
@@ -121,7 +123,10 @@ module.exports = {
 
   /** @param {RuleContext} context */
   create(context) {
-    const forbiddenClasses = context.options || []
+    const forbiddenClasses = new Set(context.options || [])
+    const forbiddenClassesRegexps = (context.options || [])
+      .filter((cl) => regexp.isRegExp(cl))
+      .map((cl) => regexp.toRegExp(cl))
 
     return utils.defineTemplateBodyVisitor(context, {
       /**
@@ -129,7 +134,13 @@ module.exports = {
        */
       'VAttribute[directive=false][key.name="class"]'(node) {
         for (const className of node.value.value.split(/\s+/)) {
-          reportForbiddenClass(className, node, context, forbiddenClasses)
+          reportForbiddenClass(
+            className,
+            node,
+            context,
+            forbiddenClasses,
+            forbiddenClassesRegexps
+          )
         }
       },
 
@@ -144,7 +155,13 @@ module.exports = {
         for (const { className, reportNode } of extractClassNames(
           /** @type {Expression} */ (node.expression)
         )) {
-          reportForbiddenClass(className, reportNode, context, forbiddenClasses)
+          reportForbiddenClass(
+            className,
+            reportNode,
+            context,
+            forbiddenClasses,
+            forbiddenClassesRegexps
+          )
         }
       }
     })

--- a/lib/rules/no-restricted-class.js
+++ b/lib/rules/no-restricted-class.js
@@ -5,16 +5,25 @@
 'use strict'
 
 const utils = require('../utils')
+const regexp = require('../utils/regexp')
 
 /**
  * Report a forbidden class
  * @param {string} className
  * @param {*} node
  * @param {RuleContext} context
- * @param {Set<string>} forbiddenClasses
+ * @param {Array<string>} forbiddenClasses
  */
 const reportForbiddenClass = (className, node, context, forbiddenClasses) => {
-  if (forbiddenClasses.has(className)) {
+  const isForbidden = forbiddenClasses.some((cl) => {
+    if (regexp.isRegExp(cl)) {
+      const re = regexp.toRegExp(cl)
+      return re.test(className)
+    } else {
+      return className.includes(cl)
+    }
+  })
+  if (isForbidden) {
     const loc = node.value ? node.value.loc : node.loc
     context.report({
       node,
@@ -112,7 +121,7 @@ module.exports = {
 
   /** @param {RuleContext} context */
   create(context) {
-    const forbiddenClasses = new Set(context.options || [])
+    const forbiddenClasses = context.options || []
 
     return utils.defineTemplateBodyVisitor(context, {
       /**

--- a/tests/lib/rules/no-restricted-class.js
+++ b/tests/lib/rules/no-restricted-class.js
@@ -32,7 +32,7 @@ ruleTester.run('no-restricted-class', rule, {
       options: ['forbidden']
     },
     {
-      code: `<template><div class="allowed"">Content</div></template>`,
+      code: `<template><div class="allowed">Content</div></template>`,
       options: ['/^for(bidden|gotten)/']
     }
   ],

--- a/tests/lib/rules/no-restricted-class.js
+++ b/tests/lib/rules/no-restricted-class.js
@@ -30,6 +30,10 @@ ruleTester.run('no-restricted-class', rule, {
     {
       code: `<template><div :class="'' + {forbidden: true}">Content</div></template>`,
       options: ['forbidden']
+    },
+    {
+      code: `<template><div class="allowed"">Content</div></template>`,
+      options: ['/^for(bidden|gotten)/']
     }
   ],
 
@@ -113,6 +117,16 @@ ruleTester.run('no-restricted-class', rule, {
         }
       ],
       options: ['forbidden']
+    },
+    {
+      code: `<template><div class="forbidden allowed" /></template>`,
+      errors: [
+        {
+          message: "'forbidden' class is not allowed.",
+          type: 'VAttribute'
+        }
+      ],
+      options: ['/^for(bidden|gotten)/']
     }
   ]
 })


### PR DESCRIPTION
Closes #1877

This PR adds support for RegEx to the `no-restricted-class` rule and an update to the example in the docs.

I didn't add all the `buildMatcher` logic like in the example linked in the Issue (`no-restricted-custom-event`: https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-restricted-custom-event.js) because this rule seemed a little more straightforward.

Please let me know if you need anything else. Thanks!