### PR TITLE
Ignore `<Textarea>` components in `vue/no-textarea-mustache`

### DIFF
--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -27,6 +27,13 @@ module.exports = {
           return
         }
 
+        const sourceCode = context.getSourceCode()
+        const parentStartTag = sourceCode.getText(node.parent.startTag)
+
+        if (parentStartTag.startsWith('<T')) {
+          return
+        }
+
         context.report({
           node,
           loc: node.loc,

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -20,18 +20,13 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
-    const sourceCode = context.getSourceCode()
-
     return utils.defineTemplateBodyVisitor(context, {
       /** @param {VExpressionContainer} node */
       "VElement[name='textarea'] VExpressionContainer"(node) {
-        if (node.parent.type !== 'VElement') {
-          return
-        }
-
-        const parentStartTag = sourceCode.getText(node.parent.startTag)
-
-        if (parentStartTag.startsWith('<T')) {
+        if (
+          node.parent.type !== 'VElement' ||
+          node.parent.rawName.startsWith('T')
+        ) {
           return
         }
 

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -22,11 +22,8 @@ module.exports = {
   create(context) {
     return utils.defineTemplateBodyVisitor(context, {
       /** @param {VExpressionContainer} node */
-      "VElement[name='textarea'] VExpressionContainer"(node) {
-        if (
-          node.parent.type !== 'VElement' ||
-          node.parent.rawName.startsWith('T')
-        ) {
+      "VElement[rawName='textarea'] VExpressionContainer"(node) {
+        if (node.parent.type !== 'VElement') {
           return
         }
 

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -20,6 +20,8 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
+    const sourceCode = context.getSourceCode()
+
     return utils.defineTemplateBodyVisitor(context, {
       /** @param {VExpressionContainer} node */
       "VElement[name='textarea'] VExpressionContainer"(node) {
@@ -27,7 +29,6 @@ module.exports = {
           return
         }
 
-        const sourceCode = context.getSourceCode()
         const parentStartTag = sourceCode.getText(node.parent.startTag)
 
         if (parentStartTag.startsWith('<T')) {

--- a/tests/lib/rules/no-textarea-mustache.js
+++ b/tests/lib/rules/no-textarea-mustache.js
@@ -22,12 +22,21 @@ tester.run('no-textarea-mustache', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><textarea v-model="text"></textarea></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><Textarea>{{text}}</Textarea></div></template>'
     }
   ],
   invalid: [
     {
       filename: 'test.vue',
       code: '<template><div><textarea>{{text}}</textarea></div></template>',
+      errors: ["Unexpected mustache. Use 'v-model' instead."]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><textarea v-model="text">{{text}}</textarea></div></template>',
       errors: ["Unexpected mustache. Use 'v-model' instead."]
     },
     {


### PR DESCRIPTION
Fix #2023 