### PR TITLE
Use `@eslint-community/eslint-utils` package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,7 +131,9 @@ module.exports = {
     'unicorn/no-useless-undefined': 'off',
     'unicorn/prefer-optional-catch-binding': 'off', // not supported by current ESLint parser version
     'unicorn/prefer-module': 'off',
-    'unicorn/prevent-abbreviations': 'off'
+    'unicorn/prevent-abbreviations': 'off',
+
+    'require-eslint-community': ['error']
   },
   overrides: [
     {

--- a/eslint-internal-rules/require-eslint-community.js
+++ b/eslint-internal-rules/require-eslint-community.js
@@ -1,0 +1,39 @@
+'use strict'
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'enforce use of the `@eslint-community/*` package',
+      categories: ['Internal']
+    },
+    fixable: 'code',
+    messages: {
+      useCommunityPackageInstead:
+        'Please use `@eslint-community/{{name}}` instead.'
+    },
+    schema: []
+  },
+
+  /** @param {import('eslint').Rule.RuleContext} context */
+  create(context) {
+    return {
+      /**
+       * @param {import("../typings/eslint-plugin-vue/util-types/ast").Literal} node
+       */
+      'CallExpression > Literal.arguments[value=/^(?:eslint-utils|regexpp)$/u]'(
+        node
+      ) {
+        context.report({
+          node,
+          messageId: 'useCommunityPackageInstead',
+          data: {
+            name: node.value
+          },
+          fix(fixer) {
+            return fixer.replaceText(node, `'@eslint-community/${node.value}'`)
+          }
+        })
+      }
+    }
+  }
+}

--- a/lib/rules/custom-event-name-casing.js
+++ b/lib/rules/custom-event-name-casing.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 const casing = require('../utils/casing')
 const { toRegExp } = require('../utils/regexp')

--- a/lib/rules/next-tick-style.js
+++ b/lib/rules/next-tick-style.js
@@ -7,7 +7,7 @@
 'use strict'
 
 const utils = require('../utils')
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 
 /**
  * @param {Identifier} identifier

--- a/lib/rules/no-async-in-computed-properties.js
+++ b/lib/rules/no-async-in-computed-properties.js
@@ -3,7 +3,7 @@
  * @author Armano
  */
 'use strict'
-const { ReferenceTracker } = require('eslint-utils')
+const { ReferenceTracker } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**

--- a/lib/rules/no-expose-after-await.js
+++ b/lib/rules/no-expose-after-await.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -3,7 +3,7 @@
  */
 'use strict'
 
-const { isParenthesized } = require('eslint-utils')
+const { isParenthesized } = require('@eslint-community/eslint-utils')
 const { wrapCoreRule } = require('../utils')
 const { getStyleVariablesContext } = require('../utils/style-variables')
 

--- a/lib/rules/no-lifecycle-after-await.js
+++ b/lib/rules/no-lifecycle-after-await.js
@@ -3,11 +3,11 @@
  * See LICENSE file in root directory for full license.
  */
 'use strict'
