### PR TITLE
Add example for rule `vue/no-restricted-static-attribute`

### DIFF
--- a/docs/rules/no-restricted-static-attribute.md
+++ b/docs/rules/no-restricted-static-attribute.md
@@ -46,7 +46,7 @@ Alternatively, the rule also accepts objects.
     },
     {
       "key": "style",
-      "element": /^([A-Z$][a-zA-Z_$]*)$/,
+      "element": "/^([A-Z][a-zA-Z_-]*)$/",
       "message": "Using \"style\" is not allowed in custom component. Use \"class\" instead."
     }
   ]

--- a/docs/rules/no-restricted-static-attribute.md
+++ b/docs/rules/no-restricted-static-attribute.md
@@ -43,6 +43,11 @@ Alternatively, the rule also accepts objects.
     {
       "key": "stlye",
       "message": "Using \"stlye\" is not allowed. Use \"style\" instead."
+    },
+    {
+      "key": "style",
+      "element": /^([A-Z$][a-zA-Z_$]*)$/,
+      "message": "Using \"style\" is not allowed in custom component. Use \"class\" instead."
     }
   ]
 }


### PR DESCRIPTION
From the conversation of https://github.com/vuejs/eslint-plugin-vue/pull/2020, after some unnecessary work and the valuable comments from @FloEdelmann, I then added a example to the document to make it clearer.

The example of the `element` property about the rule `vue/no-restricted-static-attribute`:
```javascript
options = [
    {
        "key": "style",
        "element": /^([A-Z$][a-zA-Z_$]*)$/,
        "message": "Using \"style\" is not allowed in custom component. Use \"class\" instead."
    }
]
```