### PR TITLE
Extract JSDoc comment recognition into util functions

### DIFF
--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -6,6 +6,7 @@
 
 const utils = require('../utils')
 const eslintUtils = require('eslint-utils')
+const { isJSDocComment } = require('../utils/comments.js')
 const { getStyleVariablesContext } = require('../utils/style-variables')
 const {
   definePropertyReferenceExtractor,
@@ -169,11 +170,7 @@ function findJSDocComment(node, sourceCode) {
     break
   }
 
-  if (
-    tokenBefore &&
-    tokenBefore.type === 'Block' &&
-    tokenBefore.value.charAt(0) === '*'
-  ) {
+  if (tokenBefore && isJSDocComment(tokenBefore)) {
     return tokenBefore
   }
 

--- a/lib/rules/require-prop-comment.js
+++ b/lib/rules/require-prop-comment.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
+const { isBlockComment, isJSDocComment } = require('../utils/comments.js')
 
 module.exports = {
   meta: {
@@ -43,9 +44,7 @@ module.exports = {
 
     /** @param {Comment | undefined} comment */
     const verifyBlock = (comment) =>
-      comment && comment.type === 'Block' && comment.value.charAt(0) !== '*'
-        ? undefined
-        : 'requireBlockComment'
+      comment && isBlockComment(comment) ? undefined : 'requireBlockComment'
 
     /** @param {Comment | undefined} comment */
     const verifyLine = (comment) =>
@@ -56,9 +55,7 @@ module.exports = {
 
     /** @param {Comment | undefined} comment */
     const verifyJSDoc = (comment) =>
-      comment && comment.type === 'Block' && comment.value.charAt(0) === '*'
-        ? undefined
-        : 'requireJSDocComment'
+      comment && isJSDocComment(comment) ? undefined : 'requireJSDocComment'
 
     /**
      * @param {import('../utils').ComponentProp[]} props

--- a/lib/utils/comments.js
+++ b/lib/utils/comments.js
@@ -1,0 +1,21 @@
+/**
+ * @param {Comment} node
+ * @returns {boolean}
+ */
+const isJSDocComment = (node) =>
+  node.type === 'Block' &&
+  node.value.charAt(0) === '*' &&
+  node.value.charAt(1) !== '*'
+
+/**
+ * @param {Comment} node
+ * @returns {boolean}
+ */
+const isBlockComment = (node) =>
+  node.type === 'Block' &&
+  (node.value.charAt(0) !== '*' || node.value.charAt(1) === '*')
+
+module.exports = {
+  isJSDocComment,
+  isBlockComment
+}

--- a/tests/lib/utils/comments.js
+++ b/tests/lib/utils/comments.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const assert = require('assert')
+const {
+  isBlockComment,
+  isJSDocComment
+} = require('../../../lib/utils/comments.js')
+
+// //foo
+const lineCommentNode = {
+  type: 'Line',
+  value: 'foo'
+}
+
+// /*foo*/
+const blockCommentNodeWithoutAsterisks = {
+  type: 'Block',
+  value: 'foo'
+}
+
+// //** foo */
+const blockCommentNodeWithOneAsterisk = {
+  type: 'Block',
+  value: '* foo'
+}
+
+// /*** foo */
+const blockCommentNodeWithTwoAsterisks = {
+  type: 'Block',
+  value: '** foo'
+}
+
+describe('isJSDocComment()', () => {
+  it('returns true for JSDoc comments', () => {
+    assert.equal(isJSDocComment(blockCommentNodeWithOneAsterisk), true)
+  })
+
+  it('returns false for block comments', () => {
+    assert.equal(isJSDocComment(blockCommentNodeWithoutAsterisks), false)
+  })
+
+  it('returns false for line comments', () => {
+    assert.equal(isJSDocComment(lineCommentNode), false)
+  })
+
+  it('returns false for block comments with two asterisks', () => {
+    assert.equal(isJSDocComment(blockCommentNodeWithTwoAsterisks), false)
+  })
+})
+
+describe('isBlockComment()', () => {
+  it('returns false for JSDoc comments', () => {
+    assert.equal(isBlockComment(blockCommentNodeWithOneAsterisk), false)
+  })
+
+  it('returns true for block comments', () => {
+    assert.equal(isBlockComment(blockCommentNodeWithoutAsterisks), true)
+  })
+
+  it('returns false for line comments', () => {
+    assert.equal(isBlockComment(lineCommentNode), false)
+  })
+
+  it('returns true for block comments with two asterisks', () => {
+    assert.equal(isBlockComment(blockCommentNodeWithTwoAsterisks), true)
+  })
+})


### PR DESCRIPTION
and add tests for them.

Follow-up to #2019. This was the commit that @czb3279338858 removed accidentally.