### PR TITLE
fix: [vue/component-name-in-template-casing] False positive for dynamic component in template

### DIFF
--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -11,6 +11,30 @@ const { toRegExp } = require('../utils/regexp')
 const allowedCaseOptions = ['PascalCase', 'kebab-case']
 const defaultCase = 'PascalCase'
 
+/**
+ * Checks whether the given variable is the type-only import object.
+ * @param {Variable} variable
+ * @returns {boolean} `true` if the given variable is the type-only import.
+ */
+function isTypeOnlyImport(variable) {
+  if (variable.defs.length === 0) return false
+
+  return variable.defs.every((def) => {
+    if (def.type !== 'ImportBinding') {
+      return false
+    }
+    if (def.parent.importKind === 'type') {
+      // check for `import type Foo from './xxx'`
+      return true
+    }
+    if (def.node.type === 'ImportSpecifier' && def.node.importKind === 'type') {
+      // check for `import { type Foo } from './xxx'`
+      return true
+    }
+    return false
+  })
+}
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -75,10 +99,13 @@ module.exports = {
           (scope) => scope.type === 'module'
         )
         for (const variable of (moduleScope && moduleScope.variables) || []) {
-          registeredComponents.add(variable.name)
+          if (!isTypeOnlyImport(variable)) {
+            registeredComponents.add(variable.name)
+          }
         }
       }
     }
