### PR TITLE
Ignore well known tags in `component-name-in-template-casing`

### DIFF
--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -90,23 +90,21 @@ module.exports = {
         return false
       }
 
+      if (
+        (!utils.isHtmlElementNode(node) && !utils.isSvgElementNode(node)) ||
+        utils.isHtmlWellKnownElementName(node.rawName) ||
+        utils.isSvgWellKnownElementName(node.rawName)
+      ) {
+        return false
+      }
+
       if (!registeredComponentsOnly) {
         // If the user specifies registeredComponentsOnly as false, it checks all component tags.
-        if (
-          (!utils.isHtmlElementNode(node) && !utils.isSvgElementNode(node)) ||
-          utils.isHtmlWellKnownElementName(node.rawName) ||
-          utils.isSvgWellKnownElementName(node.rawName)
-        ) {
-          return false
-        }
-        return true
-      }
-      // We only verify the registered components.
-      if (registeredComponents.has(casing.pascalCase(node.rawName))) {
         return true
       }
 
-      return false
+      // We only verify the registered components.
+      return registeredComponents.has(casing.pascalCase(node.rawName))
     }
 
     let hasInvalidEOF = false

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -162,6 +162,15 @@ tester.run('component-name-in-template-casing', rule, {
       `
     },
 
+    {
+      code: `
+        <template><div/></template>
+        <script setup>const Div = 0</script>
+      `,
+      options: ['PascalCase'],
+      filename: 'test.vue'
+    },
+
     // globals
     {
       code: `


### PR DESCRIPTION
Vue does not treat built-in HTML tags as components, so them should be always excluded from verification.

e.g.

```html
<template>
    <div/>
<template>
<script setup>
    import Div from "component"
</script>
```

will be compiled to

```javascript
import Div from "component"

const __sfc__ = {
  __name: 'App',
  setup(__props) {

return (_ctx, _cache) => {
  // `Div` is not used.
  return (_openBlock(), _createElementBlock("div"))
}
}
```