### PR TITLE
Allow deprecated rules in configs

### DIFF
--- a/docs/rules/experimental-script-setup-vars.md
+++ b/docs/rules/experimental-script-setup-vars.md
@@ -9,7 +9,7 @@ since: v7.0.0
 
 > prevent variables defined in `<script setup>` to be marked as undefined
 
-- :no_entry_sign: This rule was **removed** in eslint-plugin-vue v9.0.0.
+- :no_entry: This rule was **removed** in eslint-plugin-vue v9.0.0.
 
 This rule will find variables defined in `<script setup="args">` and mark them as defined variables.
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -330,7 +330,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 
 ## Deprecated
 
-- :warning: We're going to remove deprecated rules in the next major release. Please migrate to successor/new rules.
+- :no_entry_sign: We're going to remove deprecated rules in the next major release. Please migrate to successor/new rules.
 - :innocent: We don't fix bugs which are in deprecated rules since we don't have enough resources.
 
 | Rule ID | Replaced by |
@@ -341,7 +341,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 
 ## Removed
 
-- :no_entry_sign: These rules have been removed in a previous major release, after they have been deprecated for a while.
+- :no_entry: These rules have been removed in a previous major release, after they have been deprecated for a while.
 
 | Rule ID | Replaced by | Deprecated in version  | Removed in version |
 |:--------|:------------|:-----------------------|:-------------------|

--- a/docs/rules/name-property-casing.md
+++ b/docs/rules/name-property-casing.md
@@ -9,7 +9,7 @@ since: v3.8.0
 
 > enforce specific casing for the name property in Vue components
 
-- :no_entry_sign: This rule was **removed** in eslint-plugin-vue v9.0.0 and replaced by [vue/component-definition-name-casing](component-definition-name-casing.md) rule.
+- :no_entry: This rule was **removed** in eslint-plugin-vue v9.0.0 and replaced by [vue/component-definition-name-casing](component-definition-name-casing.md) rule.
 
 ## :book: Rule Details
 

--- a/docs/rules/no-confusing-v-for-v-if.md
+++ b/docs/rules/no-confusing-v-for-v-if.md
@@ -9,7 +9,7 @@ since: v3.0.0
 
 > disallow confusing `v-for` and `v-if` on the same element
 
-- :no_entry_sign: This rule was **removed** in eslint-plugin-vue v9.0.0 and replaced by [vue/no-use-v-if-with-v-for](no-use-v-if-with-v-for.md) rule.
+- :no_entry: This rule was **removed** in eslint-plugin-vue v9.0.0 and replaced by [vue/no-use-v-if-with-v-for](no-use-v-if-with-v-for.md) rule.
 
 ## :book: Rule Details
 

--- a/docs/rules/no-invalid-model-keys.md
+++ b/docs/rules/no-invalid-model-keys.md
@@ -9,7 +9,7 @@ since: v7.9.0
 
 > require valid keys in model option
 
-- :warning: This rule was **deprecated** and replaced by [vue/valid-model-definition](valid-model-definition.md) rule.
+- :no_entry_sign: This rule was **deprecated** and replaced by [vue/valid-model-definition](valid-model-definition.md) rule.
 
 ## :book: Rule Details
 

--- a/docs/rules/no-unregistered-components.md
+++ b/docs/rules/no-unregistered-components.md
@@ -9,7 +9,7 @@ since: v7.0.0
 
 > disallow using components that are not registered inside templates
 
-- :no_entry_sign: This rule was **removed** in eslint-plugin-vue v9.0.0 and replaced by [vue/no-undef-components](no-undef-components.md) rule.
+- :no_entry: This rule was **removed** in eslint-plugin-vue v9.0.0 and replaced by [vue/no-undef-components](no-undef-components.md) rule.
 
 ## :book: Rule Details
 

--- a/docs/rules/script-setup-uses-vars.md
+++ b/docs/rules/script-setup-uses-vars.md
@@ -9,7 +9,7 @@ since: v7.13.0
 
 > prevent `<script setup>` variables used in `<template>` to be marked as unused
 
-- :warning: This rule was **deprecated**.
+- :no_entry_sign: This rule was **deprecated**.
 
 ::: tip
 

--- a/docs/rules/v-on-function-call.md
+++ b/docs/rules/v-on-function-call.md
@@ -9,7 +9,7 @@ since: v5.2.0
 
 > enforce or forbid parentheses after method calls without arguments in `v-on` directives
 
-- :warning: This rule was **deprecated** and replaced by [vue/v-on-handler-style](v-on-handler-style.md) rule.
+- :no_entry_sign: This rule was **deprecated** and replaced by [vue/v-on-handler-style](v-on-handler-style.md) rule.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/tools/lib/categories.js
+++ b/tools/lib/categories.js
@@ -56,8 +56,6 @@ module.exports = categoryIds
   .map((categoryId) => ({
     categoryId,
     title: categoryTitles[categoryId],
-    rules: (categoryRules[categoryId] || []).filter(
-      (rule) => !rule.meta.deprecated
-    )
+    rules: categoryRules[categoryId] || []
   }))
   .filter((category) => category.rules.length > 0)

