### PR TITLE
Add support for `defineOptions` to `vue/padding-lines-in-component-definition` rule

### DIFF
--- a/lib/rules/padding-lines-in-component-definition.js
+++ b/lib/rules/padding-lines-in-component-definition.js
@@ -352,6 +352,16 @@ module.exports = {
             parseOption(emitsOption, OptionKeys.BetweenItems),
             parseOption(emitsOption, OptionKeys.WithinEach)
           )
+        },
+        onDefineOptionsEnter(node) {
+          if (node.arguments.length === 0) return
+          const define = node.arguments[0]
+          if (define.type !== 'ObjectExpression') return
+          verify(
+            define.properties,
+            parseOption(options, OptionKeys.BetweenOptions),
+            parseOption(options, OptionKeys.WithinOption)
+          )
         }
       })
     )

--- a/tests/lib/rules/padding-lines-in-component-definition.js
+++ b/tests/lib/rules/padding-lines-in-component-definition.js
@@ -385,6 +385,19 @@ tester.run('padding-lines-in-component-definition', rule, {
         </script>
       `,
       options: ['always']
+    },
+    {
+      filename: 'MyComment.vue',
+      code: `
+        <script setup>
+        defineOptions({
+            name: 'MyComment',
+
+            inheritAttrs: false,
+        })
+        </script>
+      `,
+      options: [{ betweenOptions: 'always', groupSingleLineProperties: false }]
     }
   ],
   invalid: [
@@ -1233,6 +1246,33 @@ tester.run('padding-lines-in-component-definition', rule, {
         {
           message: 'Unexpected blank line before this definition.',
           line: 16
+        }
+      ]
+    },
+    {
+      filename: 'MyComment.vue',
+      code: `
+        <script setup>
+        defineOptions({
+            name: 'MyComment',
+            inheritAttrs: false,
+        })
+        </script>
+      `,
+      output: `
+        <script setup>
+        defineOptions({
+            name: 'MyComment',
+
+            inheritAttrs: false,
+        })
+        </script>
+      `,
+      options: [{ betweenOptions: 'always', groupSingleLineProperties: false }],
+      errors: [
+        {
+          message: 'Expected blank line before this definition.',
+          line: 5
         }
       ]
     }


### PR DESCRIPTION


Related to https://github.com/vuejs/eslint-plugin-vue/issues/2118