### PR TITLE
fix (vue/define-macros-order): hoist secondary expressions correctly

### DIFF
--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -137,7 +137,7 @@ function create(context) {
 
           // need move only second
           if (secondStatement !== shouldSecondNode) {
-            reportNotOnTop(order[1], shouldSecondNode, shouldFirstNode)
+            reportNotOnTop(order[1], shouldSecondNode, secondStatement)
           }
 
           return

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -128,6 +128,26 @@ tester.run('define-macros-order', rule, {
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          'use strict';
+          defineProps({
+            test: Boolean
+          })
+          defineEmits(['update:test'])
+        </script>
+      `,
+      options: optionsPropsFirst
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+        </script>
+      `
     }
   ],
   invalid: [
@@ -452,6 +472,52 @@ tester.run('define-macros-order', rule, {
         {
           message: message('defineProps'),
           line: 2
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          console.log('test1')
+          defineProps({ test: Boolean })
+        </script>
+      `,
+      output: `
+        <script setup>
+          defineProps({ test: Boolean })
+          console.log('test1')
+        </script>
+      `,
+      options: optionsEmitsFirst,
+      errors: [
+        {
+          message: message('defineProps'),
+          line: 4
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          defineEmits(['update:test'])
+          console.log('test1')
+          defineProps({ test: Boolean })
+        </script>
+      `,
+      output: `
+        <script setup>
+          defineEmits(['update:test'])
+          defineProps({ test: Boolean })
+          console.log('test1')
+        </script>
+      `,
+      options: optionsEmitsFirst,
+      errors: [
+        {
+          message: message('defineProps'),
+          line: 5
         }
       ]
     }


### PR DESCRIPTION
as per #2067 

```ts
      code: `
        <script setup>
          defineEmits(['update:test'])
          console.log('test1')
          defineProps({ test: Boolean })
        </script>
      `,
      output: `
        <script setup>
          defineEmits(['update:test'])
          defineProps({ test: Boolean })
          console.log('test1')
        </script>
      `,
      options: optionsEmitsFirst,
```

the output ends up as:

```html
        <script setup>
          defineProps({ test: Boolean })
          defineEmits(['update:test'])
          console.log('test1')
        </script>
```

which contradicts the options passed (emits _then_ props).

this PR fixes that and adds tests for some gaps we had.