### PR TITLE
Chore: add script to site that remove service-worker

### DIFF
--- a/docs/.vitepress/public/service-worker.js
+++ b/docs/.vitepress/public/service-worker.js
@@ -1,0 +1,14 @@
+// https://github.com/NekR/self-destroying-sw
+/* globals self */
+self.addEventListener('install', (e) => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (e) => {
+  self.registration
+    .unregister()
+    .then(() => self.clients.matchAll())
+    .then((clients) => {
+      for (const client of clients) client.navigate(client.url)
+    })
+})


### PR DESCRIPTION
I've noticed that the latest docs site doesn't display from some devices.
This is because previously we were using `@vuepress/plugin-pwa` and the cache is displayed by the service worker.
https://vuepress.vuejs.org/plugin/official/plugin-pwa.html

This PR adds a script to remove service workers.
See also below for how to remove.
https://github.com/NekR/self-destroying-sw