### PR TITLE
Add new attributes order for dynamic and static props

### DIFF
--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -35,11 +35,13 @@ This rule aims to enforce ordering of component attributes. The default order is
 - `OTHER_DIRECTIVES`
   e.g. 'v-custom-directive'
 - `OTHER_ATTR`
-  alias for `[ATTR_DYNAMIC, ATTR_STATIC]`:
+  alias for `[ATTR_DYNAMIC, ATTR_STATIC, ATTR_SHORTHAND_BOOL]`:
   - `ATTR_DYNAMIC`
     e.g. 'v-bind:prop="foo"', ':prop="foo"'
   - `ATTR_STATIC`
     e.g. 'prop="foo"', 'custom-prop="foo"'
+  - `ATTR_SHORTHAND_BOOL`
+    e.g. 'boolean-prop'
 - `EVENTS`
   e.g. '@click="functionCall"', 'v-on="event"'
 - `CONTENT`

--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -35,11 +35,11 @@ This rule aims to enforce ordering of component attributes. The default order is
 - `OTHER_DIRECTIVES`
   e.g. 'v-custom-directive'
 - `OTHER_ATTR`
-  alias for '[OTHER_ATTR_DYNAMIC, OTHER_ATTR_STATIC]'
-- `OTHER_ATTR_DYNAMIC`
-  e.g. 'v-bind:prop="foo"', ':prop="foo"'
-- `OTHER_ATTR_STATIC`
-  e.g. 'prop="foo"', 'custom-prop="foo"'
+  alias for `[OTHER_ATTR_DYNAMIC, OTHER_ATTR_STATIC]`:
+  - `OTHER_ATTR_DYNAMIC`
+    e.g. 'v-bind:prop="foo"', ':prop="foo"'
+  - `OTHER_ATTR_STATIC`
+    e.g. 'prop="foo"', 'custom-prop="foo"'
 - `EVENTS`
   e.g. '@click="functionCall"', 'v-on="event"'
 - `CONTENT`

--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -35,10 +35,10 @@ This rule aims to enforce ordering of component attributes. The default order is
 - `OTHER_DIRECTIVES`
   e.g. 'v-custom-directive'
 - `OTHER_ATTR`
-  alias for `[OTHER_ATTR_DYNAMIC, OTHER_ATTR_STATIC]`:
-  - `OTHER_ATTR_DYNAMIC`
+  alias for `[ATTR_DYNAMIC, ATTR_STATIC]`:
+  - `ATTR_DYNAMIC`
     e.g. 'v-bind:prop="foo"', ':prop="foo"'
-  - `OTHER_ATTR_STATIC`
+  - `ATTR_STATIC`
     e.g. 'prop="foo"', 'custom-prop="foo"'
 - `EVENTS`
   e.g. '@click="functionCall"', 'v-on="event"'

--- a/docs/rules/attributes-order.md
+++ b/docs/rules/attributes-order.md
@@ -35,7 +35,11 @@ This rule aims to enforce ordering of component attributes. The default order is
 - `OTHER_DIRECTIVES`
   e.g. 'v-custom-directive'
 - `OTHER_ATTR`
-  e.g. 'custom-prop="foo"', 'v-bind:prop="foo"', ':prop="foo"'
+  alias for '[OTHER_ATTR_DYNAMIC, OTHER_ATTR_STATIC]'
+- `OTHER_ATTR_DYNAMIC`
+  e.g. 'v-bind:prop="foo"', ':prop="foo"'
+- `OTHER_ATTR_STATIC`
+  e.g. 'prop="foo"', 'custom-prop="foo"'
 - `EVENTS`
   e.g. '@click="functionCall"', 'v-on="event"'
 - `CONTENT`

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -70,7 +70,7 @@ function isVBindObject(node) {
 }
 
 /**
- * Check whether the given attribute is `v-bind="..."` directive.
+ * Check whether the given attribute is a shorthand boolean like `selected`.
  * @param {VAttribute | VDirective | undefined | null} node
  * @returns { node is VAttribute }
  */