+
     /**
      * Checks whether the given node is the verification target node.
      * @param {VElement} node element node

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -93,7 +93,8 @@ module.exports = {
       if (
         (!utils.isHtmlElementNode(node) && !utils.isSvgElementNode(node)) ||
         utils.isHtmlWellKnownElementName(node.rawName) ||
-        utils.isSvgWellKnownElementName(node.rawName)
+        utils.isSvgWellKnownElementName(node.rawName) ||
+        utils.isBuiltInComponentName(node.rawName)
       ) {
         return false
       }

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -93,8 +93,7 @@ module.exports = {
       if (
         (!utils.isHtmlElementNode(node) && !utils.isSvgElementNode(node)) ||
         utils.isHtmlWellKnownElementName(node.rawName) ||
-        utils.isSvgWellKnownElementName(node.rawName) ||
-        utils.isBuiltInComponentName(node.rawName)
+        utils.isSvgWellKnownElementName(node.rawName)
       ) {
         return false
       }

--- a/lib/utils/vue2-builtin-components.js
+++ b/lib/utils/vue2-builtin-components.js
@@ -8,5 +8,7 @@ module.exports = [
   'transition-group',
   'TransitionGroup',
   'keep-alive',
-  'KeepAlive'
+  'KeepAlive',
+  'client-only',
+  'ClientOnly'
 ]

--- a/lib/utils/vue2-builtin-components.js
+++ b/lib/utils/vue2-builtin-components.js
@@ -8,7 +8,5 @@ module.exports = [
   'transition-group',
   'TransitionGroup',
   'keep-alive',
-  'KeepAlive',
-  'client-only',
-  'ClientOnly'
+  'KeepAlive'
 ]

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -159,8 +159,7 @@ tester.run('component-name-in-template-casing', rule, {
           <client-only />
           <keep-alive />
         </template>
-      `,
-      options: ['PascalCase', { registeredComponentsOnly: false }]
+      `
     },
 
     {
@@ -810,6 +809,35 @@ tester.run('component-name-in-template-casing', rule, {
         'Component name "Foo--Bar" is not kebab-case.',
         'Component name "FooBar" is not kebab-case.',
         'Component name "FooBar_Baz-qux" is not kebab-case.'
+      ]
+    },
+    {
+      // built-in components (behave the same way as other components)
+      code: `
+        <template>
+          <component />
+          <suspense />
+          <teleport />
+          <client-only />
+          <keep-alive />
+        </template>
+      `,
+      output: `
+        <template>
+          <Component />
+          <Suspense />
+          <Teleport />
+          <ClientOnly />
+          <KeepAlive />
+        </template>
+      `,
+      options: ['PascalCase', { registeredComponentsOnly: false }],
+      errors: [
+        'Component name "component" is not PascalCase.',
+        'Component name "suspense" is not PascalCase.',
+        'Component name "teleport" is not PascalCase.',
+        'Component name "client-only" is not PascalCase.',
+        'Component name "keep-alive" is not PascalCase.'
       ]
     },
     {

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -159,7 +159,8 @@ tester.run('component-name-in-template-casing', rule, {
           <client-only />
           <keep-alive />
         </template>
-      `
+      `,
+      options: ['PascalCase', { registeredComponentsOnly: false }]
     },
 
     {
@@ -809,35 +810,6 @@ tester.run('component-name-in-template-casing', rule, {
         'Component name "Foo--Bar" is not kebab-case.',
         'Component name "FooBar" is not kebab-case.',
         'Component name "FooBar_Baz-qux" is not kebab-case.'
-      ]
-    },
-    {
-      // built-in components (behave the same way as other components)
-      code: `
-        <template>
-          <component />
-          <suspense />
-          <teleport />
-          <client-only />
-          <keep-alive />
-        </template>
-      `,
-      output: `
-        <template>
-          <Component />
-          <Suspense />
-          <Teleport />
-          <ClientOnly />
-          <KeepAlive />
-        </template>
-      `,
-      options: ['PascalCase', { registeredComponentsOnly: false }],
-      errors: [
-        'Component name "component" is not PascalCase.',
-        'Component name "suspense" is not PascalCase.',
-        'Component name "teleport" is not PascalCase.',
-        'Component name "client-only" is not PascalCase.',
-        'Component name "keep-alive" is not PascalCase.'
       ]
     },
     {

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -193,6 +193,35 @@ tester.run('component-name-in-template-casing', rule, {
         </template>
       `,
       options: ['kebab-case', { globals: ['RouterView', 'router-link'] }]
+    },
+
+    // type-only imports
+    {
+      code: `
+        <script setup lang="ts">
+          import type Foo from './Foo.vue'
+          import type { HelloWorld1 } from './components/HelloWorld'
+          import { type HelloWorld2 } from './components/HelloWorld2'
+          import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
+          import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
+          import { type default as HelloWorld5 } from './components/HelloWorld5';
+          import { type Component } from 'vue';
+        </script>
+
+        <template>
+          <foo />
+          <hello-world1 />
+          <hello-world2 />
+          <hello-world3 />
+          <hello-world4 />
+          <hello-world5 />
+          <component />
+        </template>
+      `,
+      options: ['PascalCase', { registeredComponentsOnly: true }],
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     }
   ],
   invalid: [
@@ -936,6 +965,92 @@ tester.run('component-name-in-template-casing', rule, {
         {
           message: 'Component name "RouterView" is not kebab-case.',
           line: 3,
+          column: 11
+        }
+      ]
+    },
+    // type-only imports
+    {
+      code: `
+        <script setup lang="ts">
+          import type Foo from './Foo.vue'
+          import type { HelloWorld1 } from './components/HelloWorld'
+          import { type HelloWorld2 } from './components/HelloWorld2'
+          import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
+          import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
+          import { type default as HelloWorld5 } from './components/HelloWorld5';
+          import { type Component } from 'vue';
+        </script>
+
+        <template>
+          <foo />
+          <hello-world1 />
+          <hello-world2 />
+          <hello-world3 />
+          <hello-world4 />
+          <hello-world5 />
+          <component />
+        </template>
+      `,
+      options: ['PascalCase', { registeredComponentsOnly: false }],
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      },
+      output: `
+        <script setup lang="ts">
+          import type Foo from './Foo.vue'
+          import type { HelloWorld1 } from './components/HelloWorld'
+          import { type HelloWorld2 } from './components/HelloWorld2'
+          import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
+          import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
+          import { type default as HelloWorld5 } from './components/HelloWorld5';
+          import { type Component } from 'vue';
+        </script>
+
+        <template>
+          <Foo />
+          <HelloWorld1 />
+          <HelloWorld2 />
+          <HelloWorld3 />
+          <HelloWorld4 />
+          <HelloWorld5 />
+          <Component />
+        </template>
+      `,
+      errors: [
+        {
+          message: 'Component name "foo" is not PascalCase.',
+          line: 13,
+          column: 11
+        },
+        {
+          message: 'Component name "hello-world1" is not PascalCase.',
+          line: 14,
+          column: 11
+        },
+        {
+          message: 'Component name "hello-world2" is not PascalCase.',
+          line: 15,
+          column: 11
+        },
+        {
+          message: 'Component name "hello-world3" is not PascalCase.',
+          line: 16,
+          column: 11
+        },
+        {
+          message: 'Component name "hello-world4" is not PascalCase.',
+          line: 17,
+          column: 11
+        },
+        {
+          message: 'Component name "hello-world5" is not PascalCase.',
+          line: 18,
+          column: 11
+        },
+        {
+          message: 'Component name "component" is not PascalCase.',
+          line: 19,
           column: 11
         }
       ]

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -4,6 +4,7 @@
 'use strict'
 
 const rule = require('../../../lib/rules/component-name-in-template-casing')
+const semver = require('semver')
 const RuleTester = require('eslint').RuleTester
 
 const tester = new RuleTester({
@@ -196,33 +197,40 @@ tester.run('component-name-in-template-casing', rule, {
     },
 
     // type-only imports
-    {
-      code: `
-        <script setup lang="ts">
-          import type Foo from './Foo.vue'
-          import type { HelloWorld1 } from './components/HelloWorld'
-          import { type HelloWorld2 } from './components/HelloWorld2'
-          import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
-          import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
-          import { type default as HelloWorld5 } from './components/HelloWorld5';
-          import { type Component } from 'vue';
-        </script>
+    ...(semver.gte(
+      require('@typescript-eslint/parser/package.json').version,
+      '5.0.0'
+    )
+      ? [
+          {
+            code: `
+              <script setup lang="ts">
+                import type Foo from './Foo.vue'
+                import type { HelloWorld1 } from './components/HelloWorld'
+                import { type HelloWorld2 } from './components/HelloWorld2'
+                import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
+                import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
+                import { type default as HelloWorld5 } from './components/HelloWorld5';
+                import { type Component } from 'vue';
+              </script>
 
-        <template>
-          <foo />
-          <hello-world1 />
-          <hello-world2 />
-          <hello-world3 />
-          <hello-world4 />
-          <hello-world5 />
-          <component />
-        </template>
-      `,
-      options: ['PascalCase', { registeredComponentsOnly: true }],
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      }
-    }
+              <template>
+                <foo />
+                <hello-world1 />
+                <hello-world2 />
+                <hello-world3 />
+                <hello-world4 />
+                <hello-world5 />
+                <component />
+              </template>
+            `,
+            options: ['PascalCase', { registeredComponentsOnly: true }],
+            parserOptions: {
+              parser: require.resolve('@typescript-eslint/parser')
+            }
+          }
+        ]
+      : [])
   ],
   invalid: [
     {
@@ -970,90 +978,97 @@ tester.run('component-name-in-template-casing', rule, {
       ]
     },
     // type-only imports
-    {
-      code: `
-        <script setup lang="ts">
-          import type Foo from './Foo.vue'
-          import type { HelloWorld1 } from './components/HelloWorld'
-          import { type HelloWorld2 } from './components/HelloWorld2'
-          import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
-          import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
-          import { type default as HelloWorld5 } from './components/HelloWorld5';
-          import { type Component } from 'vue';
-        </script>
+    ...(semver.gte(
+      require('@typescript-eslint/parser/package.json').version,
+      '5.0.0'
+    )
+      ? [
+          {
+            code: `
+              <script setup lang="ts">
+                import type Foo from './Foo.vue'
+                import type { HelloWorld1 } from './components/HelloWorld'
+                import { type HelloWorld2 } from './components/HelloWorld2'
+                import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
+                import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
+                import { type default as HelloWorld5 } from './components/HelloWorld5';
+                import { type Component } from 'vue';
+              </script>
 
-        <template>
-          <foo />
-          <hello-world1 />
-          <hello-world2 />
-          <hello-world3 />
-          <hello-world4 />
-          <hello-world5 />
-          <component />
-        </template>
-      `,
-      options: ['PascalCase', { registeredComponentsOnly: false }],
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      },
-      output: `
-        <script setup lang="ts">
-          import type Foo from './Foo.vue'
-          import type { HelloWorld1 } from './components/HelloWorld'
-          import { type HelloWorld2 } from './components/HelloWorld2'
-          import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
-          import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
-          import { type default as HelloWorld5 } from './components/HelloWorld5';
-          import { type Component } from 'vue';
-        </script>
+              <template>
+                <foo />
+                <hello-world1 />
+                <hello-world2 />
+                <hello-world3 />
+                <hello-world4 />
+                <hello-world5 />
+                <component />
+              </template>
+            `,
+            options: ['PascalCase', { registeredComponentsOnly: false }],
+            parserOptions: {
+              parser: require.resolve('@typescript-eslint/parser')
+            },
+            output: `
+              <script setup lang="ts">
+                import type Foo from './Foo.vue'
+                import type { HelloWorld1 } from './components/HelloWorld'
+                import { type HelloWorld2 } from './components/HelloWorld2'
+                import type { HelloWorld as HelloWorld3 } from './components/HelloWorld3'
+                import { type HelloWorld as HelloWorld4 } from './components/HelloWorld4';
+                import { type default as HelloWorld5 } from './components/HelloWorld5';
+                import { type Component } from 'vue';
+              </script>
 
-        <template>
-          <Foo />
-          <HelloWorld1 />
-          <HelloWorld2 />
-          <HelloWorld3 />
-          <HelloWorld4 />
-          <HelloWorld5 />
-          <Component />
-        </template>
-      `,
-      errors: [
-        {
-          message: 'Component name "foo" is not PascalCase.',
-          line: 13,
-          column: 11
-        },
-        {
-          message: 'Component name "hello-world1" is not PascalCase.',
-          line: 14,
-          column: 11
-        },
-        {
-          message: 'Component name "hello-world2" is not PascalCase.',
-          line: 15,
-          column: 11
-        },
-        {
-          message: 'Component name "hello-world3" is not PascalCase.',
-          line: 16,
-          column: 11
-        },
-        {
-          message: 'Component name "hello-world4" is not PascalCase.',
-          line: 17,
-          column: 11
-        },
-        {
-          message: 'Component name "hello-world5" is not PascalCase.',
-          line: 18,
-          column: 11
-        },
-        {
-          message: 'Component name "component" is not PascalCase.',
-          line: 19,
-          column: 11
-        }
-      ]
-    }
+              <template>
+                <Foo />
+                <HelloWorld1 />
+                <HelloWorld2 />
+                <HelloWorld3 />
+                <HelloWorld4 />
+                <HelloWorld5 />
+                <Component />
+              </template>
+            `,
+            errors: [
+              {
+                message: 'Component name "foo" is not PascalCase.',
+                line: 13,
+                column: 17
+              },
+              {
+                message: 'Component name "hello-world1" is not PascalCase.',
+                line: 14,
+                column: 17
+              },
+              {
+                message: 'Component name "hello-world2" is not PascalCase.',
+                line: 15,
+                column: 17
+              },
+              {
+                message: 'Component name "hello-world3" is not PascalCase.',
+                line: 16,
+                column: 17
+              },
+              {
+                message: 'Component name "hello-world4" is not PascalCase.',
+                line: 17,
+                column: 17
+              },
+              {
+                message: 'Component name "hello-world5" is not PascalCase.',
+                line: 18,
+                column: 17
+              },
+              {
+                message: 'Component name "component" is not PascalCase.',
+                line: 19,
+                column: 17
+              }
+            ]
+          }
+        ]
+      : [])
   ]
 })


### PR DESCRIPTION
Modified at Jan. 07.


## Issue
This pull request is a fix for issue #2048.

## How to fixed
Linter check is ignored if type-only import and registeredComponentsOnly=true.
The logic to check whether type-only import or not is the same as for [no-undef-components](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-undef-components.js#L127-L145).


