### PR TITLE
fix(docs): update example code for watch()

### DIFF
--- a/docs/rules/no-setup-props-destructure.md
+++ b/docs/rules/no-setup-props-destructure.md
@@ -22,7 +22,7 @@ This rule reports the destructuring of `props` passed to `setup` causing the val
 export default {
   /* ✓ GOOD */
   setup(props) {
-    watch(() => {
+    watch(() => props.count, () => {
       console.log(props.count)
     })
 
@@ -45,8 +45,8 @@ Destructuring the `props` passed to `setup` will cause the value to lose reactiv
 export default {
   /* ✗ BAD */
   setup({ count }) {
-    watch(() => {
-      console.log(count) // not going to detect changes
+    watch(() => count, () => { // not going to detect changes
+      console.log(count)
     })
 
     return () => {
@@ -69,8 +69,8 @@ export default {
   setup(props) {
     /* ✗ BAD */
     const { count } = props
-
-    watch(() => {
+  
+    watch(() => props.count, () => {
       /* ✓ GOOD */
       const { count } = props
       console.log(count)

--- a/docs/rules/no-setup-props-destructure.md
+++ b/docs/rules/no-setup-props-destructure.md
@@ -69,7 +69,7 @@ export default {
   setup(props) {
     /* ✗ BAD */
     const { count } = props
-  
+
     watch(() => props.count, () => {
       /* ✓ GOOD */
       const { count } = props


### PR DESCRIPTION
The 1st argument for watch() should be a ref/reactive/getter function/array of ref, reactive, getter function. But in the example code, the watch callback has been used as the 1st argument