@@ -167,7 +167,8 @@ function getAttributeType(attribute) {
     default:
       if (isVBind(attribute)) {
         return ATTRS.ATTR_DYNAMIC
-      } else if (isVShorthandBoolean(attribute)) {
+      }
+      if (isVShorthandBoolean(attribute)) {
         return ATTRS.ATTR_SHORTHAND_BOOL
       }
       return ATTRS.ATTR_STATIC
@@ -233,13 +234,10 @@ function create(context) {
     for (const [index, item] of attributeOrder.entries()) {
       if (item === ATTRS.OTHER_ATTR) {
         attributeOrder[index] = otherAttrs
-      } else if (Array.isArray(item)) {
-        const itemIndex = item.indexOf(ATTRS.OTHER_ATTR)
-        if (itemIndex > -1) {
-          const attributes = item.filter((i) => i !== ATTRS.OTHER_ATTR)
-          attributes.push(...otherAttrs)
-          attributeOrder[index] = attributes
-        }
+      } else if (Array.isArray(item) && item.includes(ATTRS.OTHER_ATTR)) {
+        const attributes = item.filter((i) => i !== ATTRS.OTHER_ATTR)
+        attributes.push(...otherAttrs)
+        attributeOrder[index] = attributes
       }
     }
   }

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -20,8 +20,8 @@ const ATTRS = {
   TWO_WAY_BINDING: 'TWO_WAY_BINDING',
   OTHER_DIRECTIVES: 'OTHER_DIRECTIVES',
   OTHER_ATTR: 'OTHER_ATTR',
-  OTHER_ATTR_STATIC: 'OTHER_ATTR_STATIC',
-  OTHER_ATTR_DYNAMIC: 'OTHER_ATTR_DYNAMIC',
+  ATTR_STATIC: 'ATTR_STATIC',
+  ATTR_DYNAMIC: 'ATTR_DYNAMIC',
   EVENTS: 'EVENTS',
   CONTENT: 'CONTENT'
 }
@@ -156,9 +156,9 @@ function getAttributeType(attribute) {
       return ATTRS.SLOT
     default:
       if (isVBind(attribute)) {
-        return ATTRS.OTHER_ATTR_DYNAMIC
+        return ATTRS.ATTR_DYNAMIC
       }
-      return ATTRS.OTHER_ATTR_STATIC
+      return ATTRS.ATTR_STATIC
   }
 }
 
