### PR TITLE
Chore: Fix order-in-components rule doc page demo not working

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@
 /docs/.vitepress/build-system/shim/eslint.mjs
 /docs/.vitepress/build-system/shim/assert.mjs
 /docs/.vitepress/.temp
+/docs/.vitepress/cache

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ yarn-error.log
 /docs/.vitepress/build-system/shim/eslint.mjs
 /docs/.vitepress/build-system/shim/assert.mjs
 /docs/.vitepress/.temp
+/docs/.vitepress/cache
 typings/eslint/lib/rules

--- a/docs/.vitepress/vite-plugin.ts
+++ b/docs/.vitepress/vite-plugin.ts
@@ -50,8 +50,6 @@ export function viteCommonjs(): Plugin {
 
 /**
  * Transform `require()` to `import`
- * Inspired by `@originjs/vite-plugin-commonjs`.
- * https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-commonjs
  */
 function transformRequire(code: string) {
   if (!code.includes('require')) {
@@ -66,9 +64,11 @@ function transformRequire(code: string) {
       }
 
       let id =
-        '__' + moduleString.replace(/[^a-zA-Z0-9_$]+/gu, '_') + randomString()
+        '__' +
+        moduleString.replace(/[^a-zA-Z0-9_$]+/gu, '_') +
+        Math.random().toString(32).substring(2)
       while (code.includes(id) || modules.has(id)) {
-        id += randomString()
+        id += Math.random().toString(32).substring(2)
       }
       modules.set(id, moduleString)
       return id
@@ -86,13 +86,4 @@ const ${id} = __temp_${id}.default || __temp_${id};
     ';\n' +
     replaced
   )
-}
-
-function randomString() {
-  const code = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
-  let result = ''
-  for (let index = 0; index < 6; index++) {
-    result += code[Math.floor(Math.random() * code.length)]
-  }
-  return result
 }

--- a/docs/.vitepress/vite-plugin.ts
+++ b/docs/.vitepress/vite-plugin.ts
@@ -1,7 +1,7 @@
 import type { UserConfig } from 'vitepress'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { viteCommonjs as baseViteCommonjs } from '@originjs/vite-plugin-commonjs'
+import esbuild from 'esbuild'
 type Plugin = Extract<
   NonNullable<NonNullable<UserConfig['vite']>['plugins']>[number],
   { name: string }
@@ -27,27 +27,72 @@ export function vitePluginRequireResolve(): Plugin {
 }
 
 export function viteCommonjs(): Plugin {
-  const base = baseViteCommonjs({
-    include: [libRoot],
-    skipPreBuild: true
-  }) as Plugin
   return {
-    ...base,
-    // The `@originjs/vite-plugin-commonjs` is 'serve' only, but use it in 'build' as well.
+    name: 'vite-plugin-cjs-to-esm',
     apply: () => true,
-    async transform(code, id, options) {
-      if (typeof base.transform !== 'function') {
-        return null
+    async transform(code, id) {
+      if (!id.startsWith(libRoot)) {
+        return undefined
       }
-      const result = await base.transform.call(this, code, id, options)
-      if (result && typeof result === 'object' && result.code) {
-        return {
-          ...result,
-          // Replace it with null, because blanks can be given to the sourcemap and cause an error.
-          map: undefined
-        }
+      const base = transformRequire(code)
+      try {
+        const transformed = esbuild.transformSync(base, {
+          format: 'esm'
+        })
+        return transformed.code
+      } catch (e) {
+        console.error('Transform error. base code:\n' + base, e)
       }
-      return result
+      return undefined
     }
   }
+}
+
+/**
+ * Transform `require()` to `import`
+ * Inspired by `@originjs/vite-plugin-commonjs`.
+ * https://github.com/originjs/vite-plugins/tree/main/packages/vite-plugin-commonjs
+ */
+function transformRequire(code: string) {
+  if (!code.includes('require')) {
+    return code
+  }
+  const modules = new Map()
+  const replaced = code.replace(
+    /(\/\/[^\n\r]*|\/\*[\s\S]*?\*\/)|\brequire\s*\(\s*(["'].*?["'])\s*\)/gu,
+    (match, comment, moduleString) => {
+      if (comment) {
+        return match
+      }
+
+      let id =
+        '__' + moduleString.replace(/[^a-zA-Z0-9_$]+/gu, '_') + randomString()
+      while (code.includes(id) || modules.has(id)) {
+        id += randomString()
+      }
+      modules.set(id, moduleString)
+      return id
+    }
+  )
+
+  return (
+    [...modules]
+      .map(([id, moduleString]) => {
+        return `import * as __temp_${id} from ${moduleString};
+const ${id} = __temp_${id}.default || __temp_${id};
+`
+      })
+      .join('') +
+    ';\n' +
+    replaced
+  )
+}
+
+function randomString() {
+  const code = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
+  let result = ''
+  for (let index = 0; index < 6; index++) {
+    result += code[Math.floor(Math.random() * code.length)]
+  }
+  return result
 }

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -5,7 +5,8 @@
 'use strict'
 
 const utils = require('../utils')
-const traverseNodes = require('vue-eslint-parser').AST.traverseNodes
+const vueESLintParser = require('vue-eslint-parser')
+const traverseNodes = vueESLintParser.AST.traverseNodes
 
 /**
  * @typedef {import('eslint-visitor-keys').VisitorKeys} VisitorKeys

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -5,8 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
-const vueESLintParser = require('vue-eslint-parser')
-const traverseNodes = vueESLintParser.AST.traverseNodes
+const traverseNodes = require('vue-eslint-parser').AST.traverseNodes
 
 /**
  * @typedef {import('eslint-visitor-keys').VisitorKeys} VisitorKeys

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "xml-name-validator": "^4.0.0"
   },
   "devDependencies": {
-    "@originjs/vite-plugin-commonjs": "^1.0.3",
     "@ota-meshi/site-kit-eslint-editor-vue": "^0.1.0",
     "@types/eslint": "^8.4.2",
     "@types/eslint-visitor-keys": "^1.0.0",


### PR DESCRIPTION
I noticed that the demo on the order-in-components rule documentation page is not working.
https://eslint.vuejs.org/rules/order-in-components.html

<img width="729" alt="image" src="https://user-images.githubusercontent.com/16508807/212269741-342a0203-c859-48ce-af15-00906d0df85b.png">

This PR modifies the source code to make it work in the demo.


The cause seems to be that the conversion by [`@originjs/vite-plugin-commonjs`](https://www.npmjs.com/package/@originjs/vite-plugin-commonjs) does not work.

This PR will fix the problem by changing this repository to do the same logic as `@originjs/vite-plugin-commonjs`.
