### PR TITLE
Add option to show warnings when props could be accessed via this

### DIFF
--- a/docs/rules/no-unused-properties.md
+++ b/docs/rules/no-unused-properties.md
@@ -14,7 +14,7 @@ since: v7.0.0
 This rule is aimed at eliminating unused properties.
 
 ::: warning Note
-This rule cannot be checked for use in other components (e.g. `mixins`, Property access via `$refs`) and use in places where the scope cannot be determined.
+This rule cannot check for use of properties by other components (e.g. `mixins`, property access via `$refs`) and use in places where the scope cannot be determined. Some access to properties might be implied, for example accessing data or computed via a variable such as `this[varName]`. In this case, the default is to assume all properties, methods, etc. are 'used'. See the `unreferencedOptions` for a more strict interpretation of 'use' in these cases.
 :::
 
 <eslint-code-block :rules="{'vue/no-unused-properties': ['error']}">
@@ -56,7 +56,8 @@ This rule cannot be checked for use in other components (e.g. `mixins`, Property
   "vue/no-unused-properties": ["error", {
     "groups": ["props"],
     "deepData": false,
-    "ignorePublicMembers": false
+    "ignorePublicMembers": false,
+    "unreferencedOptions": []
   }]
 }
 ```
@@ -69,6 +70,7 @@ This rule cannot be checked for use in other components (e.g. `mixins`, Property
   - `"setup"`
 - `deepData` (`boolean`) If `true`, the object of the property defined in `data` will be searched deeply. Default is `false`. Include `"data"` in `groups` to use this option.
 - `ignorePublicMembers` (`boolean`) If `true`, members marked with a [JSDoc `/** @public */` tag](https://jsdoc.app/tags-public.html) will be ignored. Default is `false`.
+- `unreferencedOptions` (`string[]`) Array of access methods that should be interpreted as leaving properties unreferenced. Currently, two such methods are available: `unknownMemberAsUnreferenced`, and `returnAsUnreferenced`. See examples below.
 
 ### `"groups": ["props", "data"]`
 
@@ -211,6 +213,71 @@ This rule cannot be checked for use in other components (e.g. `mixins`, Property
       
       /* ✗ BAD */
       unusedMethod() {}
+    }
+  }
+</script>
+```
+
+</eslint-code-block>
+
+### `{ "groups": ["computed"], "unreferencedOptions": ["unknownMemberAsUnreferenced"] }`
+
+<eslint-code-block :rules="{'vue/no-unused-properties': ['error', {groups: ['computed'], unreferencedOptions: ['unknownMemberAsUnreferenced']}]}">
+
+```vue
+<template>
+  
+</template>
+<script>
+  export default {
+    computed: {
+      one () {
+        return 1
+      },
+      two () {
+        return 2
+      }
+    },
+    methods: {
+      handler () {
+        /* ✓ GOOD - explicit access to computed */
+        const a = this.one
+        const i = 'two'
+        /* ✗ BAD - unknown access via a variable, two will be reported as unreferenced */
+        return this[i]
+      },
+    }
+  }
+</script>
+```
+
+</eslint-code-block>
+
+### `{ "groups": ["computed"], "unreferencedOptions": ["returnAsUnreferenced"] }`
+
+<eslint-code-block :rules="{'vue/no-unused-properties': ['error', {groups: ['computed'], unreferencedOptions: ['returnAsUnreferenced']}]}">
+
+```vue
+<template>
+  
+</template>
+<script>
+  export default {
+    computed: {
+      one () {
+        return 1
+      },
+      two () {
+        return 2
+      }
+    },
+    methods: {
+      handler () {
+        /* ✓ GOOD - explicit access to computed */
+        const a = this.one
+        /* ✗ BAD - any property could be accessed by returning `this`, but two will still be reported as unreferenced */
+        return this
+      },
     }
   }
 </script>

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -55,7 +55,8 @@ const GROUP_SETUP = 'setup'
 const GROUP_WATCHER = 'watch'
 const GROUP_EXPOSE = 'expose'
 
-const STOPREPORTING_THIS = 'ThisExpression'
+const STOPREPORTING_UNKNOWN = 'unknownPropertyAccess'
+const STOPREPORTING_RETURN = 'returnInstance'
 
 const PROPERTY_LABEL = {
   props: 'property',
@@ -212,7 +213,10 @@ module.exports = {
           stopReporting: {
             type: 'array',
             items: {
-              enum: [ STOPREPORTING_THIS ]
+              enum: [
+                STOPREPORTING_UNKNOWN,
+                STOPREPORTING_RETURN
+              ]
             },
             additionalItems: false,
             uniqueItems: true
@@ -231,7 +235,7 @@ module.exports = {
     const groups = new Set(options.groups || [GROUP_PROPERTY])
     const deepData = Boolean(options.deepData)
     const ignorePublicMembers = Boolean(options.ignorePublicMembers)
-    const stopReporting = new Set(options.stopReporting || [STOPREPORTING_THIS])
+    const stopReporting = new Set(options.stopReporting || [STOPREPORTING_UNKNOWN, STOPREPORTING_RETURN])
 
     const propertyReferenceExtractor = definePropertyReferenceExtractor(context)
 
@@ -571,9 +575,18 @@ module.exports = {
           if (!utils.isThis(node, context)) {
             return
           }
-          if (!stopReporting.has(STOPREPORTING_THIS)) {
+
+          // e.g. return this
+          if (node.parent.type === 'ReturnStatement' &&
+            !stopReporting.has(STOPREPORTING_RETURN)) {
             return
-          }
+          } 
+          // e.g. this[unknown]
+          if (node.parent.computed &&
+            !stopReporting.has(STOPREPORTING_UNKNOWN)) {
+            return
+          } 
+
           const container = getVueComponentPropertiesContainer(vueData.node)
           const propertyReferences =
             propertyReferenceExtractor.extractFromExpression(node, false)

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -55,8 +55,8 @@ const GROUP_SETUP = 'setup'
 const GROUP_WATCHER = 'watch'
 const GROUP_EXPOSE = 'expose'
 
-const STOPREPORTING_UNKNOWN = 'unknownPropertyAccess'
-const STOPREPORTING_RETURN = 'returnInstance'
+const REPORT_DYNAMIC_THIS = 'reportDynamicThis'
+const REPORT_RETURNED_THIS = 'reportReturnedThis'
 
 const PROPERTY_LABEL = {
   props: 'property',
@@ -210,10 +210,10 @@ module.exports = {
           },
           deepData: { type: 'boolean' },
           ignorePublicMembers: { type: 'boolean' },
-          stopReporting: {
+          reportingOptions: {
             type: 'array',
             items: {
-              enum: [STOPREPORTING_UNKNOWN, STOPREPORTING_RETURN]
+              enum: [REPORT_DYNAMIC_THIS, REPORT_RETURNED_THIS]
             },
             additionalItems: false,
             uniqueItems: true
@@ -232,19 +232,15 @@ module.exports = {
     const groups = new Set(options.groups || [GROUP_PROPERTY])
     const deepData = Boolean(options.deepData)
     const ignorePublicMembers = Boolean(options.ignorePublicMembers)
-    const stopReporting = new Set(
-      options.stopReporting || [STOPREPORTING_UNKNOWN, STOPREPORTING_RETURN]
-    )
-    const stopReportingUnknown = Boolean(
-      stopReporting.has(STOPREPORTING_UNKNOWN)
-    )
-    const stopReportingReturn = Boolean(stopReporting.has(STOPREPORTING_RETURN))
+    const reportingOptions = new Set(options.reportingOptions || [])
+    const reportDynamicThis = Boolean(reportingOptions.has(REPORT_DYNAMIC_THIS))
+    const reportReturnedThis = Boolean(reportingOptions.has(REPORT_RETURNED_THIS))
 
     const propertyReferenceExtractor = definePropertyReferenceExtractor(
       context,
       {
-        stopReportingUnknown,
-        stopReportingReturn
+        reportDynamicThis,
+        reportReturnedThis
       }
     )
 

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -55,8 +55,8 @@ const GROUP_SETUP = 'setup'
 const GROUP_WATCHER = 'watch'
 const GROUP_EXPOSE = 'expose'
 
-const REPORT_DYNAMIC_THIS = 'reportDynamicThis'
-const REPORT_RETURNED_THIS = 'reportReturnedThis'
+const UNREFERENCED_UNKNOWN_MEMBER = 'unknownMemberAsUnreferenced'
+const UNREFERENCED_RETURN = 'returnAsUnreferenced'
 
 const PROPERTY_LABEL = {
   props: 'property',
@@ -210,10 +210,10 @@ module.exports = {
           },
           deepData: { type: 'boolean' },
           ignorePublicMembers: { type: 'boolean' },
-          reportingOptions: {
+          unreferencedOptions: {
             type: 'array',
             items: {
-              enum: [REPORT_DYNAMIC_THIS, REPORT_RETURNED_THIS]
+              enum: [UNREFERENCED_UNKNOWN_MEMBER, UNREFERENCED_RETURN]
             },
             additionalItems: false,
             uniqueItems: true
@@ -232,15 +232,17 @@ module.exports = {
     const groups = new Set(options.groups || [GROUP_PROPERTY])
     const deepData = Boolean(options.deepData)
     const ignorePublicMembers = Boolean(options.ignorePublicMembers)
-    const reportingOptions = new Set(options.reportingOptions || [])
-    const reportDynamicThis = Boolean(reportingOptions.has(REPORT_DYNAMIC_THIS))
-    const reportReturnedThis = Boolean(reportingOptions.has(REPORT_RETURNED_THIS))
+    const unreferencedOptions = new Set(options.unreferencedOptions || [])
 
     const propertyReferenceExtractor = definePropertyReferenceExtractor(
       context,
       {
-        reportDynamicThis,
-        reportReturnedThis
+        unknownMemberAsUnreferenced: Boolean(
+          unreferencedOptions.has(UNREFERENCED_UNKNOWN_MEMBER)
+        ),
+        returnAsUnreferenced: Boolean(
+          unreferencedOptions.has(UNREFERENCED_RETURN)
+        )
       }
     )
 

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -213,10 +213,7 @@ module.exports = {
           stopReporting: {
             type: 'array',
             items: {
-              enum: [
-                STOPREPORTING_UNKNOWN,
-                STOPREPORTING_RETURN
-              ]
+              enum: [STOPREPORTING_UNKNOWN, STOPREPORTING_RETURN]
             },
             additionalItems: false,
             uniqueItems: true
@@ -235,7 +232,9 @@ module.exports = {
     const groups = new Set(options.groups || [GROUP_PROPERTY])
     const deepData = Boolean(options.deepData)
     const ignorePublicMembers = Boolean(options.ignorePublicMembers)
-    const stopReporting = new Set(options.stopReporting || [STOPREPORTING_UNKNOWN, STOPREPORTING_RETURN])
+    const stopReporting = new Set(
+      options.stopReporting || [STOPREPORTING_UNKNOWN, STOPREPORTING_RETURN]
+    )
 
     const propertyReferenceExtractor = definePropertyReferenceExtractor(context)
 
@@ -577,15 +576,19 @@ module.exports = {
           }
 
           // e.g. return this
-          if (node.parent.type === 'ReturnStatement' &&
-            !stopReporting.has(STOPREPORTING_RETURN)) {
+          if (
+            node.parent.type === 'ReturnStatement' &&
+            !stopReporting.has(STOPREPORTING_RETURN)
+          ) {
             return
-          } 
+          }
           // e.g. this[unknown]
-          if (node.parent.computed &&
-            !stopReporting.has(STOPREPORTING_UNKNOWN)) {
+          if (
+            node.parent.computed &&
+            !stopReporting.has(STOPREPORTING_UNKNOWN)
+          ) {
             return
-          } 
+          }
 
           const container = getVueComponentPropertiesContainer(vueData.node)
           const propertyReferences =

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -237,12 +237,10 @@ module.exports = {
     const propertyReferenceExtractor = definePropertyReferenceExtractor(
       context,
       {
-        unknownMemberAsUnreferenced: Boolean(
-          unreferencedOptions.has(UNREFERENCED_UNKNOWN_MEMBER)
+        unknownMemberAsUnreferenced: unreferencedOptions.has(
+          UNREFERENCED_UNKNOWN_MEMBER
         ),
-        returnAsUnreferenced: Boolean(
-          unreferencedOptions.has(UNREFERENCED_RETURN)
-        )
+        returnAsUnreferenced: unreferencedOptions.has(UNREFERENCED_RETURN)
       }
     )
 

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -55,6 +55,8 @@ const GROUP_SETUP = 'setup'
 const GROUP_WATCHER = 'watch'
 const GROUP_EXPOSE = 'expose'
 
+const STOPREPORTING_THIS = 'ThisExpression'
+
 const PROPERTY_LABEL = {
   props: 'property',
   data: 'data',
@@ -206,7 +208,15 @@ module.exports = {
             uniqueItems: true
           },
           deepData: { type: 'boolean' },
-          ignorePublicMembers: { type: 'boolean' }
+          ignorePublicMembers: { type: 'boolean' },
+          stopReporting: {
+            type: 'array',
+            items: {
+              enum: [ STOPREPORTING_THIS ]
+            },
+            additionalItems: false,
+            uniqueItems: true
+          }
         },
         additionalProperties: false
       }
@@ -221,6 +231,7 @@ module.exports = {
     const groups = new Set(options.groups || [GROUP_PROPERTY])
     const deepData = Boolean(options.deepData)
     const ignorePublicMembers = Boolean(options.ignorePublicMembers)
+    const stopReporting = new Set(options.stopReporting || [STOPREPORTING_THIS])
 
     const propertyReferenceExtractor = definePropertyReferenceExtractor(context)
 
@@ -558,6 +569,9 @@ module.exports = {
          */
         'ThisExpression, Identifier'(node, vueData) {
           if (!utils.isThis(node, context)) {
+            return
+          }
+          if (!stopReporting.has(STOPREPORTING_THIS)) {
             return
           }
           const container = getVueComponentPropertiesContainer(vueData.node)

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -235,8 +235,18 @@ module.exports = {
     const stopReporting = new Set(
       options.stopReporting || [STOPREPORTING_UNKNOWN, STOPREPORTING_RETURN]
     )
+    const stopReportingUnknown = Boolean(
+      stopReporting.has(STOPREPORTING_UNKNOWN)
+    )
+    const stopReportingReturn = Boolean(stopReporting.has(STOPREPORTING_RETURN))
 
-    const propertyReferenceExtractor = definePropertyReferenceExtractor(context)
+    const propertyReferenceExtractor = definePropertyReferenceExtractor(
+      context,
+      {
+        stopReportingUnknown,
+        stopReportingReturn
+      }
+    )
 
     /** @type {TemplatePropertiesContainer} */
     const templatePropertiesContainer = {
@@ -574,22 +584,6 @@ module.exports = {
           if (!utils.isThis(node, context)) {
             return
           }
-
-          // e.g. return this
-          if (
-            node.parent.type === 'ReturnStatement' &&
-            !stopReporting.has(STOPREPORTING_RETURN)
-          ) {
-            return
-          }
-          // e.g. this[unknown]
-          if (
-            node.parent.computed &&
-            !stopReporting.has(STOPREPORTING_UNKNOWN)
-          ) {
-            return
-          }
-
           const container = getVueComponentPropertiesContainer(vueData.node)
           const propertyReferences =
             propertyReferenceExtractor.extractFromExpression(node, false)

--- a/lib/utils/property-references.js
+++ b/lib/utils/property-references.js
@@ -94,7 +94,7 @@ module.exports = {
  */
 function definePropertyReferenceExtractor(
   context,
-  { reportDynamicThis = false, reportReturnedThis = false } = {}
+  { unknownMemberAsUnreferenced = false, returnAsUnreferenced = false } = {}
 ) {
   /** @type {Map<Expression, IPropertyReferences>} */
   const cacheForExpression = new Map()
@@ -324,7 +324,7 @@ function definePropertyReferenceExtractor(
                 withInTemplate
               )
             } else {
-              return reportDynamicThis ? NEVER : ANY
+              return unknownMemberAsUnreferenced ? NEVER : ANY
             }
           }
           return NEVER
@@ -346,7 +346,7 @@ function definePropertyReferenceExtractor(
           return maybeExternalUsed(parent) ? ANY : NEVER
         }
         case 'ReturnStatement': {
-          if (reportReturnedThis) {
+          if (returnAsUnreferenced) {
             return NEVER
           } else {
             return maybeExternalUsed(parent) ? ANY : NEVER

--- a/lib/utils/property-references.js
+++ b/lib/utils/property-references.js
@@ -94,7 +94,7 @@ module.exports = {
  */
 function definePropertyReferenceExtractor(
   context,
-  { stopReportingUnknown = true, stopReportingReturn = true } = {}
+  { reportDynamicThis = false, reportReturnedThis = false } = {}
 ) {
   /** @type {Map<Expression, IPropertyReferences>} */
   const cacheForExpression = new Map()
@@ -324,7 +324,7 @@ function definePropertyReferenceExtractor(
                 withInTemplate
               )
             } else {
-              return stopReportingUnknown ? ANY : NEVER
+              return reportDynamicThis ? NEVER : ANY
             }
           }
           return NEVER
@@ -346,10 +346,10 @@ function definePropertyReferenceExtractor(
           return maybeExternalUsed(parent) ? ANY : NEVER
         }
         case 'ReturnStatement': {
-          if (stopReportingReturn) {
-            return maybeExternalUsed(parent) ? ANY : NEVER
-          } else {
+          if (reportReturnedThis) {
             return NEVER
+          } else {
+            return maybeExternalUsed(parent) ? ANY : NEVER
           }
         }
       }

--- a/lib/utils/property-references.js
+++ b/lib/utils/property-references.js
@@ -92,7 +92,10 @@ module.exports = {
 /**
  * @param {RuleContext} context The rule context.
  */
-function definePropertyReferenceExtractor(context) {
+function definePropertyReferenceExtractor(
+  context,
+  { stopReportingUnknown = true, stopReportingReturn = true } = {}
+) {
   /** @type {Map<Expression, IPropertyReferences>} */
   const cacheForExpression = new Map()
   /** @type {Map<Pattern, IPropertyReferences>} */
@@ -314,9 +317,15 @@ function definePropertyReferenceExtractor(context) {
           if (parent.object === node) {
             // `arg.foo`
             const name = utils.getStaticPropertyName(parent)
-            return name
-              ? new PropertyReferencesForMember(parent, name, withInTemplate)
-              : ANY
+            if (name) {
+              return new PropertyReferencesForMember(
+                parent,
+                name,
+                withInTemplate
+              )
+            } else {
+              return stopReportingUnknown ? ANY : NEVER
+            }
           }
           return NEVER
         }
@@ -331,11 +340,17 @@ function definePropertyReferenceExtractor(context) {
           return extractFromExpression(parent, withInTemplate)
         }
         case 'ArrowFunctionExpression':
-        case 'ReturnStatement':
         case 'VExpressionContainer':
         case 'Property':
         case 'ArrayExpression': {
           return maybeExternalUsed(parent) ? ANY : NEVER
+        }
+        case 'ReturnStatement': {
+          if (stopReportingReturn) {
+            return maybeExternalUsed(parent) ? ANY : NEVER
+          } else {
+            return NEVER
+          }
         }
       }
       return NEVER

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -2892,6 +2892,44 @@ tester.run('no-unused-properties', rule, {
         }
       ]
     },
+    // unreferencedOptions: returnAsUnreferenced via variable with deepData
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          data () {
+            return {
+              foo: {
+                bar: 1
+              },
+              baz: 2
+            }
+          },
+          methods: {
+            handler () {
+              const vm = this
+              console.log(vm.baz)
+              return vm.foo
+            },
+          }
+        }
+      </script>
+      `,
+      options: [
+        {
+          groups: ['data'],
+          unreferencedOptions: ['returnAsUnreferenced'],
+          deepData: true
+        }
+      ],
+      errors: [
+        {
+          message: "'foo.bar' of data found, but never used.",
+          line: 7
+        }
+      ]
+    },
     // unreferencedOptions: all
     {
       filename: 'test.vue',

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -21,26 +21,26 @@ const allOptions = [
 ]
 const deepDataOptions = [{ groups: ['data'], deepData: true }]
 
-const stopReportingOptions = {
-  // Stop reporting errors when accessing via unknown property, e.g. this[varName]
-  unknownPropertyAccess: [
+const reportingOptions = {
+  // Report errors when accessing via unknown property, e.g. this[varName]
+  reportDynamicThis: [
     {
       groups: ['computed'],
-      stopReporting: ['unknownPropertyAccess']
+      reportingOptions: ['reportDynamicThis']
     }
   ],
-  // Stop reporting errors when returning this
-  returnInstance: [
+  // Report errors when returning this
+  reportReturnedThis: [
     {
       groups: ['computed'],
-      stopReporting: ['returnInstance']
+      reportingOptions: ['reportReturnedThis']
     }
   ],
-  // Don't stop reporting any errors
-  none: [
+  // Report all
+  all: [
     {
       groups: ['computed'],
-      stopReporting: []
+      reportingOptions: ['reportDynamicThis', 'reportReturnedThis']
     }
   ]
 }
@@ -1721,56 +1721,6 @@ tester.run('no-unused-properties', rule, {
         },
       };
       </script>`
-    },
-
-    // stopReportingOptions: unknownPropertyAccess
-    {
-      filename: 'test.vue',
-      code: `
-      <script>
-        export default {
-          computed: {
-            one () {
-              return 1
-            },
-            two () {
-              return 2
-            },
-          },
-          methods: {
-            handler () {
-              const i = 'two'
-              const b = this[i]
-            },
-          }
-        }
-      </script>
-      `,
-      options: stopReportingOptions.unknownPropertyAccess
-    },
-    // stopReportingOptions: returnInstance
-    {
-      filename: 'test.vue',
-      code: `
-      <script>
-        export default {
-          computed: {
-            one () {
-              return 1
-            },
-            two () {
-              return 2
-            },
-          },
-          methods: {
-            handler () {
-              return this
-            },
-          }
-        }
-      </script>
-      `,
-      options: stopReportingOptions.returnInstance
     }
   ],
   invalid: [
@@ -2878,38 +2828,7 @@ tester.run('no-unused-properties', rule, {
       ]
     },
 
-    // stopReportingOptions: unknownPropertyAccess
-    {
-      filename: 'test.vue',
-      code: `
-      <script>
-        export default {
-          computed: {
-            one () {
-              return 1
-            },
-            two () {
-              return 2
-            }
-          },
-          methods: {
-            handler () {
-              const a = this.one
-              return this
-            },
-          }
-        }
-      </script>
-      `,
-      options: stopReportingOptions.unknownPropertyAccess,
-      errors: [
-        {
-          message: "'two' of computed property found, but never used.",
-          line: 8
-        }
-      ]
-    },
-    // stopReportingOptions: returnInstance
+    // reportingOptions: reportDynamicThis
     {
       filename: 'test.vue',
       code: `
@@ -2931,9 +2850,8 @@ tester.run('no-unused-properties', rule, {
             },
           }
         }
-      </script>
-      `,
-      options: stopReportingOptions.returnInstance,
+      </script>`,
+      options: reportingOptions.reportDynamicThis,
       errors: [
         {
           message: "'two' of computed property found, but never used.",
@@ -2941,7 +2859,37 @@ tester.run('no-unused-properties', rule, {
         }
       ]
     },
-    // stopReportingOptions: []
+    // stopReportingOptions: reportReturnedThis
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          computed: {
+            one () {
+              return 1
+            },
+            two () {
+              return 2
+            }
+          },
+          methods: {
+            handler () {
+              const a = this.one
+              return this
+            },
+          }
+        }
+      </script>`,
+      options: reportingOptions.reportReturnedThis,
+      errors: [
+        {
+          message: "'two' of computed property found, but never used.",
+          line: 8
+        }
+      ]
+    },
+    // reportingOptions: all
     {
       filename: 'test.vue',
       code: `
@@ -2964,49 +2912,12 @@ tester.run('no-unused-properties', rule, {
             },
           }
         }
-      </script>
-      `,
-      options: stopReportingOptions.none,
+      </script>`,
+      options: reportingOptions.all,
       errors: [
         {
           message: "'two' of computed property found, but never used.",
           line: 8
-        }
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: `
-      <script>
-        export default {
-          data () {
-            return {
-              foo: {
-                bar: 1
-              },
-              baz: 2
-            }
-          },
-          methods: {
-            handler () {
-              console.log(this.baz)
-              return this.foo
-            },
-          }
-        }
-      </script>
-      `,
-      options: [
-        {
-          groups: ['data'],
-          deepData: true,
-          stopReporting: []
-        }
-      ],
-      errors: [
-        {
-          message: "'foo.bar' of data found, but never used.",
-          line: 7
         }
       ]
     }

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -2973,6 +2973,42 @@ tester.run('no-unused-properties', rule, {
           line: 8
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          data () {
+            return {
+              foo: {
+                bar: 1
+              },
+              baz: 2
+            }
+          },
+          methods: {
+            handler () {
+              console.log(this.baz)
+              return this.foo
+            },
+          }
+        }
+      </script>
+      `,
+      options: [
+        {
+          groups: ['data'],
+          deepData: true,
+          stopReporting: []
+        }
+      ],
+      errors: [
+        {
+          message: "'foo.bar' of data found, but never used.",
+          line: 7
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -21,6 +21,30 @@ const allOptions = [
 ]
 const deepDataOptions = [{ groups: ['data'], deepData: true }]
 
+const stopReportingOptions = {
+  // Stop reporting errors when accessing via unknown property, e.g. this[varName]
+  unknownPropertyAccess: [
+    {
+      groups: ['computed'],
+      stopReporting: ['unknownPropertyAccess']
+    }
+  ],
+  // Stop reporting errors when returning this
+  returnInstance: [
+    {
+      groups: ['computed'],
+      stopReporting: ['returnInstance']
+    }
+  ],
+  // Don't stop reporting any errors
+  none: [
+    {
+      groups: ['computed'],
+      stopReporting: []
+    }
+  ]
+}
+
 tester.run('no-unused-properties', rule, {
   valid: [
     // a property used in a script expression
@@ -1697,9 +1721,58 @@ tester.run('no-unused-properties', rule, {
         },
       };
       </script>`
+    },
+
+    // stopReportingOptions: unknownPropertyAccess
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          computed: {
+            one () {
+              return 1
+            },
+            two () {
+              return 2
+            },
+          },
+          methods: {
+            handler () {
+              const i = 'two'
+              const b = this[i]
+            },
+          }
+        }
+      </script>
+      `,
+      options: stopReportingOptions.unknownPropertyAccess
+    },
+    // stopReportingOptions: returnInstance
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          computed: {
+            one () {
+              return 1
+            },
+            two () {
+              return 2
+            },
+          },
+          methods: {
+            handler () {
+              return this
+            },
+          }
+        }
+      </script>
+      `,
+      options: stopReportingOptions.returnInstance
     }
   ],
