### PR TITLE
Fix typo in `vue/require-typed-ref` message

### DIFF
--- a/lib/rules/require-typed-ref.js
+++ b/lib/rules/require-typed-ref.js
@@ -33,7 +33,7 @@ module.exports = {
     fixable: null,
     messages: {
       noType:
-        'Specify type parameter for `{{name}}` function, otherwise created variable will not by typechecked.'
+        'Specify type parameter for `{{name}}` function, otherwise created variable will not be typechecked.'
     },
     schema: []
   },


### PR DESCRIPTION
Follow-up to #2204.