### PR TITLE
Add `vue/no-restricted-component-names` rule

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -234,6 +234,7 @@ For example:
 | [vue/no-restricted-block](./no-restricted-block.md) | disallow specific block |  | :hammer: |
 | [vue/no-restricted-call-after-await](./no-restricted-call-after-await.md) | disallow asynchronously called restricted methods |  | :hammer: |
 | [vue/no-restricted-class](./no-restricted-class.md) | disallow specific classes in Vue components |  | :warning: |
+| [vue/no-restricted-component-names](./no-restricted-component-names.md) | disallow specific component names | :bulb: | :hammer: |
 | [vue/no-restricted-component-options](./no-restricted-component-options.md) | disallow specific component option |  | :hammer: |
 | [vue/no-restricted-custom-event](./no-restricted-custom-event.md) | disallow specific custom event | :bulb: | :hammer: |
 | [vue/no-restricted-html-elements](./no-restricted-html-elements.md) | disallow specific HTML elements |  | :hammer: |

--- a/docs/rules/no-restricted-component-names.md
+++ b/docs/rules/no-restricted-component-names.md
@@ -70,13 +70,7 @@ Alternatively, you can specify an object with a `name` property and an optional 
   }
   ```
 
-<eslint-code-block :rules="{'vue/no-restricted-component-names': ['error',
-{
-  "name": "Disallow",
-  "message": "Please don't use `Disallow` as a component name",
-  "suggest": "allow"
-}
-]}">
+<eslint-code-block :rules="{'vue/no-restricted-component-names': ['error', { "name": "Disallow", "message": "Please don't use `Disallow` as a component name", "suggest": "allow"}]}">
 
 ```vue
 <!-- ✗ BAD -->

--- a/docs/rules/no-restricted-component-names.md
+++ b/docs/rules/no-restricted-component-names.md
@@ -59,18 +59,18 @@ Alternatively, you can specify an object with a `name` property and an optional 
       "error",
       {
         "name": "Disallow",
-        "message": "Please don't use `Disallow` as a component name",
+        "message": "Please do not use `Disallow` as a component name",
         "suggest": "allow"
       },
       {
         "name": "/^custom/",
-        "message": "Please don't use component names starting with 'custom'",
+        "message": "Please do not use component names starting with 'custom'"
       }
     ]
   }
   ```
 
-<eslint-code-block :rules="{'vue/no-restricted-component-names': ['error', { "name": "Disallow", "message": "Please don't use `Disallow` as a component name", "suggest": "allow"}]}">
+<eslint-code-block :rules="{'vue/no-restricted-component-names': ['error', { name: 'Disallow', message: 'Please do not use \'Disallow\' as a component name', suggest: 'allow'}]}">
 
 ```vue
 <!-- ✗ BAD -->

