### PR TITLE
Fix false positive for unknown prop in `vue/no-undef-properties` rule

### DIFF
--- a/lib/rules/no-undef-properties.js
+++ b/lib/rules/no-undef-properties.js
@@ -127,6 +127,8 @@ module.exports = {
 
         /** @type { Set<string | ASTNode> } */
         this.reported = new Set()
+
+        this.haveUnknownProperty = false
       }
       /**
        * Report
@@ -135,6 +137,7 @@ module.exports = {
        * @param {boolean} [options.props]
        */
       verifyReferences(references, options) {
+        if (this.haveUnknownProperty) return
         const report = this.report.bind(this)
         verifyUndefProperties(this.defineProperties, references, null)
 
@@ -205,6 +208,10 @@ module.exports = {
             name
           }
         })
+      }
+
+      markAsHaveUnknownProperty() {
+        this.haveUnknownProperty = true
       }
     }
 
@@ -280,6 +287,10 @@ module.exports = {
           const ctx = getVueComponentContext(programNode)
 
           for (const prop of props) {
+            if (prop.type === 'unknown') {
+              ctx.markAsHaveUnknownProperty()
+              return
+            }
             if (!prop.propName) {
               continue
             }

--- a/lib/rules/no-undef-properties.js
+++ b/lib/rules/no-undef-properties.js
@@ -128,7 +128,7 @@ module.exports = {
         /** @type { Set<string | ASTNode> } */
         this.reported = new Set()
 
-        this.haveUnknownProperty = false
+        this.hasUnknownProperty = false
       }
       /**
        * Report
@@ -137,7 +137,7 @@ module.exports = {
        * @param {boolean} [options.props]
        */
       verifyReferences(references, options) {
-        if (this.haveUnknownProperty) return
+        if (this.hasUnknownProperty) return
         const report = this.report.bind(this)
         verifyUndefProperties(this.defineProperties, references, null)
 
@@ -210,8 +210,8 @@ module.exports = {
         })
       }
 
-      markAsHaveUnknownProperty() {
-        this.haveUnknownProperty = true
+      markAsHasUnknownProperty() {
+        this.hasUnknownProperty = true
       }
     }
 
@@ -288,7 +288,7 @@ module.exports = {
 
           for (const prop of props) {
             if (prop.type === 'unknown') {
-              ctx.markAsHaveUnknownProperty()
+              ctx.markAsHasUnknownProperty()
               return
             }
             if (!prop.propName) {

--- a/tests/lib/rules/no-undef-properties.js
+++ b/tests/lib/rules/no-undef-properties.js
@@ -1155,7 +1155,7 @@ tester.run('no-undef-properties', rule, {
     },
 
     {
-      // unknown type
+      // known type
       filename: 'test.vue',
       code: `
       <script setup lang="ts">

--- a/tests/lib/rules/no-undef-properties.js
+++ b/tests/lib/rules/no-undef-properties.js
@@ -6,6 +6,9 @@
 
 const RuleTester = require('eslint').RuleTester
 const rule = require('../../../lib/rules/no-undef-properties')
+const {
+  getTypeScriptFixtureTestOptions
+} = require('../../test-utils/typescript')
 
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
@@ -542,15 +545,15 @@ tester.run('no-undef-properties', rule, {
       filename: 'test.vue',
       code: `
       <script setup lang="ts">
-      import { defineProps } from 'vue';
-      import type { Props } from './types';
+      import type { Props1 } from './test01';
 
-      defineProps<Props>();
+      defineProps<Props1>();
 
       </script>
 
       <template>
-        <div>{{ foo }}</div>
+      <div>{{ foo }}</div>
+      <div>{{ unknown }}</div>
       </template>`,
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
@@ -1147,6 +1150,30 @@ tester.run('no-undef-properties', rule, {
           message: "'c' is not defined.",
           line: 3,
           column: 46
+        }
+      ]
+    },
+
+    {
+      // unknown type
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      import type { Props1 } from './test01';
+
+      defineProps<Props1>();
+
+      </script>
+
+      <template>
+      <div>{{ foo }}</div>
+      <div>{{ unknown }}</div>
+      </template>`,
+      ...getTypeScriptFixtureTestOptions(),
+      errors: [
+        {
+          message: "'unknown' is not defined.",
+          line: 11
         }
       ]
     }

--- a/tests/lib/rules/no-undef-properties.js
+++ b/tests/lib/rules/no-undef-properties.js
@@ -535,6 +535,26 @@ tester.run('no-undef-properties', rule, {
         },
       };
       </script>`
+    },
+
+    {
+      // unknown type
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      import { defineProps } from 'vue';
+      import type { Props } from './types';
+
+      defineProps<Props>();
+
+      </script>
+
+      <template>
+        <div>{{ foo }}</div>
+      </template>`,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     }
   ],
 


### PR DESCRIPTION
fixes #2183

---

This PR fixes unknown properties to be ignored from check when encountered.
There was a false positive if the user did not enable type information for rules in the ESLint configuration and defined the prop type externally.