### PR TITLE
Update VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,4 +14,8 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[javascript]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
     "editor.tabSize": 2,
-    "eslint.options": {
-        "rulePaths": ["eslint-internal-rules"]
-    },
+    "eslint.experimental.useFlatConfig": true,
     "eslint.validate": [
         "javascript",
         "javascriptreact",


### PR DESCRIPTION
Since this repo is using ESLint Flat Config (#2226), the VS Code ESLint plugin was not working correctly. This PR fixes that, and also enabled Prettier autosave in JavaScript files.