### PR TITLE
Fixed false negatives in `vue/camelcase` when using ESLint>=v8.38

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -191,7 +191,7 @@ function wrapContextToOverrideTokenMethods(context, tokenStore, options) {
       },
       getNodeByRangeIndex,
       // @ts-expect-error -- Added in ESLint v8.38.0
-      getDeclaredVariables,
+      getDeclaredVariables
     },
     tokenStore
   )
@@ -262,7 +262,6 @@ function wrapContextToOverrideTokenMethods(context, tokenStore, options) {
     }
 
     return context.getDeclaredVariables(node)
-
   }
 }
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -189,7 +189,9 @@ function wrapContextToOverrideTokenMethods(context, tokenStore, options) {
       get tokensAndComments() {
         return getTokensAndComments()
       },
-      getNodeByRangeIndex
+      getNodeByRangeIndex,
+      // @ts-expect-error -- Added in ESLint v8.38.0
+      getDeclaredVariables,
     },
     tokenStore
   )
@@ -246,15 +248,22 @@ function wrapContextToOverrideTokenMethods(context, tokenStore, options) {
     getSourceCode() {
       return sourceCode
     },
-    getDeclaredVariables(node) {
-      const scope = getContainerScope(node)
-      if (scope) {
-        return scope.getDeclaredVariables(node)
-      }
-
-      return context.getDeclaredVariables(node)
-    }
+    getDeclaredVariables
   })
+
+  /**
+   * @param {ESNode} node
+   * @returns {Variable[]}
+   */
+  function getDeclaredVariables(node) {
+    const scope = getContainerScope(node)
+    if (scope) {
+      return scope.getDeclaredVariables(node)
+    }
+
+    return context.getDeclaredVariables(node)
+
+  }
 }
 
 /**


### PR DESCRIPTION

This PR fixes a bug found in https://github.com/vuejs/eslint-plugin-vue/pull/2101#pullrequestreview-1383007618.