### PR TITLE
fix(define-macros-order): update rule to support interface/type expor…

### DIFF
--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -45,7 +45,8 @@ function getTargetStatementPosition(scriptSetup, program) {
     'TSInterfaceDeclaration',
     'TSTypeAliasDeclaration',
     'DebuggerStatement',
-    'EmptyStatement'
+    'EmptyStatement',
+    'ExportNamedDeclaration'
   ])
 
   for (const [index, item] of program.body.entries()) {

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -106,6 +106,28 @@ tester.run('define-macros-order', rule, {
         </script>
       `,
       options: optionsEmitsFirst
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          import { bar } from 'foo'
+          export interface Props {
+            msg?: string
+            labels?: string[]
+          }
+          defineEmits(['update:test'])
+          const props = withDefaults(defineProps<Props>(), {
+            msg: 'hello',
+            labels: () => ['one', 'two']
+          })
+          console.log('test')
+        </script>
+      `,
+      options: optionsEmitsFirst,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     }
   ],
   invalid: [


### PR DESCRIPTION
I'm using this workaround https://github.com/johnsoncodehk/volar/issues/1232#issuecomment-1165416439 , but `define-macros-order` has conflict with Volar,