### PR TITLE
fix (vue/component-api-style): add spacing around comma in report message

### DIFF
--- a/lib/rules/component-api-style.js
+++ b/lib/rules/component-api-style.js
@@ -162,7 +162,7 @@ function buildAllowedPhrase(allowsOpt) {
     phrases.push('Options API')
   }
   return phrases.length > 2
-    ? `${phrases.slice(0, -1).join(',')} or ${phrases.slice(-1)[0]}`
+    ? `${phrases.slice(0, -1).join(', ')} or ${phrases.slice(-1)[0]}`
     : phrases.join(' or ')
 }
 

--- a/tests/lib/rules/component-api-style.js
+++ b/tests/lib/rules/component-api-style.js
@@ -817,6 +817,31 @@ tester.run('component-api-style', rule, {
           column: 9
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        data () {
+          return {
+            msg: 'Hello World!',
+            // ...
+          }
+        },
+        // ...
+      }
+      </script>
+      `,
+      options: [['script-setup', 'composition', 'composition-vue2']],
+      errors: [
+        {
+          message:
+            'Options API is not allowed in your project. `data` option is part of the Options API. Use `<script setup>`, Composition API or Composition API (Vue 2) instead.',
+          line: 4,
+          column: 9
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
in the component-api-style rule, the output used to join by `,` which would lead to something like: `you should use a,b or c`.

this simply adds a space such that it becomes `a, b or c`.

i also added a test to hit this branch of code since there wasn't already one.