### PR TITLE
Add `slots`+`expose` to `vue/order-in-components` default order

### DIFF
--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -88,6 +88,8 @@ export default {
       "model",
       ["props", "propsData"],
       "emits",
+      "slots",
+      "expose",
       "setup",
       "asyncData",
       "data",

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -48,6 +48,8 @@ const defaultOrder = [
   'model',
   ['props', 'propsData'],
   'emits', // for Vue.js 3.x
+  'slots',
+  'expose',
 
   // Note:
   // The `setup` option is included in the "Composition" category,

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -50,6 +50,8 @@ ruleTester.run('order-in-components', rule, {
           model,
           props, propsData,
           emits,
+          slots,
+          expose,
           setup,
           data,
           computed,
@@ -1282,6 +1284,61 @@ ruleTester.run('order-in-components', rule, {
         {
           message:
             'The "name" property should be above the "inheritAttrs" property on line 4.',
+          line: 5
+        }
+      ]
+    },
+    {
+      filename: 'example.vue',
+      code: `
+        export default {
+          setup,
+          slots,
+          expose,
+        };
+      `,
+      output: `
+        export default {
+          slots,
+          setup,
+          expose,
+        };
+      `,
+      languageOptions,
+      errors: [
+        {
+          message:
+            'The "slots" property should be above the "setup" property on line 3.',
+          line: 4
+        },
+        {
+          message:
+            'The "expose" property should be above the "setup" property on line 3.',
+          line: 5
+        }
+      ]
+    },
+    {
+      filename: 'example.vue',
+      code: `
+        export default {
+          slots,
+          setup,
+          expose,
+        };
+      `,
+      output: `
+        export default {
+          slots,
+          expose,
+          setup,
+        };
+      `,
+      languageOptions,
+      errors: [
+        {
+          message:
+            'The "expose" property should be above the "setup" property on line 4.',
           line: 5
         }
       ]


### PR DESCRIPTION
* Related to #2125
* Fixes #2399