-
   invalid: [
     // unused property
     {
@@ -2801,6 +2874,103 @@ tester.run('no-unused-properties', rule, {
         {
           message: "'b' of property found, but never used.",
           line: 10
+        }
+      ]
+    },
+
+    // stopReportingOptions: unknownPropertyAccess
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          computed: {
+            one () {
+              return 1
+            },
+            two () {
+              return 2
+            }
+          },
+          methods: {
+            handler () {
+              const a = this.one
+              return this
+            },
+          }
+        }
+      </script>
+      `,
+      options: stopReportingOptions.unknownPropertyAccess,
+      errors: [
+        {
+          message: "'two' of computed property found, but never used.",
+          line: 8
+        }
+      ]
+    },
+    // stopReportingOptions: returnInstance
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          computed: {
+            one () {
+              return 1
+            },
+            two () {
+              return 2
+            }
+          },
+          methods: {
+            handler () {
+              const a = this.one
+              const i = 'two'
+              return this[i]
+            },
+          }
+        }
+      </script>
+      `,
+      options: stopReportingOptions.returnInstance,
+      errors: [
+        {
+          message: "'two' of computed property found, but never used.",
+          line: 8
+        }
+      ]
+    },
+    // stopReportingOptions: []
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+        export default {
+          computed: {
+            one () {
+              return 1
+            },
+            two () {
+              return 2
+            }
+          },
+          methods: {
+            handler () {
+              const a = this.one
+              const i = 'two'
+              const b = this[i]
+              return this
+            },
+          }
+        }
+      </script>
+      `,
+      options: stopReportingOptions.none,
+      errors: [
+        {
+          message: "'two' of computed property found, but never used.",
+          line: 8
         }
       ]
     }

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -21,26 +21,29 @@ const allOptions = [
 ]
 const deepDataOptions = [{ groups: ['data'], deepData: true }]
 
-const reportingOptions = {
+const unreferencedOptions = {
   // Report errors when accessing via unknown property, e.g. this[varName]
-  reportDynamicThis: [
+  unknownMemberAsUnreferenced: [
     {
       groups: ['computed'],
-      reportingOptions: ['reportDynamicThis']
+      unreferencedOptions: ['unknownMemberAsUnreferenced']
     }
   ],
   // Report errors when returning this
-  reportReturnedThis: [
+  returnAsUnreferenced: [
     {
       groups: ['computed'],
-      reportingOptions: ['reportReturnedThis']
+      unreferencedOptions: ['returnAsUnreferenced']
     }
   ],
   // Report all
   all: [
     {
       groups: ['computed'],
-      reportingOptions: ['reportDynamicThis', 'reportReturnedThis']
+      unreferencedOptions: [
+        'unknownMemberAsUnreferenced',
+        'returnAsUnreferenced'
+      ]
     }
   ]
 }
@@ -2828,7 +2831,7 @@ tester.run('no-unused-properties', rule, {
       ]
     },
 
-    // reportingOptions: reportDynamicThis
+    // unreferencedOptions: unknownMemberAsUnreferenced
     {
       filename: 'test.vue',
       code: `
