### PR TITLE
Fixed rules incompatible with ESLint v8.40.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -133,7 +133,11 @@ module.exports = {
     'unicorn/prefer-module': 'off',
     'unicorn/prevent-abbreviations': 'off',
 
-    'require-eslint-community': ['error']
+    'require-eslint-community': ['error'],
+
+    // FIXME: The version we are currently using is not compatible.
+    // May be removed in #2146. https://github.com/vuejs/eslint-plugin-vue/pull/2146
+    'unicorn/expiring-todo-comments': 'off'
   },
   overrides: [
     {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -248,6 +248,10 @@ function wrapContextToOverrideTokenMethods(context, tokenStore, options) {
     getSourceCode() {
       return sourceCode
     },
+    // @ts-expect-error -- Added in ESLint v8.40
+    get sourceCode() {
+      return sourceCode
+    },
     getDeclaredVariables
   })
 


### PR DESCRIPTION
I looked into #2145 and found that the CI #2145 test was failing due to rules not compatible with ESLint v8.40.
This PR fixes that issue.