### PR TITLE
Set source type to `commonjs` to enable rule lint rules again

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,9 @@ module.exports = [
         ...globals.mocha
       }
     },
+    linterOptions: {
+      reportUnusedDisableDirectives: true
+    },
     rules: {
       'accessor-pairs': 2,
       camelcase: [2, { properties: 'never' }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,6 +49,7 @@ module.exports = [
     files: ['**/*.js'],
     languageOptions: {
       ecmaVersion: 'latest',
+      sourceType: 'commonjs',
       globals: {
         ...globals.es6,
         ...globals.node,

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('array-bracket-newline', {
   skipDynamicArguments: true
 })

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('array-bracket-spacing', {
   skipDynamicArguments: true
 })

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('array-element-newline', {
   skipDynamicArguments: true
 })

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -5,5 +5,5 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('arrow-spacing')

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('block-spacing', {
   skipDynamicArguments: true
 })

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('brace-style', {
   skipDynamicArguments: true
 })

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -5,5 +5,5 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('camelcase')

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -5,5 +5,5 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('comma-dangle')

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('comma-spacing', {
   skipDynamicArguments: true,
   skipDynamicArgumentsReport: true,

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('comma-style', {
   create(_context, { coreHandlers }) {
     return {

--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -5,5 +5,5 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('dot-location')

--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('dot-notation', {
   applyDocument: true
 })

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('eqeqeq', {
   applyDocument: true
 })

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('func-call-spacing', {
   skipDynamicArguments: true,
   applyDocument: true

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('key-spacing', {
   skipDynamicArguments: true
 })

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('keyword-spacing', {
   skipDynamicArguments: true
 })

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -6,7 +6,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('multiline-ternary', {
   skipDynamicArguments: true,
   applyDocument: true

--- a/lib/rules/no-console.js
+++ b/lib/rules/no-console.js
@@ -6,7 +6,7 @@
 
 const utils = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = utils.wrapCoreRule('no-console', {
   skipCoreHandlers: true,
   create(context) {

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -7,7 +7,7 @@ const { wrapCoreRule } = require('../utils')
 
 const conditionalDirectiveNames = new Set(['v-show', 'v-if', 'v-else-if'])
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('no-constant-condition', {
   create(_context, { coreHandlers }) {
     return {

--- a/lib/rules/no-empty-pattern.js
+++ b/lib/rules/no-empty-pattern.js
@@ -5,5 +5,5 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('no-empty-pattern')

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -7,7 +7,7 @@ const { isParenthesized } = require('@eslint-community/eslint-utils')
 const { wrapCoreRule } = require('../utils')
 const { getStyleVariablesContext } = require('../utils/style-variables')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('no-extra-parens', {
   skipDynamicArguments: true,
   applyDocument: true,

--- a/lib/rules/no-loss-of-precision.js
+++ b/lib/rules/no-loss-of-precision.js
@@ -6,7 +6,7 @@
 
 const utils = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = utils.wrapCoreRule('no-loss-of-precision', {
   applyDocument: true
 })

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('no-restricted-syntax', {
   applyDocument: true
 })

--- a/lib/rules/no-sparse-arrays.js
+++ b/lib/rules/no-sparse-arrays.js
@@ -5,5 +5,5 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('no-sparse-arrays')

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('no-useless-concat', {
   applyDocument: true
 })

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('object-curly-newline', {
   skipDynamicArguments: true
 })

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('object-curly-spacing', {
   skipDynamicArguments: true
 })

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('object-property-newline', {
   skipDynamicArguments: true
 })

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -6,7 +6,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('object-shorthand', {
   skipDynamicArguments: true
 })

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -5,5 +5,5 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('operator-linebreak')

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('prefer-template', {
   applyDocument: true
 })

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -6,7 +6,7 @@
 
 const { wrapCoreRule, flatten } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('quote-props', {
   skipDynamicArguments: true,
   preprocess(context, { wrapContextToOverrideProperties, defineVisitor }) {

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('space-in-parens', {
   skipDynamicArguments: true,
   skipDynamicArgumentsReport: true,

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('space-infix-ops', {
   skipDynamicArguments: true,
   applyDocument: true

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('space-unary-ops', {
   skipDynamicArguments: true,
   applyDocument: true

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -5,7 +5,7 @@
 
 const { wrapCoreRule } = require('../utils')
 
-// eslint-disable-next-line internal/no-invalid-meta, internal/no-invalid-meta-docs-categories
+// eslint-disable-next-line internal/no-invalid-meta
 module.exports = wrapCoreRule('template-curly-spacing', {
   skipDynamicArguments: true,
   applyDocument: true

--- a/lib/utils/indent-ts.js
+++ b/lib/utils/indent-ts.js
@@ -229,7 +229,6 @@ function defineVisitor({
     /**
      * @param {ASTNode} node
      */
-    // eslint-disable-next-line complexity -- ignore
     '*[type=/^TS/]'(node) {
       if (!isTypeNode(node)) {
         return


### PR DESCRIPTION
Another follow-up to #2226 to enable `eslint-plugin-eslint-plugin` rules again.