@@ -2851,7 +2854,7 @@ tester.run('no-unused-properties', rule, {
           }
         }
       </script>`,
-      options: reportingOptions.reportDynamicThis,
+      options: unreferencedOptions.unknownMemberAsUnreferenced,
       errors: [
         {
           message: "'two' of computed property found, but never used.",
@@ -2859,7 +2862,7 @@ tester.run('no-unused-properties', rule, {
         }
       ]
     },
-    // stopReportingOptions: reportReturnedThis
+    // unreferencedOptions: returnAsUnreferenced
     {
       filename: 'test.vue',
       code: `
@@ -2881,7 +2884,7 @@ tester.run('no-unused-properties', rule, {
           }
         }
       </script>`,
-      options: reportingOptions.reportReturnedThis,
+      options: unreferencedOptions.returnAsUnreferenced,
       errors: [
         {
           message: "'two' of computed property found, but never used.",
@@ -2889,7 +2892,7 @@ tester.run('no-unused-properties', rule, {
         }
       ]
     },
-    // reportingOptions: all
+    // unreferencedOptions: all
     {
       filename: 'test.vue',
       code: `
@@ -2913,7 +2916,7 @@ tester.run('no-unused-properties', rule, {
           }
         }
       </script>`,
-      options: reportingOptions.all,
+      options: unreferencedOptions.all,
       errors: [
         {
           message: "'two' of computed property found, but never used.",


### PR DESCRIPTION
Ref #1636, this is my first stab at adding an option to not treat generic access to `this` as 'using' properties / data / computed, etc. If this is the right approach, I can try adding tests if needed. It's more general I think than what you'd proposed in that issue, but for my use case it works well.