### PR TITLE
Add support for `defineOptions` to `vue/no-duplicate-attr-inheritance` rule

### DIFF
--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -26,12 +26,23 @@ module.exports = {
     /** @type {string | number | boolean | RegExp | BigInt | null} */
     let inheritsAttrs = true
 
-    return Object.assign(
-      utils.executeOnVue(context, (node) => {
-        const inheritAttrsProp = utils.findProperty(node, 'inheritAttrs')
+    /** @param {ObjectExpression} node */
+    function processOptions(node) {
+      const inheritAttrsProp = utils.findProperty(node, 'inheritAttrs')
 
-        if (inheritAttrsProp && inheritAttrsProp.value.type === 'Literal') {
-          inheritsAttrs = inheritAttrsProp.value.value
+      if (inheritAttrsProp && inheritAttrsProp.value.type === 'Literal') {
+        inheritsAttrs = inheritAttrsProp.value.value
+      }
+    }
+
+    return utils.compositingVisitors(
+      utils.executeOnVue(context, processOptions),
+      utils.defineScriptSetupVisitor(context, {
+        onDefineOptionsEnter(node) {
+          if (node.arguments.length === 0) return
+          const define = node.arguments[0]
+          if (define.type !== 'ObjectExpression') return
+          processOptions(define)
         }
       }),
       utils.defineTemplateBodyVisitor(context, {

--- a/tests/lib/rules/no-duplicate-attr-inheritance.js
+++ b/tests/lib/rules/no-duplicate-attr-inheritance.js
@@ -79,6 +79,26 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
         export default {  }
         </script>
       `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default { inheritAttrs: false }
+      </script>
+      <script setup>
+      </script>
+      <template><div v-bind="$attrs" /></template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({ inheritAttrs: false })
+      </script>
+      <template><div v-bind="$attrs" /></template>
+      `
     }
   ],
 

--- a/tests/lib/rules/no-duplicate-attr-inheritance.js
+++ b/tests/lib/rules/no-duplicate-attr-inheritance.js
@@ -119,6 +119,38 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
         </script>
       `,
       errors: ['Set "inheritAttrs" to false.']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default { inheritAttrs: true }
+      </script>
+      <script setup>
+      </script>
+      <template><div v-bind="$attrs" /></template>
+      `,
+      errors: [
+        {
+          message: 'Set "inheritAttrs" to false.',
+          line: 7
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({ inheritAttrs: true })
+      </script>
+      <template><div v-bind="$attrs" /></template>
+      `,
+      errors: [
+        {
+          message: 'Set "inheritAttrs" to false.',
+          line: 5
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION


close #1886