--- a/tools/update-docs-rules-index.js
+++ b/tools/update-docs-rules-index.js
@@ -15,10 +15,7 @@ const VUE2_EMOJI = ':two:'
 
 // -----------------------------------------------------------------------------
 const categorizedRules = rules.filter(
-  (rule) =>
-    rule.meta.docs.categories &&
-    !rule.meta.docs.extensionRule &&
-    !rule.meta.deprecated
+  (rule) => rule.meta.docs.categories && !rule.meta.docs.extensionRule
 )
 const uncategorizedRules = rules.filter(
   (rule) =>

--- a/tools/update-docs-rules-index.js
+++ b/tools/update-docs-rules-index.js
@@ -41,7 +41,7 @@ function toRuleRow(rule, kindMarks = []) {
   const mark = [
     rule.meta.fixable ? ':wrench:' : '',
     rule.meta.hasSuggestions ? ':bulb:' : '',
-    rule.meta.deprecated ? ':warning:' : ''
+    rule.meta.deprecated ? ':no_entry_sign:' : ''
   ].join('')
   const kindMark = [...kindMarks, TYPE_MARK[rule.meta.type]].join('')
   const link = `[${rule.ruleId}](./${rule.name}.md)`
@@ -222,7 +222,7 @@ if (deprecatedRules.length > 0) {
   rulesTableContent += `
 ## Deprecated
 
-- :warning: We're going to remove deprecated rules in the next major release. Please migrate to successor/new rules.
+- :no_entry_sign: We're going to remove deprecated rules in the next major release. Please migrate to successor/new rules.
 - :innocent: We don't fix bugs which are in deprecated rules since we don't have enough resources.
 
 | Rule ID | Replaced by |
@@ -235,7 +235,7 @@ ${deprecatedRules.map(toDeprecatedRuleRow).join('\n')}
 rulesTableContent += `
 ## Removed
 
-- :no_entry_sign: These rules have been removed in a previous major release, after they have been deprecated for a while.
+- :no_entry: These rules have been removed in a previous major release, after they have been deprecated for a while.
 
 | Rule ID | Replaced by | Deprecated in version  | Removed in version |
 |:--------|:------------|:-----------------------|:-------------------|

--- a/tools/update-docs.js
+++ b/tools/update-docs.js
@@ -13,7 +13,7 @@ For example:
 # rule description (vue/rule-name)
 
 - :gear: This rule is included in `"plugin:vue/strongly-recommended"` and `"plugin:vue/recommended"`.
-- :warning: This rule was **deprecated**.
+- :no_entry_sign: This rule was **deprecated**.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
 ```
 */
@@ -95,13 +95,13 @@ class DocFile {
           (name) => `[vue/${name}](${name}.md) rule`
         )
         notes.push(
-          `- :no_entry_sign: This rule was **removed** in eslint-plugin-vue ${
+          `- :no_entry: This rule was **removed** in eslint-plugin-vue ${
             meta.removedInVersion
           } and replaced by ${formatItems(replacedRules)}.`
         )
       } else {
         notes.push(
-          `- :no_entry_sign: This rule was **removed** in eslint-plugin-vue ${meta.removedInVersion}.`
+          `- :no_entry: This rule was **removed** in eslint-plugin-vue ${meta.removedInVersion}.`
         )
       }
     } else if (meta.deprecated) {
@@ -110,12 +110,12 @@ class DocFile {
           (name) => `[vue/${name}](${name}.md) rule`
         )
         notes.push(
-          `- :warning: This rule was **deprecated** and replaced by ${formatItems(
+          `- :no_entry_sign: This rule was **deprecated** and replaced by ${formatItems(
             replacedRules
           )}.`
         )
       } else {
-        notes.push(`- :warning: This rule was **deprecated**.`)
+        notes.push(`- :no_entry_sign: This rule was **deprecated**.`)
       }
     } else if (meta.docs.categories) {
       const presets = getPresetIds(meta.docs.categories).map(


### PR DESCRIPTION
Needed for https://github.com/vuejs/eslint-plugin-vue/pull/2222#issuecomment-1626900433. Note that this currently does not change any configs at all.

Also updates emojis in docs to distinguish rules with type "problem" and deprecated rules:

<table>
<tr>
 <th scope=col> Rule type
 <th scope=col> Previous emoji
 <th scope=col> New emoji
<tr>
 <td>Rules with type "problem"
 <td><code>:warning:</code> :warning:
 <td><code>:warning:</code> :warning: (no change)
<tr>
 <td>Deprecated rules
 <td><code>:warning:</code> :warning: 
 <td><code>:no_entry_sign:</code> :no_entry_sign: 
<tr>
 <td>Removed rules
 <td><code>:no_entry_sign:</code> :no_entry_sign: 
 <td><code>:no_entry:</code> :no_entry: 
</table>