### PR TITLE
Link to Vue 3 migration guide in docs

### DIFF
--- a/docs/rules/no-deprecated-destroyed-lifecycle.md
+++ b/docs/rules/no-deprecated-destroyed-lifecycle.md
@@ -40,6 +40,10 @@ export default {
 
 Nothing.
 
+## :books: Further Reading
+
+- [Migration Guide - VNode Lifecycle Events](https://v3-migration.vuejs.org/breaking-changes/vnode-lifecycle-events.html#migration-strategy)
+
 ## :rocket: Version
 
 This rule was introduced in eslint-plugin-vue v7.0.0

--- a/docs/rules/no-deprecated-dollar-listeners-api.md
+++ b/docs/rules/no-deprecated-dollar-listeners-api.md
@@ -46,7 +46,7 @@ Nothing.
 ## :books: Further Reading
 
 - [Vue RFCs - 0031-attr-fallthrough](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md)
-- [Migration Guide - $listeners removed](https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html)
+- [Migration Guide - `$listeners` removed](https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-dollar-listeners-api.md
+++ b/docs/rules/no-deprecated-dollar-listeners-api.md
@@ -46,6 +46,7 @@ Nothing.
 ## :books: Further Reading
 
 - [Vue RFCs - 0031-attr-fallthrough](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md)
+- [Migration Guide - $listeners removed](https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-v-on-native-modifier.md
+++ b/docs/rules/no-deprecated-v-on-native-modifier.md
@@ -44,7 +44,7 @@ Nothing.
 ## :books: Further Reading
 
 - [Vue RFCs - 0031-attr-fallthrough](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md)
-- [Migration Guide - v-on.native modifier removed](https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html)
+- [Migration Guide - `v-on.native` modifier removed](https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-v-on-native-modifier.md
+++ b/docs/rules/no-deprecated-v-on-native-modifier.md
@@ -44,6 +44,7 @@ Nothing.
 ## :books: Further Reading
 
 - [Vue RFCs - 0031-attr-fallthrough](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md)
+- [Migration Guide - v-on.native modifier removed](https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html)
 
 ## :rocket: Version
 


### PR DESCRIPTION
Added a migration guide in further reading.

Vue 3 Migration Guide - v-on.native modifier removed
https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html

Vue 3 Migration Guide - VNode Lifecycle Events
https://v3-migration.vuejs.org/breaking-changes/vnode-lifecycle-events.html#migration-strategy

Vue 3 Migration Guide - $listeners removed
https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html