--- a/docs/rules/no-restricted-component-names.md
+++ b/docs/rules/no-restricted-component-names.md
@@ -1,0 +1,95 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-restricted-component-names
+description: disallow specific component names
+---
+# vue/no-restricted-component-names
+
+> disallow specific component names
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> ***This rule has not been released yet.*** </badge>
+- :bulb: Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+## :book: Rule Details
+
+This rule allows you to specify component names that you don't want to use in your application.
+
+<eslint-code-block :rules="{'vue/no-restricted-component-names': ['error', 'Disallow']}">
+
+```vue
+<!-- ✗ BAD -->
+<script>
+export default {
+  name: 'Disallow',
+}
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-restricted-component-names': ['error', 'Disallow']}">
+
+```vue
+<!-- ✓ GOOD -->
+<script>
+export default {
+  name: 'Allow',
+}
+</script>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+This rule takes a list of strings, where each string is a component name or pattern to be restricted:
+
+```json
+{
+  "vue/no-restricted-component-names": ["error", "foo", "/^Disallow/"]
+}
+```
+
+Alternatively, you can specify an object with a `name` property and an optional `message` and `suggest` property:
+  
+```json
+  {
+    "vue/no-restricted-component-names": [
+      "error",
+      {
+        "name": "Disallow",
+        "message": "Please don't use `Disallow` as a component name",
+        "suggest": "allow"
+      },
+      {
+        "name": "/^custom/",
+        "message": "Please don't use component names starting with 'custom'",
+      }
+    ]
+  }
+  ```
+
+<eslint-code-block :rules="{'vue/no-restricted-component-names': ['error',
+{
+  "name": "Disallow",
+  "message": "Please don't use `Disallow` as a component name",
+  "suggest": "allow"
+}
+]}">
+
+```vue
+<!-- ✗ BAD -->
+<script>
+export default {
+  name: 'Disallow',
+}
+</script>
+```
+
+</eslint-code-block>
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-restricted-component-names.js)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-restricted-component-names.js)

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,6 +118,7 @@ module.exports = {
     'no-restricted-block': require('./rules/no-restricted-block'),
     'no-restricted-call-after-await': require('./rules/no-restricted-call-after-await'),
     'no-restricted-class': require('./rules/no-restricted-class'),
+    'no-restricted-component-names': require('./rules/no-restricted-component-names'),
     'no-restricted-component-options': require('./rules/no-restricted-component-options'),
     'no-restricted-custom-event': require('./rules/no-restricted-custom-event'),
     'no-restricted-html-elements': require('./rules/no-restricted-html-elements'),

--- a/lib/rules/no-restricted-component-names.js
+++ b/lib/rules/no-restricted-component-names.js
@@ -5,8 +5,8 @@
 'use strict'
 
 const utils = require('../utils')
-const { isRegExp } = require('../utils/regexp')
-const { toRegExp } = require('../utils/regexp')
+const casing = require('../utils/casing')
+const { isRegExp, toRegExp } = require('../utils/regexp')
 
 /**
  * @typedef {object} OptionParsed
@@ -25,7 +25,7 @@ function buildMatcher(str) {
     const regex = toRegExp(str)
     return (s) => regex.test(s)
   }
-  return (s) => s === str
+  return (s) => s === casing.pascalCase(str) || s === casing.kebabCase(str)
 }
 
 /**
@@ -51,7 +51,9 @@ function parseOption(option) {
  * @private
  * */
 function createSuggest(property, suggest) {
-  if (!suggest) return []
+  if (!suggest) {
+    return []
+  }
 
   return [
     {
@@ -112,7 +114,9 @@ module.exports = {
       const propertyName = utils.getStaticPropertyName(property)
       if (propertyName === 'name' && property.value.type === 'Literal') {
         const componentName = property.value.value?.toString()
-        if (!componentName) return
+        if (!componentName) {
+          return
+        }
 
         for (const option of options) {
           if (option.test(componentName)) {

--- a/lib/rules/no-restricted-component-names.js
+++ b/lib/rules/no-restricted-component-names.js
@@ -97,7 +97,7 @@ module.exports = {
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       disallow: '{{message}}',
-      suggest: 'Instead, change to `{{suggest}}`'
+      suggest: 'Instead, change to `{{suggest}}`.'
     }
   },
   /** @param {RuleContext} context */

--- a/lib/rules/no-restricted-component-names.js
+++ b/lib/rules/no-restricted-component-names.js
@@ -108,9 +108,12 @@ module.exports = {
     const options = context.options.map(parseOption)
 
     /**
-     * @param {Property | AssignmentProperty} property
+     * @param {ObjectExpression} node
      */
-    function verify(property) {
+    function verify(node) {
+      const property = utils.findProperty(node, 'name')
+      if (!property) return
+
       const propertyName = utils.getStaticPropertyName(property)
       if (propertyName === 'name' && property.value.type === 'Literal') {
         const componentName = property.value.value?.toString()
@@ -137,7 +140,7 @@ module.exports = {
 
     return utils.compositingVisitors(
       utils.defineVueVisitor(context, {
-        Property(node) {
+        onVueObjectEnter(node) {
           verify(node)
         }
       }),
@@ -145,10 +148,7 @@ module.exports = {
         onDefineOptionsEnter(node) {
           const expression = node.arguments[0]
           if (expression.type === 'ObjectExpression') {
-            const property = utils.findProperty(expression, 'name')
-            if (!property) return
-
-            verify(property)
+            verify(expression)
           }
         }
       })

--- a/lib/rules/no-restricted-component-names.js
+++ b/lib/rules/no-restricted-component-names.js
@@ -97,7 +97,7 @@ module.exports = {
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       disallow: '{{message}}',
-      suggest: "Instead, change to '{{suggest}}'"
+      suggest: 'Instead, change to `{{suggest}}`'
     }
   },
   /** @param {RuleContext} context */
@@ -122,7 +122,7 @@ module.exports = {
               data: {
                 message:
                   option.message ||
-                  `Using component name '${componentName}' is not allowed.`
+                  `Using component name \`${componentName}\` is not allowed.`
               },
               suggest: createSuggest(property, option.suggest)
             })

--- a/lib/rules/no-restricted-component-names.js
+++ b/lib/rules/no-restricted-component-names.js
@@ -1,0 +1,153 @@
+/**
+ * @author ItMaga <https://github.com/ItMaga>
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const utils = require('../utils')
+const { isRegExp } = require('../utils/regexp')
+const { toRegExp } = require('../utils/regexp')
+
+/**
+ * @typedef {object} OptionParsed
+ * @property { (name: string) => boolean } test
+ * @property {string|undefined} [message]
+ * @property {string|undefined} [suggest]
+ */
+
+/**
+ * @param {string} str
+ * @returns {(str: string) => boolean}
+ * @private
+ */
+function buildMatcher(str) {
+  if (isRegExp(str)) {
+    const regex = toRegExp(str)
+    return (s) => regex.test(s)
+  }
+  return (s) => s === str
+}
+
+/**
+ * @param {string|{name: string, message?: string, suggest?: string}} option
+ * @returns {OptionParsed}
+ * @private
+ * */
+function parseOption(option) {
+  if (typeof option === 'string') {
+    const matcher = buildMatcher(option)
+    return { test: matcher }
+  }
+  const parsed = parseOption(option.name)
+  parsed.message = option.message
+  parsed.suggest = option.suggest
+  return parsed
+}
+
+/**
+ * @param {Property | AssignmentProperty} property
+ * @param {string | undefined} suggest
+ * @returns {Rule.SuggestionReportDescriptor[]}
+ * @private
+ * */
+function createSuggest(property, suggest) {
+  if (!suggest) return []
+
+  return [
+    {
+      fix(fixer) {
+        return fixer.replaceText(property.value, JSON.stringify(suggest))
+      },
+      messageId: 'suggest',
+      data: { suggest }
+    }
+  ]
+}
+
+module.exports = {
+  meta: {
+    hasSuggestions: true,
+    type: 'suggestion',
+    docs: {
+      description: 'disallow specific component names',
+      categories: undefined,
+      url: 'https://eslint.vuejs.org/rules/no-restricted-component-names.html'
+    },
+    fixable: null,
+    schema: {
+      type: 'array',
+      items: {
+        oneOf: [
+          { type: 'string' },
+          {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              message: { type: 'string', minLength: 1 },
+              suggest: { type: 'string' }
+            },
+            required: ['name'],
+            additionalProperties: false
+          }
+        ]
+      },
+      uniqueItems: true,
+      minItems: 0
+    },
+    messages: {
+      // eslint-disable-next-line eslint-plugin/report-message-format
+      disallow: '{{message}}',
+      suggest: "Instead, change to '{{suggest}}'"
+    }
+  },
+  /** @param {RuleContext} context */
+  create(context) {
+    /** @type {OptionParsed[]} */
+    const options = context.options.map(parseOption)
+
+    /**
+     * @param {Property | AssignmentProperty} property
+     */
+    function verify(property) {
+      const propertyName = utils.getStaticPropertyName(property)
+      if (propertyName === 'name' && property.value.type === 'Literal') {
+        const componentName = property.value.value?.toString()
+        if (!componentName) return
+
+        for (const option of options) {
+          if (option.test(componentName)) {
+            context.report({
+              node: property.value,
+              messageId: 'disallow',
+              data: {
+                message:
+                  option.message ||
+                  `Using component name '${componentName}' is not allowed.`
+              },
+              suggest: createSuggest(property, option.suggest)
+            })
+          }
+        }
+      }
+    }
+
+    return utils.compositingVisitors(
+      utils.defineVueVisitor(context, {
+        Property(node) {
+          verify(node)
+        }
+      }),
+      utils.defineScriptSetupVisitor(context, {
+        onDefineOptionsEnter(node) {
+          const expression = node.arguments[0]
+          if (expression.type === 'ObjectExpression') {
+            const property = utils.findProperty(expression, 'name')
+            if (!property) return
+
+            verify(property)
+          }
+        }
+      })
+    )
+  }
+}

--- a/tests/lib/rules/no-restricted-component-names.js
+++ b/tests/lib/rules/no-restricted-component-names.js
@@ -58,7 +58,7 @@ tester.run('no-restricted-component-names', rule, {
       options: ['Disallow', 'Disallow2'],
       errors: [
         {
-          message: "Using component name 'Disallow' is not allowed.",
+          message: 'Using component name `Disallow` is not allowed.',
           line: 4,
           column: 15
         }
@@ -76,7 +76,7 @@ tester.run('no-restricted-component-names', rule, {
       options: ['Disallow'],
       errors: [
         {
-          message: "Using component name 'Disallow' is not allowed.",
+          message: 'Using component name `Disallow` is not allowed.',
           line: 4,
           column: 15
         }
@@ -94,7 +94,7 @@ tester.run('no-restricted-component-names', rule, {
       options: ['Disallow'],
       errors: [
         {
-          message: "Using component name 'Disallow' is not allowed.",
+          message: 'Using component name `Disallow` is not allowed.',
           line: 4,
           column: 15
         }
@@ -112,7 +112,7 @@ tester.run('no-restricted-component-names', rule, {
       options: ['/^Foo(Bar|Baz)/'],
       errors: [
         {
-          message: "Using component name 'FooBar' is not allowed.",
+          message: 'Using component name `FooBar` is not allowed.',
           line: 4,
           column: 15
         }
@@ -138,7 +138,7 @@ tester.run('no-restricted-component-names', rule, {
           column: 15,
           suggestions: [
             {
-              desc: "Instead, change to 'Allow'",
+              desc: 'Instead, change to `Allow`',
               output: `
       <script setup>
       defineOptions({
@@ -165,12 +165,12 @@ tester.run('no-restricted-component-names', rule, {
       options: [{ name: 'Disallow', suggest: 'Allow' }],
       errors: [
         {
-          message: "Using component name 'Disallow' is not allowed.",
+          message: 'Using component name `Disallow` is not allowed.',
           line: 4,
           column: 15,
           suggestions: [
             {
-              desc: "Instead, change to 'Allow'",
+              desc: 'Instead, change to `Allow`',
               output: `
       <script setup>
       defineOptions({
@@ -215,7 +215,7 @@ tester.run('no-restricted-component-names', rule, {
       options: ['1'],
       errors: [
         {
-          message: "Using component name '1' is not allowed.",
+          message: 'Using component name `1` is not allowed.',
           line: 4,
           column: 15
         }

--- a/tests/lib/rules/no-restricted-component-names.js
+++ b/tests/lib/rules/no-restricted-component-names.js
@@ -1,0 +1,225 @@
+/**
+ * @author ItMaga <https://github.com/ItMaga>
+ * See LICENSE file in root directory for full license.
+ */
+'use strict'
+
+const RuleTester = require('eslint').RuleTester
+const rule = require('../../../lib/rules/no-restricted-component-names')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  }
+})
+
+tester.run('no-restricted-component-names', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        name: 'Allow'
+      }
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      new Vue({
+        name: 'Allow',
+      })
+    `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'Allow'
+      })
+      </script>
+      `
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        name: 'Disallow'
+      }
+      </script>
+      `,
+      options: ['Disallow', 'Disallow2'],
+      errors: [
+        {
+          message: "Using component name 'Disallow' is not allowed.",
+          line: 4,
+          column: 15
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      new Vue({
+        name: 'Disallow',
+      })
+      </script>
+      `,
+      options: ['Disallow'],
+      errors: [
+        {
+          message: "Using component name 'Disallow' is not allowed.",
+          line: 4,
+          column: 15
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'Disallow'
+      })
+      </script>
+      `,
+      options: ['Disallow'],
+      errors: [
+        {
+          message: "Using component name 'Disallow' is not allowed.",
+          line: 4,
+          column: 15
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'FooBar'
+      })
+      </script>
+      `,
+      options: ['/^Foo(Bar|Baz)/'],
+      errors: [
+        {
+          message: "Using component name 'FooBar' is not allowed.",
+          line: 4,
+          column: 15
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'Disallow',
+        inheritAttrs: false,
+      })
+      </script>
+      `,
+      options: [
+        { name: 'Disallow', message: 'Custom message', suggest: 'Allow' }
+      ],
+      errors: [
+        {
+          message: 'Custom message',
+          line: 4,
+          column: 15,
+          suggestions: [
+            {
+              desc: "Instead, change to 'Allow'",
+              output: `
+      <script setup>
+      defineOptions({
+        name: "Allow",
+        inheritAttrs: false,
+      })
+      </script>
+      `
+            }
+          ]
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'Disallow',
+        inheritAttrs: false,
+      })
+      </script>
+      `,
+      options: [{ name: 'Disallow', suggest: 'Allow' }],
+      errors: [
+        {
+          message: "Using component name 'Disallow' is not allowed.",
+          line: 4,
+          column: 15,
+          suggestions: [
+            {
+              desc: "Instead, change to 'Allow'",
+              output: `
+      <script setup>
+      defineOptions({
+        name: "Allow",
+        inheritAttrs: false,
+      })
+      </script>
+      `
+            }
+          ]
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'Disallow',
+        inheritAttrs: false,
+      })
+      </script>
+      `,
+      options: [{ name: 'Disallow', message: 'Custom message' }],
+      errors: [
+        {
+          message: 'Custom message',
+          line: 4,
+          column: 15
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 1
+      })
+      </script>
+      `,
+      options: ['1'],
+      errors: [
+        {
+          message: "Using component name '1' is not allowed.",
+          line: 4,
+          column: 15
+        }
+      ]
+    }
+  ]
+})

--- a/tests/lib/rules/no-restricted-component-names.js
+++ b/tests/lib/rules/no-restricted-component-names.js
@@ -220,6 +220,43 @@ tester.run('no-restricted-component-names', rule, {
           column: 15
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'disallowed-component',
+      })
+      </script>
+      `,
+      options: ['DisallowedComponent'],
+      errors: [
+        {
+          message:
+            'Using component name `disallowed-component` is not allowed.',
+          line: 4,
+          column: 15
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({
+        name: 'DisallowedComponent',
+      })
+      </script>
+      `,
+      options: ['disallowed-component'],
+      errors: [
+        {
+          message: 'Using component name `DisallowedComponent` is not allowed.',
+          line: 4,
+          column: 15
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-restricted-component-names.js
+++ b/tests/lib/rules/no-restricted-component-names.js
@@ -138,7 +138,7 @@ tester.run('no-restricted-component-names', rule, {
           column: 15,
           suggestions: [
             {
-              desc: 'Instead, change to `Allow`',
+              desc: 'Instead, change to `Allow`.',
               output: `
       <script setup>
       defineOptions({
@@ -170,7 +170,7 @@ tester.run('no-restricted-component-names', rule, {
           column: 15,
           suggestions: [
             {
-              desc: 'Instead, change to `Allow`',
+              desc: 'Instead, change to `Allow`.',
               output: `
       <script setup>
       defineOptions({


### PR DESCRIPTION
closes #2182 

---

I slightly changed the schema format that was proposed in the issue, as in [no-restricted-props](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-restricted-props.js) rule.