### PR TITLE
Restrict the `vue/no-console` rule to the `<template>` block

### DIFF
--- a/lib/rules/no-console.js
+++ b/lib/rules/no-console.js
@@ -8,6 +8,7 @@ const utils = require('../utils')
 
 // eslint-disable-next-line no-invalid-meta, no-invalid-meta-docs-categories
 module.exports = utils.wrapCoreRule('no-console', {
+  skipCoreHandlers: true,
   create(context) {
     const options = context.options[0] || {}
     const allowed = options.allow || []

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -382,6 +382,7 @@ module.exports = {
    * @param {boolean} [options.skipDynamicArguments] If `true`, skip validation within dynamic arguments.
    * @param {boolean} [options.skipDynamicArgumentsReport] If `true`, skip report within dynamic arguments.
    * @param {boolean} [options.applyDocument] If `true`, apply check to document fragment.
+   * @param {boolean} [options.skipCoreHandlers] If `true`, skip core handlers.
    * @param {WrapCoreRulePreprocess} [options.preprocess] Preprocess to calling create of core rule.
    * @param {WrapCoreRuleCreate} [options.create] If define, extend core rule.
    * @returns {RuleModule} The wrapped rule implementation.
@@ -418,6 +419,7 @@ module.exports = {
       categories,
       skipDynamicArguments,
       skipDynamicArgumentsReport,
+      skipCoreHandlers,
       applyDocument,
       preprocess,
       create
@@ -457,7 +459,9 @@ module.exports = {
         }
 
         const coreHandlers = coreRule.create(context)
-        compositingVisitors(handlers, coreHandlers)
+        if (!skipCoreHandlers) {
+          compositingVisitors(handlers, coreHandlers)
+        }
 
         // Move `Program` handlers to `VElement[parent.type!='VElement']`
         if (handlers.Program) {

--- a/tests/lib/rules/no-console.js
+++ b/tests/lib/rules/no-console.js
@@ -53,6 +53,18 @@ tester.run('no-console', rule, {
       </template>
       `,
       options: [{ allow: ['log', 'warn', 'info'] }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <button :foo="console.error">button</button>
+      </template>
+      <script setup>
+        console.log('test')
+      </script>
+      `,
+      options: [{ allow: ['error'] }]
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-console.js
+++ b/tests/lib/rules/no-console.js
@@ -57,14 +57,11 @@ tester.run('no-console', rule, {
     {
       filename: 'test.vue',
       code: `
-      <template>
-        <button :foo="console.error">button</button>
-      </template>
+      <template><div /></template>
       <script setup>
         console.log('test')
       </script>
-      `,
-      options: [{ allow: ['error'] }]
+      `
     }
   ],
   invalid: [


### PR DESCRIPTION
fixes #2220 