@@ -196,7 +196,7 @@ function isAlphabetical(prevNode, currNode, sourceCode) {
  */
 function create(context) {
   const sourceCode = context.getSourceCode()
-  const otherAttrs = [ATTRS.OTHER_ATTR_DYNAMIC, ATTRS.OTHER_ATTR_STATIC]
+  const otherAttrs = [ATTRS.ATTR_DYNAMIC, ATTRS.ATTR_STATIC]
   let attributeOrder = [
     ATTRS.DEFINITION,
     ATTRS.LIST_RENDERING,
@@ -206,7 +206,7 @@ function create(context) {
     [ATTRS.UNIQUE, ATTRS.SLOT],
     ATTRS.TWO_WAY_BINDING,
     ATTRS.OTHER_DIRECTIVES,
-    [ATTRS.OTHER_ATTR_DYNAMIC, ATTRS.OTHER_ATTR_STATIC],
+    [ATTRS.ATTR_DYNAMIC, ATTRS.ATTR_STATIC],
     ATTRS.EVENTS,
     ATTRS.CONTENT
   ]

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -20,6 +20,8 @@ const ATTRS = {
   TWO_WAY_BINDING: 'TWO_WAY_BINDING',
   OTHER_DIRECTIVES: 'OTHER_DIRECTIVES',
   OTHER_ATTR: 'OTHER_ATTR',
+  OTHER_ATTR_STATIC: 'OTHER_ATTR_STATIC',
+  OTHER_ATTR_DYNAMIC: 'OTHER_ATTR_DYNAMIC',
   EVENTS: 'EVENTS',
   CONTENT: 'CONTENT'
 }
@@ -153,7 +155,10 @@ function getAttributeType(attribute) {
     case 'slot-scope':
       return ATTRS.SLOT
     default:
-      return ATTRS.OTHER_ATTR
+      if (attribute.directive) {
+        return ATTRS.OTHER_ATTR_DYNAMIC
+      }
+      return ATTRS.OTHER_ATTR_STATIC
   }
 }
 
@@ -191,6 +196,7 @@ function isAlphabetical(prevNode, currNode, sourceCode) {
  */
 function create(context) {
   const sourceCode = context.getSourceCode()
+  const otherAttrs = [ATTRS.OTHER_ATTR_DYNAMIC, ATTRS.OTHER_ATTR_STATIC]
   let attributeOrder = [
     ATTRS.DEFINITION,
     ATTRS.LIST_RENDERING,
@@ -200,16 +206,26 @@ function create(context) {
     [ATTRS.UNIQUE, ATTRS.SLOT],
     ATTRS.TWO_WAY_BINDING,
     ATTRS.OTHER_DIRECTIVES,
-    ATTRS.OTHER_ATTR,
+    [ATTRS.OTHER_ATTR_DYNAMIC, ATTRS.OTHER_ATTR_STATIC],
     ATTRS.EVENTS,
     ATTRS.CONTENT
   ]
   if (context.options[0] && context.options[0].order) {
-    attributeOrder = context.options[0].order
+    attributeOrder = [...context.options[0].order]
   }
   const alphabetical = Boolean(
     context.options[0] && context.options[0].alphabetical
   )
+
+  for (const [index, item] of attributeOrder.entries()) {
+    if (Array.isArray(item) && item.includes(ATTRS.OTHER_ATTR)) {
+      const attributes = item.filter((i) => i !== ATTRS.OTHER_ATTR)
+      attributes.push(...otherAttrs)
+      attributeOrder[index] = attributes
+    } else if (item === ATTRS.OTHER_ATTR) {
+      attributeOrder[index] = otherAttrs
+    }
+  }
 
   /** @type { { [key: string]: number } } */
   const attributePosition = {}

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -211,21 +211,25 @@ function create(context) {
     ATTRS.CONTENT
   ]
   if (context.options[0] && context.options[0].order) {
-    attributeOrder = [...context.options[0].order]
+    const contextAttributeOrder = [...context.options[0].order]
+
+    // expand `OTHER_ATTR` alias
+    for (const [index, item] of contextAttributeOrder.entries()) {
+      if (item === ATTRS.OTHER_ATTR) {
+        contextAttributeOrder[index] = otherAttrs
+      } else if (Array.isArray(item)) {
+        const itemIndex = item.indexOf(ATTRS.OTHER_ATTR)
+        if (itemIndex > -1) {
+          contextAttributeOrder[index].splice(itemIndex, 1, ...otherAttrs)
+        }
+      }
+    }
+
+    attributeOrder = contextAttributeOrder
   }
   const alphabetical = Boolean(
     context.options[0] && context.options[0].alphabetical
   )
-
-  for (const [index, item] of attributeOrder.entries()) {
-    if (Array.isArray(item) && item.includes(ATTRS.OTHER_ATTR)) {
-      const attributes = item.filter((i) => i !== ATTRS.OTHER_ATTR)
-      attributes.push(...otherAttrs)
-      attributeOrder[index] = attributes
-    } else if (item === ATTRS.OTHER_ATTR) {
-      attributeOrder[index] = otherAttrs
-    }
-  }
 
   /** @type { { [key: string]: number } } */
   const attributePosition = {}

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -230,6 +230,19 @@ function create(context) {
   if (context.options[0] && context.options[0].order) {
     attributeOrder = [...context.options[0].order]
 
+    // check if `OTHER_ATTR` is valid
+    for (const item of attributeOrder.flat()) {
+      if (item === ATTRS.OTHER_ATTR) {
+        for (const attribute of attributeOrder.flat()) {
+          if (otherAttrs.includes(attribute)) {
+            throw new Error(
+              `Value "${ATTRS.OTHER_ATTR}" is not allowed with "${attribute}".`
+            )
+          }
+        }
+      }
+    }
+
     // expand `OTHER_ATTR` alias
     for (const [index, item] of attributeOrder.entries()) {
       if (item === ATTRS.OTHER_ATTR) {

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -155,7 +155,7 @@ function getAttributeType(attribute) {
     case 'slot-scope':
       return ATTRS.SLOT
     default:
-      if (attribute.directive) {
+      if (isVBind(attribute)) {
         return ATTRS.OTHER_ATTR_DYNAMIC
       }
       return ATTRS.OTHER_ATTR_STATIC

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -22,6 +22,7 @@ const ATTRS = {
   OTHER_ATTR: 'OTHER_ATTR',
   ATTR_STATIC: 'ATTR_STATIC',
   ATTR_DYNAMIC: 'ATTR_DYNAMIC',
+  ATTR_SHORTHAND_BOOL: 'ATTR_SHORTHAND_BOOL',
   EVENTS: 'EVENTS',
   CONTENT: 'CONTENT'
 }
@@ -66,6 +67,15 @@ function isVAttributeOrVBindOrVModel(node) {
  */
 function isVBindObject(node) {
   return isVBind(node) && node.key.argument == null
+}
+
+/**
+ * Check whether the given attribute is `v-bind="..."` directive.
+ * @param {VAttribute | VDirective | undefined | null} node
+ * @returns { node is VAttribute }
+ */
+function isVShorthandBoolean(node) {
+  return isVAttribute(node) && !node.value
 }
 
 /**
@@ -157,6 +167,8 @@ function getAttributeType(attribute) {
     default:
       if (isVBind(attribute)) {
         return ATTRS.ATTR_DYNAMIC
+      } else if (isVShorthandBoolean(attribute)) {
+        return ATTRS.ATTR_SHORTHAND_BOOL
       }
       return ATTRS.ATTR_STATIC
   }
@@ -196,7 +208,11 @@ function isAlphabetical(prevNode, currNode, sourceCode) {
  */
 function create(context) {
   const sourceCode = context.getSourceCode()
-  const otherAttrs = [ATTRS.ATTR_DYNAMIC, ATTRS.ATTR_STATIC]
+  const otherAttrs = [
+    ATTRS.ATTR_DYNAMIC,
+    ATTRS.ATTR_STATIC,
+    ATTRS.ATTR_SHORTHAND_BOOL
+  ]
   let attributeOrder = [
     ATTRS.DEFINITION,
     ATTRS.LIST_RENDERING,
@@ -206,26 +222,26 @@ function create(context) {
     [ATTRS.UNIQUE, ATTRS.SLOT],
     ATTRS.TWO_WAY_BINDING,
     ATTRS.OTHER_DIRECTIVES,
-    [ATTRS.ATTR_DYNAMIC, ATTRS.ATTR_STATIC],
+    otherAttrs,
     ATTRS.EVENTS,
     ATTRS.CONTENT
   ]
   if (context.options[0] && context.options[0].order) {
-    const contextAttributeOrder = [...context.options[0].order]
+    attributeOrder = [...context.options[0].order]
 
     // expand `OTHER_ATTR` alias
-    for (const [index, item] of contextAttributeOrder.entries()) {
+    for (const [index, item] of attributeOrder.entries()) {
       if (item === ATTRS.OTHER_ATTR) {
-        contextAttributeOrder[index] = otherAttrs
+        attributeOrder[index] = otherAttrs
       } else if (Array.isArray(item)) {
         const itemIndex = item.indexOf(ATTRS.OTHER_ATTR)
         if (itemIndex > -1) {
-          contextAttributeOrder[index].splice(itemIndex, 1, ...otherAttrs)
+          const attributes = item.filter((i) => i !== ATTRS.OTHER_ATTR)
+          attributes.push(...otherAttrs)
+          attributeOrder[index] = attributes
         }
       }
     }
-
-    attributeOrder = contextAttributeOrder
   }
   const alphabetical = Boolean(
     context.options[0] && context.options[0].alphabetical

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -498,7 +498,7 @@ tester.run('attributes-order', rule, {
       </template>`,
       options: [
         {
-          order: ['OTHER_ATTR_DYNAMIC', 'OTHER_ATTR_STATIC'],
+          order: ['ATTR_DYNAMIC', 'ATTR_STATIC'],
           alphabetical: false
         }
       ]
@@ -518,7 +518,7 @@ tester.run('attributes-order', rule, {
       </template>`,
       options: [
         {
-          order: ['TWO_WAY_BINDING', 'OTHER_ATTR_DYNAMIC', 'OTHER_ATTR_STATIC'],
+          order: ['TWO_WAY_BINDING', 'ATTR_DYNAMIC', 'ATTR_STATIC'],
           alphabetical: false
         }
       ]
@@ -544,8 +544,8 @@ tester.run('attributes-order', rule, {
             ['UNIQUE', 'SLOT'],
             'TWO_WAY_BINDING',
             'OTHER_DIRECTIVES',
-            'OTHER_ATTR_STATIC',
-            'OTHER_ATTR_DYNAMIC',
+            'ATTR_STATIC',
+            'ATTR_DYNAMIC',
             'EVENTS',
             'CONTENT'
           ],
@@ -574,7 +574,7 @@ tester.run('attributes-order', rule, {
             ['UNIQUE', 'SLOT'],
             'TWO_WAY_BINDING',
             'OTHER_DIRECTIVES',
-            ['OTHER_ATTR_STATIC', 'OTHER_ATTR_DYNAMIC'],
+            ['ATTR_STATIC', 'ATTR_DYNAMIC'],
             'EVENTS',
             'CONTENT'
           ],
@@ -1637,7 +1637,7 @@ tester.run('attributes-order', rule, {
           prop-two="b"
           :prop-three="c"/>
       </template>`,
-      options: [{ order: ['OTHER_ATTR_STATIC', 'OTHER_ATTR_DYNAMIC'] }],
+      options: [{ order: ['ATTR_STATIC', 'ATTR_DYNAMIC'] }],
       output: `
       <template>
         <div
@@ -1667,8 +1667,8 @@ tester.run('attributes-order', rule, {
             'RENDER_MODIFIERS',
             'TWO_WAY_BINDING',
             'OTHER_DIRECTIVES',
-            'OTHER_ATTR_DYNAMIC',
-            'OTHER_ATTR_STATIC',
+            'ATTR_DYNAMIC',
+            'ATTR_STATIC',
             'EVENTS'
           ]
         }
@@ -1708,7 +1708,7 @@ tester.run('attributes-order', rule, {
             'GLOBAL',
             'TWO_WAY_BINDING',
             'OTHER_DIRECTIVES',
-            ['OTHER_ATTR_STATIC', 'OTHER_ATTR_DYNAMIC'],
+            ['ATTR_STATIC', 'ATTR_DYNAMIC'],
             'EVENTS',
             'CONTENT',
             'DEFINITION',

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -581,6 +581,40 @@ tester.run('attributes-order', rule, {
           alphabetical: false
         }
       ]
+    },
+
+    // https://github.com/vuejs/eslint-plugin-vue/issues/1870
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          boolean-prop
+          prop-one="a"
+          prop-two="b"
+          :prop-three="c">
+        </div>
+      </template>`,
+      options: [
+        {
+          order: [
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            ['UNIQUE', 'SLOT'],
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'ATTR_SHORTHAND_BOOL',
+            'ATTR_STATIC',
+            'ATTR_DYNAMIC',
+            'EVENTS',
+            'CONTENT'
+          ],
+          alphabetical: false
+        }
+      ]
     }
   ],
 
@@ -1657,7 +1691,8 @@ tester.run('attributes-order', rule, {
           v-model="value"
           prop-two="b"
           :prop-three="c"
-          class="class"/>
+          class="class"
+          boolean-prop/>
       </template>`,
       options: [
         {
@@ -1669,6 +1704,7 @@ tester.run('attributes-order', rule, {
             'OTHER_DIRECTIVES',
             'ATTR_DYNAMIC',
             'ATTR_STATIC',
+            'ATTR_SHORTHAND_BOOL',
             'EVENTS'
           ]
         }
@@ -1680,7 +1716,8 @@ tester.run('attributes-order', rule, {
           :prop-one="a"
           :prop-three="c"
           prop-two="b"
-          class="class"/>
+          class="class"
+          boolean-prop/>
       </template>`,
       errors: [
         'Attribute "v-model" should go before ":prop-one".',
@@ -1695,6 +1732,7 @@ tester.run('attributes-order', rule, {
         <div
           :prop-one="a"
           v-model="value"
+          boolean-prop
           prop-two="b"
           :prop-three="c"/>
       </template>`,
@@ -1708,7 +1746,7 @@ tester.run('attributes-order', rule, {
             'GLOBAL',
             'TWO_WAY_BINDING',
             'OTHER_DIRECTIVES',
-            ['ATTR_STATIC', 'ATTR_DYNAMIC'],
+            ['ATTR_STATIC', 'ATTR_DYNAMIC', 'ATTR_SHORTHAND_BOOL'],
             'EVENTS',
             'CONTENT',
             'DEFINITION',
@@ -1721,6 +1759,7 @@ tester.run('attributes-order', rule, {
         <div
           v-model="value"
           :prop-one="a"
+          boolean-prop
           prop-two="b"
           :prop-three="c"/>
       </template>`,

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -483,6 +483,104 @@ tester.run('attributes-order', rule, {
         </div>
       </template>`,
       options: [{ order: ['LIST_RENDERING', 'CONDITIONALS'] }]
+    },
+
+    // https://github.com/vuejs/eslint-plugin-vue/issues/1728
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          :prop-bind="prop"
+          prop-one="prop"
+          prop-two="prop">
+        </div>
+      </template>`,
+      options: [
+        {
+          order: ['OTHER_ATTR_DYNAMIC', 'OTHER_ATTR_STATIC'],
+          alphabetical: false
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          v-model="a
+          :class="b"
+          :is="c"
+          prop-one="d"
+          class="e"
+          prop-two="f">
+        </div>
+      </template>`,
+      options: [
+        {
+          order: ['TWO_WAY_BINDING', 'OTHER_ATTR_DYNAMIC', 'OTHER_ATTR_STATIC'],
+          alphabetical: false
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          prop-one="a"
+          prop-three="b"
+          :prop-two="c">
+        </div>
+      </template>`,
+      options: [
+        {
+          order: [
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            ['UNIQUE', 'SLOT'],
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR_STATIC',
+            'OTHER_ATTR_DYNAMIC',
+            'EVENTS',
+            'CONTENT'
+          ],
+          alphabetical: false
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          prop-one="a"
+          :prop-two="b"
+          prop-three="c">
+        </div>
+      </template>`,
+      options: [
+        {
+          order: [
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            ['UNIQUE', 'SLOT'],
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            ['OTHER_ATTR_STATIC', 'OTHER_ATTR_DYNAMIC'],
+            'EVENTS',
+            'CONTENT'
+          ],
+          alphabetical: false
+        }
+      ]
     }
   ],
 
@@ -1528,6 +1626,105 @@ tester.run('attributes-order', rule, {
           attr="foo"/>
       </template>`,
       errors: ['Attribute "@click" should go before "v-bind".']
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          v-bind:prop-one="a"
+          prop-two="b"
+          :prop-three="c"/>
+      </template>`,
+      options: [{ order: ['OTHER_ATTR_STATIC', 'OTHER_ATTR_DYNAMIC'] }],
+      output: `
+      <template>
+        <div
+          prop-two="b"
+          v-bind:prop-one="a"
+          :prop-three="c"/>
+      </template>`,
+      errors: ['Attribute "prop-two" should go before "v-bind:prop-one".']
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          :prop-one="a"
+          v-model="value"
+          prop-two="b"
+          :prop-three="c"
+          class="class"/>
+      </template>`,
+      options: [
+        {
+          order: [
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR_DYNAMIC',
+            'OTHER_ATTR_STATIC',
+            'EVENTS'
+          ]
+        }
+      ],
+      output: `
+      <template>
+        <div
+          v-model="value"
+          :prop-one="a"
+          :prop-three="c"
+          prop-two="b"
+          class="class"/>
+      </template>`,
+      errors: [
+        'Attribute "v-model" should go before ":prop-one".',
+        'Attribute ":prop-three" should go before "prop-two".'
+      ]
+    },
+
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div
+          :prop-one="a"
+          v-model="value"
+          prop-two="b"
+          :prop-three="c"/>
+      </template>`,
+      options: [
+        {
+          order: [
+            'UNIQUE',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            ['OTHER_ATTR_STATIC', 'OTHER_ATTR_DYNAMIC'],
+            'EVENTS',
+            'CONTENT',
+            'DEFINITION',
+            'SLOT'
+          ]
+        }
+      ],
+      output: `
+      <template>
+        <div
+          v-model="value"
+          :prop-one="a"
+          prop-two="b"
+          :prop-three="c"/>
+      </template>`,
+      errors: ['Attribute "v-model" should go before ":prop-one".']
     }
   ]
 })


### PR DESCRIPTION
This PR adds `[ 'ATTR_STATIC', 'ATTR_DYNAMIC', 'ATTR_SHORTHAND_BOOL' ] ` attribute to `vue/attributes-order`. And `OTHER_ATTR` become an alias for [ 'ATTR_STATIC', 'ATTR_DYNAMIC', 'ATTR_SHORTHAND_BOOL' ]

close https://github.com/vuejs/eslint-plugin-vue/issues/1728, close #1870 