### PR TITLE
Add `additionalProperties` to `vue/no-deprecated-router-link-tag-prop` schema

### DIFF
--- a/lib/rules/no-deprecated-router-link-tag-prop.js
+++ b/lib/rules/no-deprecated-router-link-tag-prop.js
@@ -45,7 +45,8 @@ module.exports = {
             uniqueItems: true,
             minItems: 1
           }
-        }
+        },
+        additionalProperties: false
       }
     ],
     messages: {


### PR DESCRIPTION
Fixes #2137.