### PR TITLE
feat(processor): export meta object for flat config

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -124,7 +124,12 @@ module.exports = {
     return filteredMessages
   },
 
-  supportsAutofix: true
+  supportsAutofix: true,
+
+  meta: {
+    name: 'eslint-plugin-vue',
+    version: require('../package.json').version
+  }
 }
 
 /**


### PR DESCRIPTION
Related issue: nothing
Related PR: https://github.com/vuejs/vue-eslint-parser/pull/190

This PR’s purpose is to support ESLint flat config.

Loading eslint-plugin-vue in flat config, ESLint check processor’s name and version in meta object.
https://github.com/eslint/eslint/blob/main/lib/config/flat-config-array.js#L220
https://github.com/eslint/eslint/blob/main/lib/config/flat-config-array.js#L45-L76