-const { ReferenceTracker } = require('eslint-utils')
+const { ReferenceTracker } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**
- * @typedef {import('eslint-utils').TYPES.TraceMap} TraceMap
+ * @typedef {import('@eslint-community/eslint-utils').TYPES.TraceMap} TraceMap
  */
 
 const LIFECYCLE_HOOKS = [

--- a/lib/rules/no-multiple-slot-args.js
+++ b/lib/rules/no-multiple-slot-args.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 
 module.exports = {
   meta: {

--- a/lib/rules/no-mutating-props.js
+++ b/lib/rules/no-mutating-props.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 
 // https://github.com/vuejs/vue-next/blob/7c11c58faf8840ab97b6449c98da0296a60dddd8/packages/shared/src/globalsWhitelist.ts
 const GLOBALS_WHITE_LISTED = new Set([

--- a/lib/rules/no-restricted-call-after-await.js
+++ b/lib/rules/no-restricted-call-after-await.js
@@ -5,12 +5,12 @@
 'use strict'
 const fs = require('fs')
 const path = require('path')
-const { ReferenceTracker } = require('eslint-utils')
+const { ReferenceTracker } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**
- * @typedef {import('eslint-utils').TYPES.TraceMap} TraceMap
- * @typedef {import('eslint-utils').TYPES.TraceKind} TraceKind
+ * @typedef {import('@eslint-community/eslint-utils').TYPES.TraceMap} TraceMap
+ * @typedef {import('@eslint-community/eslint-utils').TYPES.TraceKind} TraceKind
  */
 
 /**

--- a/lib/rules/no-restricted-custom-event.js
+++ b/lib/rules/no-restricted-custom-event.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 const regexp = require('../utils/regexp')
 

--- a/lib/rules/no-setup-props-destructure.js
+++ b/lib/rules/no-setup-props-destructure.js
@@ -3,7 +3,7 @@
  * See LICENSE file in root directory for full license.
  */
 'use strict'
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 module.exports = {

--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -3,7 +3,10 @@
  * @author Michał Sajnóg
  */
 'use strict'
-const { ReferenceTracker, findVariable } = require('eslint-utils')
+const {
+  ReferenceTracker,
+  findVariable
+} = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
-const eslintUtils = require('eslint-utils')
+const eslintUtils = require('@eslint-community/eslint-utils')
 const { isJSDocComment } = require('../utils/comments.js')
 const { getStyleVariablesContext } = require('../utils/style-variables')
 const {

--- a/lib/rules/no-use-computed-property-like-method.js
+++ b/lib/rules/no-use-computed-property-like-method.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const eslintUtils = require('eslint-utils')
+const eslintUtils = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**

--- a/lib/rules/no-watch-after-await.js
+++ b/lib/rules/no-watch-after-await.js
@@ -3,7 +3,7 @@
  * See LICENSE file in root directory for full license.
  */
 'use strict'
-const { ReferenceTracker } = require('eslint-utils')
+const { ReferenceTracker } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**

--- a/lib/rules/padding-lines-in-component-definition.js
+++ b/lib/rules/padding-lines-in-component-definition.js
@@ -10,7 +10,7 @@
  */
 
 const utils = require('../utils')
-const { isCommentToken } = require('eslint-utils')
+const { isCommentToken } = require('@eslint-community/eslint-utils')
 
 const AvailablePaddingOptions = {
   Never: 'never',

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -15,7 +15,7 @@ const {
   isOpeningBraceToken,
   isClosingBraceToken,
   isOpeningBracketToken
-} = require('eslint-utils')
+} = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 const { capitalize } = require('../utils/casing')
 

--- a/lib/rules/require-expose.js
+++ b/lib/rules/require-expose.js
@@ -8,7 +8,7 @@ const {
   findVariable,
   isOpeningBraceToken,
   isClosingBraceToken
-} = require('eslint-utils')
+} = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 const { getVueComponentDefinitionType } = require('../utils')
 

--- a/lib/rules/require-slots-as-functions.js
+++ b/lib/rules/require-slots-as-functions.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const utils = require('../utils')
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 
 module.exports = {
   meta: {

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -3,7 +3,7 @@
  * @author Armano
  */
 'use strict'
-const { ReferenceTracker } = require('eslint-utils')
+const { ReferenceTracker } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 /**

--- a/lib/rules/valid-define-emits.js
+++ b/lib/rules/valid-define-emits.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 module.exports = {

--- a/lib/rules/valid-define-props.js
+++ b/lib/rules/valid-define-props.js
@@ -4,7 +4,7 @@
  */
 'use strict'
 
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
 
 module.exports = {

--- a/lib/rules/valid-next-tick.js
+++ b/lib/rules/valid-next-tick.js
@@ -7,7 +7,7 @@
 'use strict'
 
 const utils = require('../utils')
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 
 /**
  * @param {Identifier} identifier

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -17,7 +17,7 @@ const {
   isClosingBracketToken,
   isSemicolonToken,
   isNotSemicolonToken
-} = require('eslint-utils')
+} = require('@eslint-community/eslint-utils')
 const {
   isComment,
   isNotComment,

--- a/lib/utils/indent-ts.js
+++ b/lib/utils/indent-ts.js
@@ -11,7 +11,7 @@ const {
   isNotClosingParenToken,
   isClosingBracketToken,
   isOpeningBracketToken
-} = require('eslint-utils')
+} = require('@eslint-community/eslint-utils')
 const { isTypeNode } = require('./ts-ast-utils')
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -55,7 +55,7 @@ const VUE3_BUILTIN_COMPONENT_NAMES = new Set(
 const path = require('path')
 const vueEslintParser = require('vue-eslint-parser')
 const { traverseNodes, getFallbackKeys, NS } = vueEslintParser.AST
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 const {
   getComponentPropsFromTypeDefine,
   getComponentEmitsFromTypeDefine,
@@ -1859,7 +1859,7 @@ module.exports = {
 
   /**
    * Wraps composition API trace map in both 'vue' and '@vue/composition-api' imports
-   * @param {import('eslint-utils').TYPES.TraceMap} map
+   * @param {import('@eslint-community/eslint-utils').TYPES.TraceMap} map
    */
   createCompositionApiTraceMap: (map) => ({
     vue: map,

--- a/lib/utils/property-references.js
+++ b/lib/utils/property-references.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const utils = require('./index')
-const eslintUtils = require('eslint-utils')
+const eslintUtils = require('@eslint-community/eslint-utils')
 
 /**
  * @typedef {import('./style-variables').StyleVariablesContext} StyleVariablesContext

--- a/lib/utils/ref-object-references.js
+++ b/lib/utils/ref-object-references.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const utils = require('./index')
-const eslintUtils = require('eslint-utils')
+const eslintUtils = require('@eslint-community/eslint-utils')
 const { definePropertyReferenceExtractor } = require('./property-references')
 const { ReferenceTracker } = eslintUtils
 

--- a/lib/utils/ts-ast-utils.js
+++ b/lib/utils/ts-ast-utils.js
@@ -1,4 +1,4 @@
-const { findVariable } = require('eslint-utils')
+const { findVariable } = require('@eslint-community/eslint-utils')
 /**
  * @typedef {import('@typescript-eslint/types').TSESTree.TypeNode} TypeNode
  * @typedef {import('@typescript-eslint/types').TSESTree.TSInterfaceBody} TSInterfaceBody

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0"
   },
   "dependencies": {
-    "eslint-utils": "^3.0.0",
+    "@eslint-community/eslint-utils": "^4.3.0",
     "natural-compare": "^1.4.0",
     "nth-check": "^2.0.1",
     "postcss-selector-parser": "^6.0.9",

--- a/typings/@eslint-community/eslint-utils/index.d.ts
+++ b/typings/@eslint-community/eslint-utils/index.d.ts
@@ -1,6 +1,6 @@
-import * as VAST from '../eslint-plugin-vue/util-types/ast'
-import { Token, Comment } from '../eslint-plugin-vue/util-types/node'
-import { ParserServices } from '../eslint-plugin-vue/util-types/parser-services'
+import * as VAST from '../../eslint-plugin-vue/util-types/ast'
+import { Token, Comment } from '../../eslint-plugin-vue/util-types/node'
+import { ParserServices } from '../../eslint-plugin-vue/util-types/parser-services'
 import eslint from 'eslint'
 
 export function findVariable(


### PR DESCRIPTION
This PR will replace the dependency to use the `@eslint-community/eslint-utils` package.

FYI, ESLint itself was also recently replaced to use that package.

https://github.com/eslint/eslint/pull/16784