### PR TITLE
Bump `eslint-plugin-eslint-plugin` to v5

### DIFF
--- a/eslint-internal-rules/no-invalid-meta-docs-categories.js
+++ b/eslint-internal-rules/no-invalid-meta-docs-categories.js
@@ -104,6 +104,7 @@ function checkMetaValidity(context, exportsNode) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'enforce correct use of `meta` property in core rules',
       categories: ['Internal']

--- a/eslint-internal-rules/no-invalid-meta-docs-categories.js
+++ b/eslint-internal-rules/no-invalid-meta-docs-categories.js
@@ -56,7 +56,7 @@ function checkMetaValidity(context, exportsNode) {
   if (!categories) {
     context.report({
       node: metaDocs,
-      message: 'Rule is missing a meta.docs.categories property.',
+      messageId: 'missingCategories',
       fix(fixer) {
         const category = getPropertyFromObject('category', metaDocs.value)
         if (!category) {
@@ -98,7 +98,10 @@ function checkMetaValidity(context, exportsNode) {
       categories.value.name === 'undefined'
     )
   ) {
-    context.report(categories.value, 'meta.docs.categories must be an array.')
+    context.report({
+      node: categories.value,
+      messageId: 'categoriesMustBeArray'
+    })
   }
 }
 
@@ -110,7 +113,12 @@ module.exports = {
       categories: ['Internal']
     },
     fixable: 'code',
-    schema: []
+    schema: [],
+    messages: {
+      missingCategories: 'Rule is missing a meta.docs.categories property.',
+      // eslint-disable-next-line eslint-plugin/report-message-format
+      categoriesMustBeArray: 'meta.docs.categories must be an array.'
+    }
   },
 
   create(context) {

--- a/eslint-internal-rules/no-invalid-meta.js
+++ b/eslint-internal-rules/no-invalid-meta.js
@@ -87,11 +87,11 @@ function checkMetaValidity(context, exportsNode) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'enforce correct use of `meta` property in core rules',
       categories: ['Internal']
     },
-
     schema: []
   },
 

--- a/eslint-internal-rules/no-invalid-meta.js
+++ b/eslint-internal-rules/no-invalid-meta.js
@@ -67,20 +67,26 @@ function checkMetaValidity(context, exportsNode) {
   const metaProperty = getMetaPropertyFromExportsNode(exportsNode)
 
   if (!metaProperty) {
-    context.report(exportsNode, 'Rule is missing a meta property.')
+    context.report({
+      node: exportsNode,
+      messageId: 'missingMeta'
+    })
     return
   }
 
   if (!hasMetaDocs(metaProperty)) {
-    context.report(metaProperty, 'Rule is missing a meta.docs property.')
+    context.report({
+      node: 'metaDocs',
+      messageId: 'missingMetaDocs'
+    })
     return
   }
 
   if (!hasMetaDocsCategories(metaProperty)) {
-    context.report(
-      metaProperty,
-      'Rule is missing a meta.docs.categories property.'
-    )
+    context.report({
+      node: metaProperty,
+      messageId: 'missingMetaDocsCategories'
+    })
     return
   }
 }
@@ -92,7 +98,13 @@ module.exports = {
       description: 'enforce correct use of `meta` property in core rules',
       categories: ['Internal']
     },
-    schema: []
+    schema: [],
+    messages: {
+      missingMeta: 'Rule is missing a meta property.',
+      missingMetaDocs: 'Rule is missing a meta.docs property.',
+      missingMetaDocsCategories:
+        'Rule is missing a meta.docs.categories property.'
+    }
   },
 
   create(context) {

--- a/eslint-internal-rules/require-eslint-community.js
+++ b/eslint-internal-rules/require-eslint-community.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'enforce use of the `@eslint-community/*` package',
       categories: ['Internal']

--- a/eslint-internal-rules/require-eslint-community.js
+++ b/eslint-internal-rules/require-eslint-community.js
@@ -8,11 +8,11 @@ module.exports = {
       categories: ['Internal']
     },
     fixable: 'code',
+    schema: [],
     messages: {
       useCommunityPackageInstead:
         'Please use `@eslint-community/{{name}}` instead.'
-    },
-    schema: []
+    }
   },
 
   /** @param {import('eslint').Rule.RuleContext} context */

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,6 +145,7 @@ module.exports = [
       'eslint-plugin/report-message-format': ['error', "^[A-Z`'{].*\\.$"],
       'eslint-plugin/meta-property-ordering': 'error',
       'eslint-plugin/prefer-placeholders': 'error',
+      'eslint-plugin/prefer-replace-text': 'error',
       'eslint-plugin/test-case-property-ordering': 'error',
       'eslint-plugin/test-case-shorthand-strings': 'error',
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,6 +145,7 @@ module.exports = [
       'eslint-plugin/report-message-format': ['error', "^[A-Z`'{].*\\.$"],
       'eslint-plugin/prefer-placeholders': 'error',
       'eslint-plugin/test-case-property-ordering': 'error',
+      'eslint-plugin/test-case-shorthand-strings': 'error',
 
       'no-debugger': 'error',
       'no-console': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -143,6 +143,7 @@ module.exports = [
 
       'prettier/prettier': 'error',
       'eslint-plugin/report-message-format': ['error', "^[A-Z`'{].*\\.$"],
+      'eslint-plugin/meta-property-ordering': 'error',
       'eslint-plugin/prefer-placeholders': 'error',
       'eslint-plugin/test-case-property-ordering': 'error',
       'eslint-plugin/test-case-shorthand-strings': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,7 @@ module.exports = [
   },
   ...eslintrc.plugins('eslint-plugin', 'prettier', 'unicorn'),
   ...eslintrc.extends(
-    'plugin:eslint-plugin/recommended',
+    'plugin:eslint-plugin/all',
     'prettier',
     'plugin:node-dependencies/recommended',
     'plugin:jsonc/recommended-with-jsonc',
@@ -143,11 +143,6 @@ module.exports = [
 
       'prettier/prettier': 'error',
       'eslint-plugin/report-message-format': ['error', "^[A-Z`'{].*\\.$"],
-      'eslint-plugin/meta-property-ordering': 'error',
-      'eslint-plugin/prefer-placeholders': 'error',
-      'eslint-plugin/prefer-replace-text': 'error',
-      'eslint-plugin/test-case-property-ordering': 'error',
-      'eslint-plugin/test-case-shorthand-strings': 'error',
 
       'no-debugger': 'error',
       'no-console': 'error',
@@ -202,15 +197,18 @@ module.exports = [
   {
     files: ['lib/rules/*.js'],
     rules: {
-      'eslint-plugin/require-meta-docs-description': 'error',
       'eslint-plugin/require-meta-docs-url': [
         'error',
-        {
-          pattern: `https://eslint.vuejs.org/rules/{{name}}.html`
-        }
+        { pattern: 'https://eslint.vuejs.org/rules/{{name}}.html' }
       ],
       'internal/no-invalid-meta': 'error',
       'internal/no-invalid-meta-docs-categories': 'error'
+    }
+  },
+  {
+    files: ['eslint-internal-rules/*.js'],
+    rules: {
+      'eslint-plugin/require-meta-docs-url': 'off'
     }
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -144,6 +144,7 @@ module.exports = [
       'prettier/prettier': 'error',
       'eslint-plugin/report-message-format': ['error', "^[A-Z`'{].*\\.$"],
       'eslint-plugin/prefer-placeholders': 'error',
+      'eslint-plugin/test-case-property-ordering': 'error',
 
       'no-debugger': 'error',
       'no-console': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -144,7 +144,6 @@ module.exports = [
       'prettier/prettier': 'error',
       'eslint-plugin/report-message-format': ['error', "^[A-Z`'{].*\\.$"],
       'eslint-plugin/prefer-placeholders': 'error',
-      'eslint-plugin/consistent-output': 'error',
 
       'no-debugger': 'error',
       'no-console': 'error',
@@ -199,9 +198,6 @@ module.exports = [
   {
     files: ['lib/rules/*.js'],
     rules: {
-      'eslint-plugin/no-deprecated-context-methods': 'error',
-      'eslint-plugin/no-only-tests': 'error',
-      'eslint-plugin/prefer-object-rule': 'error',
       'eslint-plugin/require-meta-docs-description': 'error',
       'eslint-plugin/require-meta-docs-url': [
         'error',
@@ -209,9 +205,6 @@ module.exports = [
           pattern: `https://eslint.vuejs.org/rules/{{name}}.html`
         }
       ],
-      'eslint-plugin/require-meta-has-suggestions': 'error',
-      'eslint-plugin/require-meta-schema': 'error',
-      'eslint-plugin/require-meta-type': 'error',
       'internal/no-invalid-meta': 'error',
       'internal/no-invalid-meta-docs-categories': 'error'
     }

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -60,7 +60,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      mustBeHyphenated: "Attribute '{{text}}' must be hyphenated.",
+      cannotBeHyphenated: "Attribute '{{text}}' can't be hyphenated."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -88,9 +92,7 @@ module.exports = {
       context.report({
         node: node.key,
         loc: node.loc,
-        message: useHyphenated
-          ? "Attribute '{{text}}' must be hyphenated."
-          : "Attribute '{{text}}' can't be hyphenated.",
+        messageId: useHyphenated ? 'mustBeHyphenated' : 'cannotBeHyphenated',
         data: {
           text
         },

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -277,9 +277,10 @@ function create(context) {
     const prevNode = sourceCode.getText(previousNode.key)
     context.report({
       node,
-      message: `Attribute "${currentNode}" should go before "${prevNode}".`,
+      messageId: 'expectedOrder',
       data: {
-        currentNode
+        currentNode,
+        prevNode
       },
 
       fix(fixer) {
@@ -439,7 +440,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      expectedOrder: `Attribute "{{currentNode}}" should go before "{{prevNode}}".`
+    }
   },
   create
 }

--- a/lib/rules/block-tag-newline.js
+++ b/lib/rules/block-tag-newline.js
@@ -72,8 +72,6 @@ module.exports = {
     messages: {
       unexpectedOpeningLinebreak:
         "There should be no line break after '<{{tag}}>'.",
-      unexpectedClosingLinebreak:
-        "There should be no line break before '</{{tag}}>'.",
       expectedOpeningLinebreak:
         "Expected {{expected}} after '<{{tag}}>', but {{actual}} found.",
       expectedClosingLinebreak:

--- a/lib/rules/component-definition-name-casing.js
+++ b/lib/rules/component-definition-name-casing.js
@@ -34,7 +34,10 @@ module.exports = {
       {
         enum: allowedCaseOptions
       }
-    ]
+    ],
+    messages: {
+      incorrectCase: 'Property name "{{value}}" is not {{caseType}}.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -63,7 +66,7 @@ module.exports = {
       if (!casing.getChecker(caseType)(nodeValue)) {
         context.report({
           node,
-          message: 'Property name "{{value}}" is not {{caseType}}.',
+          messageId: 'incorrectCase',
           data: {
             value: nodeValue,
             caseType

--- a/lib/rules/component-definition-name-casing.js
+++ b/lib/rules/component-definition-name-casing.js
@@ -29,7 +29,7 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/component-definition-name-casing.html'
     },
-    fixable: 'code', // or "code" or "whitespace"
+    fixable: 'code',
     schema: [
       {
         enum: allowedCaseOptions

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -69,7 +69,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      incorrectCase: 'Component name "{{name}}" is not {{caseType}}.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -156,7 +159,7 @@ module.exports = {
             context.report({
               node: open,
               loc: open.loc,
-              message: 'Component name "{{name}}" is not {{caseType}}.',
+              messageId: 'incorrectCase',
               data: {
                 name,
                 caseType

--- a/lib/rules/define-emits-declaration.js
+++ b/lib/rules/define-emits-declaration.js
@@ -15,15 +15,15 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/define-emits-declaration.html'
     },
     fixable: null,
-    messages: {
-      hasArg: 'Use type-based declaration instead of runtime declaration.',
-      hasTypeArg: 'Use runtime declaration instead of type-based declaration.'
-    },
     schema: [
       {
         enum: ['type-based', 'runtime']
       }
-    ]
+    ],
+    messages: {
+      hasArg: 'Use type-based declaration instead of runtime declaration.',
+      hasTypeArg: 'Use runtime declaration instead of type-based declaration.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/define-props-declaration.js
+++ b/lib/rules/define-props-declaration.js
@@ -15,15 +15,15 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/define-props-declaration.html'
     },
     fixable: null,
-    messages: {
-      hasArg: 'Use type-based declaration instead of runtime declaration.',
-      hasTypeArg: 'Use runtime declaration instead of type-based declaration.'
-    },
     schema: [
       {
         enum: ['type-based', 'runtime']
       }
-    ]
+    ],
+    messages: {
+      hasArg: 'Use type-based declaration instead of runtime declaration.',
+      hasTypeArg: 'Use runtime declaration instead of type-based declaration.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/first-attribute-linebreak.js
+++ b/lib/rules/first-attribute-linebreak.js
@@ -14,7 +14,7 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/first-attribute-linebreak.html'
     },
-    fixable: 'whitespace', // or "code" or "whitespace"
+    fixable: 'whitespace',
     schema: [
       {
         type: 'object',

--- a/lib/rules/html-closing-bracket-newline.js
+++ b/lib/rules/html-closing-bracket-newline.js
@@ -40,7 +40,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      expectedBeforeClosingBracket:
+        'Expected {{expected}} before closing bracket, but {{actual}} found.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -83,8 +87,7 @@ module.exports = {
               start: prevToken.loc.end,
               end: closingBracketToken.loc.start
             },
-            message:
-              'Expected {{expected}} before closing bracket, but {{actual}} found.',
+            messageId: 'expectedBeforeClosingBracket',
             data: {
               expected: getPhrase(expectedLineBreaks),
               actual: getPhrase(actualLineBreaks)

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -70,7 +70,11 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    fixable: 'whitespace'
+    fixable: 'whitespace',
+    messages: {
+      missing: "Expected a space before '{{bracket}}', but not found.",
+      unexpected: "Expected no space before '{{bracket}}', but found."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -102,7 +106,7 @@ module.exports = {
           context.report({
             node,
             loc: lastToken.loc,
-            message: "Expected a space before '{{bracket}}', but not found.",
+            messageId: 'missing',
             data: { bracket: sourceCode.getText(lastToken) },
             fix: (fixer) => fixer.insertTextBefore(lastToken, ' ')
           })
@@ -113,7 +117,7 @@ module.exports = {
               start: prevToken.loc.end,
               end: lastToken.loc.end
             },
-            message: "Expected no space before '{{bracket}}', but found.",
+            messageId: 'unexpected',
             data: { bracket: sourceCode.getText(lastToken) },
             fix: (fixer) =>
               fixer.removeRange([prevToken.range[1], lastToken.range[0]])

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -59,6 +59,7 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/html-closing-bracket-spacing.html'
     },
+    fixable: 'whitespace',
     schema: [
       {
         type: 'object',
@@ -70,7 +71,6 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    fixable: 'whitespace',
     messages: {
       missing: "Expected a space before '{{bracket}}', but not found.",
       unexpected: "Expected no space before '{{bracket}}', but found."

--- a/lib/rules/html-end-tags.js
+++ b/lib/rules/html-end-tags.js
@@ -16,7 +16,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/html-end-tags.html'
     },
     fixable: 'code',
-    schema: []
+    schema: [],
+    messages: {
+      missingEndTag: "'<{{name}}>' should have end tag."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -39,7 +42,7 @@ module.exports = {
             context.report({
               node: node.startTag,
               loc: node.startTag.loc,
-              message: "'<{{name}}>' should have end tag.",
+              messageId: 'missingEndTag',
               data: { name },
               fix: (fixer) => fixer.insertTextAfter(node, `</${name}>`)
             })

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -20,6 +20,7 @@ module.exports = {
 
     return utils.defineTemplateBodyVisitor(context, visitor)
   },
+  // eslint-disable-next-line eslint-plugin/prefer-message-ids
   meta: {
     type: 'layout',
     docs: {

--- a/lib/rules/html-quotes.js
+++ b/lib/rules/html-quotes.js
@@ -27,7 +27,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      expected: 'Expected to be enclosed by {{kind}}.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -63,7 +66,7 @@ module.exports = {
             context.report({
               node: node.value,
               loc: node.value.loc,
-              message: 'Expected to be enclosed by {{kind}}.',
+              messageId: 'expected',
               data: { kind: quoteName },
               fix(fixer) {
                 const contentText = quoted ? text.slice(1, -1) : text

--- a/lib/rules/html-self-closing.js
+++ b/lib/rules/html-self-closing.js
@@ -119,6 +119,12 @@ module.exports = {
         }
       ],
       maxItems: 1
+    },
+    messages: {
+      requireSelfClosing:
+        'Require self-closing on {{elementType}} (<{{name}}>).',
+      disallowSelfClosing:
+        'Disallow self-closing on {{elementType}} (<{{name}}/>).'
     }
   },
   /** @param {RuleContext} context */
@@ -146,7 +152,7 @@ module.exports = {
             context.report({
               node,
               loc: node.loc,
-              message: 'Require self-closing on {{elementType}} (<{{name}}>).',
+              messageId: 'requireSelfClosing',
               data: {
                 elementType: ELEMENT_TYPE_MESSAGES[elementType],
                 name: node.rawName
@@ -170,8 +176,7 @@ module.exports = {
             context.report({
               node,
               loc: node.loc,
-              message:
-                'Disallow self-closing on {{elementType}} (<{{name}}/>).',
+              messageId: 'disallowSelfClosing',
               data: {
                 elementType: ELEMENT_TYPE_MESSAGES[elementType],
                 name: node.rawName

--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -31,6 +31,7 @@ SOFTWARE.
 'use strict'
 
 module.exports = {
+  // eslint-disable-next-line eslint-plugin/prefer-message-ids
   meta: {
     type: 'problem',
     docs: {

--- a/lib/rules/match-component-file-name.js
+++ b/lib/rules/match-component-file-name.js
@@ -23,7 +23,6 @@ function canVerify(node) {
 
 module.exports = {
   meta: {
-    // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions
     hasSuggestions: true,
     type: 'suggestion',
     docs: {

--- a/lib/rules/match-component-file-name.js
+++ b/lib/rules/match-component-file-name.js
@@ -23,7 +23,6 @@ function canVerify(node) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'require component name property to match its file name',
@@ -31,6 +30,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/match-component-file-name.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',

--- a/lib/rules/match-component-file-name.js
+++ b/lib/rules/match-component-file-name.js
@@ -49,7 +49,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      shouldMatchFileName:
+        'Component name `{{name}}` should match file name `{{filename}}`.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -101,8 +105,7 @@ module.exports = {
       if (!compareNames(name, filename)) {
         errors.push({
           node,
-          message:
-            'Component name `{{name}}` should match file name `{{filename}}`.',
+          messageId: 'shouldMatchFileName',
           data: { filename, name },
           suggest: [
             {

--- a/lib/rules/match-component-import-name.js
+++ b/lib/rules/match-component-import-name.js
@@ -18,7 +18,6 @@ function getExpectedNames(identifier) {
 module.exports = {
   meta: {
     type: 'problem',
-    schema: [],
     docs: {
       description:
         'require the registered component name to match the imported component name',
@@ -26,6 +25,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/match-component-import-name.html'
     },
     fixable: null,
+    schema: [],
     messages: {
       unexpected:
         'Component alias {{importedName}} should be one of: {{expectedName}}.'

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -112,7 +112,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      shouldBeOnNewLine: "'{{name}}' should be on a new line."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -155,7 +158,7 @@ module.exports = {
         context.report({
           node: prop,
           loc: prop.loc,
-          message: "'{{name}}' should be on a new line.",
+          messageId: 'shouldBeOnNewLine',
           data: { name: sourceCode.getText(prop.key) },
           fix(fixer) {
             if (i !== 0) return null

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -68,7 +68,7 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/max-attributes-per-line.html'
     },
-    fixable: 'whitespace', // or "code" or "whitespace"
+    fixable: 'whitespace',
     schema: [
       {
         type: 'object',

--- a/lib/rules/mustache-interpolation-spacing.js
+++ b/lib/rules/mustache-interpolation-spacing.js
@@ -19,7 +19,13 @@ module.exports = {
       {
         enum: ['always', 'never']
       }
-    ]
+    ],
+    messages: {
+      expectedSpaceAfter: "Expected 1 space after '{{', but not found.",
+      expectedSpaceBefore: "Expected 1 space before '}}', but not found.",
+      unexpectedSpaceAfter: "Expected no space after '{{', but found.",
+      unexpectedSpaceBefore: "Expected no space before '}}', but found."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -54,14 +60,14 @@ module.exports = {
           if (openBrace.range[1] === firstToken.range[0]) {
             context.report({
               node: openBrace,
-              message: "Expected 1 space after '{{', but not found.",
+              messageId: 'expectedSpaceAfter',
               fix: (fixer) => fixer.insertTextAfter(openBrace, ' ')
             })
           }
           if (closeBrace.range[0] === lastToken.range[1]) {
             context.report({
               node: closeBrace,
-              message: "Expected 1 space before '}}', but not found.",
+              messageId: 'expectedSpaceBefore',
               fix: (fixer) => fixer.insertTextBefore(closeBrace, ' ')
             })
           }
@@ -72,7 +78,7 @@ module.exports = {
                 start: openBrace.loc.start,
                 end: firstToken.loc.start
               },
-              message: "Expected no space after '{{', but found.",
+              messageId: 'unexpectedSpaceAfter',
               fix: (fixer) =>
                 fixer.removeRange([openBrace.range[1], firstToken.range[0]])
             })
@@ -83,7 +89,7 @@ module.exports = {
                 start: lastToken.loc.end,
                 end: closeBrace.loc.end
               },
-              message: "Expected no space before '}}', but found.",
+              messageId: 'unexpectedSpaceBefore',
               fix: (fixer) =>
                 fixer.removeRange([lastToken.range[1], closeBrace.range[0]])
             })

--- a/lib/rules/new-line-between-multi-line-property.js
+++ b/lib/rules/new-line-between-multi-line-property.js
@@ -54,7 +54,7 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/new-line-between-multi-line-property.html'
     },
-    fixable: 'whitespace', // or "code" or "whitespace"
+    fixable: 'whitespace',
     schema: [
       {
         type: 'object',

--- a/lib/rules/new-line-between-multi-line-property.js
+++ b/lib/rules/new-line-between-multi-line-property.js
@@ -67,7 +67,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      missingEmptyLine:
+        'Enforce new lines between multi-line properties in Vue components.'
+    }
   },
 
   /** @param {RuleContext} context */
@@ -121,8 +125,7 @@ module.exports = {
                 start: pre.loc.end,
                 end: cur.loc.start
               },
-              message:
-                'Enforce new lines between multi-line properties in Vue components.',
+              messageId: 'missingEmptyLine',
               fix(fixer) {
                 /** @type {Token|null} */
                 let preToken = null

--- a/lib/rules/next-tick-style.js
+++ b/lib/rules/next-tick-style.js
@@ -85,7 +85,13 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/next-tick-style.html'
     },
     fixable: 'code',
-    schema: [{ enum: ['promise', 'callback'] }]
+    schema: [{ enum: ['promise', 'callback'] }],
+    messages: {
+      usePromise:
+        'Use the Promise returned by `nextTick` instead of passing a callback function.',
+      useCallback:
+        'Pass a callback function to `nextTick` instead of using the returned Promise.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -107,8 +113,7 @@ module.exports = {
           ) {
             context.report({
               node,
-              message:
-                'Pass a callback function to `nextTick` instead of using the returned Promise.'
+              messageId: 'useCallback'
             })
           }
 
@@ -121,8 +126,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message:
-              'Use the Promise returned by `nextTick` instead of passing a callback function.',
+            messageId: 'usePromise',
             fix(fixer) {
               return fixer.insertTextAfter(node, '().then')
             }

--- a/lib/rules/no-arrow-functions-in-watch.js
+++ b/lib/rules/no-arrow-functions-in-watch.js
@@ -14,7 +14,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-arrow-functions-in-watch.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      noArrowFunctionsInWatch:
+        'You should not use an arrow function to define a watcher.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -36,8 +40,7 @@ module.exports = {
           if (handler.type === 'ArrowFunctionExpression') {
             context.report({
               node: handler,
-              message:
-                'You should not use an arrow function to define a watcher.'
+              messageId: 'noArrowFunctionsInWatch'
             })
           }
         }

--- a/lib/rules/no-async-in-computed-properties.js
+++ b/lib/rules/no-async-in-computed-properties.js
@@ -85,7 +85,13 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-async-in-computed-properties.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      unexpectedInFunction:
+        'Unexpected {{expressionName}} in computed function.',
+      unexpectedInProperty:
+        'Unexpected {{expressionName}} in "{{propertyName}}" computed property.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -151,8 +157,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message:
-              'Unexpected {{expressionName}} in "{{propertyName}}" computed property.',
+            messageId: 'unexpectedInProperty',
             data: {
               expressionName: expressionTypes[type],
               propertyName: cp.key || 'unknown'
@@ -170,7 +175,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: 'Unexpected {{expressionName}} in computed function.',
+            messageId: 'unexpectedInFunction',
             data: {
               expressionName: expressionTypes[type]
             }

--- a/lib/rules/no-boolean-default.js
+++ b/lib/rules/no-boolean-default.js
@@ -43,7 +43,12 @@ module.exports = {
       {
         enum: ['default-false', 'no-default']
       }
-    ]
+    ],
+    messages: {
+      noBooleanDefault:
+        'Boolean prop should not set a default (Vue defaults it to false).',
+      defaultFalse: 'Boolean prop should only be defaulted to false.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -95,8 +100,7 @@ module.exports = {
         case 'no-default':
           context.report({
             node: defaultNode,
-            message:
-              'Boolean prop should not set a default (Vue defaults it to false).'
+            messageId: 'noBooleanDefault'
           })
           break
 
@@ -104,7 +108,7 @@ module.exports = {
           if (defaultNode.type !== 'Literal' || defaultNode.value !== false) {
             context.report({
               node: defaultNode,
-              message: 'Boolean prop should only be defaulted to false.'
+              messageId: 'defaultFalse'
             })
           }
           break

--- a/lib/rules/no-child-content.js
+++ b/lib/rules/no-child-content.js
@@ -70,7 +70,6 @@ function getLocationRange(nodes) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'problem',
     docs: {
       description:
@@ -79,6 +78,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-child-content.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-child-content.js
+++ b/lib/rules/no-child-content.js
@@ -95,7 +95,12 @@ module.exports = {
         },
         required: ['additionalDirectives']
       }
-    ]
+    ],
+    messages: {
+      disallowedChildContent:
+        'Child content is disallowed because it will be overwritten by the v-{{ directiveName }} directive.',
+      removeChildContent: 'Remove child content.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -138,12 +143,11 @@ module.exports = {
           context.report({
             node: elementNode,
             loc: getLocationRange(childNodes),
-            message:
-              'Child content is disallowed because it will be overwritten by the v-{{ directiveName }} directive.',
+            messageId: 'disallowedChildContent',
             data: { directiveName },
             suggest: [
               {
-                desc: 'Remove child content.',
+                messageId: 'removeChildContent',
                 *fix(fixer) {
                   for (const childNode of childNodes) {
                     yield fixer.remove(childNode)

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -66,7 +66,7 @@ module.exports = {
       categories: ['vue3-essential', 'essential'],
       url: 'https://eslint.vuejs.org/rules/no-dupe-keys.html'
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -77,7 +77,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      duplicatedKey: "Duplicated key '{{name}}'."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -93,7 +96,7 @@ module.exports = {
           if (usedNames.has(o.name)) {
             context.report({
               node: o.node,
-              message: "Duplicated key '{{name}}'.",
+              messageId: 'duplicatedKey',
               data: {
                 name: o.name
               }
@@ -128,7 +131,7 @@ module.exports = {
 
             context.report({
               node: variable.defs[0].node,
-              message: "Duplicated key '{{name}}'.",
+              messageId: 'duplicatedKey',
               data: {
                 name: prop.propName
               }

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -17,9 +17,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html'
     },
     fixable: null,
-    schema: [
-      // fill in your schema
-    ]
+    schema: []
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -17,7 +17,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      noDuplicateAttrInheritance: 'Set "inheritAttrs" to false.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -62,7 +65,7 @@ module.exports = {
           if (attrsRef) {
             context.report({
               node: attrsRef.id,
-              message: 'Set "inheritAttrs" to false.'
+              messageId: 'noDuplicateAttrInheritance'
             })
           }
         }

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -50,7 +50,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      duplicateAttribute: "Duplicate attribute '{{name}}'."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -92,7 +95,7 @@ module.exports = {
           context.report({
             node,
             loc: node.loc,
-            message: "Duplicate attribute '{{name}}'.",
+            messageId: 'duplicateAttribute',
             data: { name }
           })
         }

--- a/lib/rules/no-invalid-model-keys.js
+++ b/lib/rules/no-invalid-model-keys.js
@@ -3,6 +3,7 @@
 const baseRule = require('./valid-model-definition')
 
 module.exports = {
+  // eslint-disable-next-line eslint-plugin/prefer-message-ids
   meta: {
     ...baseRule.meta,
     type: baseRule.meta.type,

--- a/lib/rules/no-invalid-model-keys.js
+++ b/lib/rules/no-invalid-model-keys.js
@@ -6,15 +6,16 @@ module.exports = {
   // eslint-disable-next-line eslint-plugin/prefer-message-ids
   meta: {
     ...baseRule.meta,
+    // eslint-disable-next-line eslint-plugin/meta-property-ordering
     type: baseRule.meta.type,
     docs: {
       description: baseRule.meta.docs.description,
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-invalid-model-keys.html'
     },
+    schema: [],
     deprecated: true,
-    replacedBy: ['valid-model-definition'],
-    schema: []
+    replacedBy: ['valid-model-definition']
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -34,7 +34,12 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      multipleSpaces: "Multiple spaces found before '{{displayValue}}'.",
+      useLatestParser:
+        'Use the latest vue-eslint-parser. See also https://eslint.vuejs.org/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error.'
+    }
   },
 
   /**
@@ -52,8 +57,7 @@ module.exports = {
           if (path.extname(filename) === '.vue') {
             context.report({
               loc: { line: 1, column: 0 },
-              message:
-                'Use the latest vue-eslint-parser. See also https://eslint.vuejs.org/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error.'
+              messageId: 'useLatestParser'
             })
           }
           return
@@ -84,7 +88,7 @@ module.exports = {
                 start: prevToken.loc.end,
                 end: token.loc.start
               },
-              message: "Multiple spaces found before '{{displayValue}}'.",
+              messageId: 'multipleSpaces',
               fix: (fixer) =>
                 fixer.replaceTextRange(
                   [prevToken.range[1], token.range[0]],

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -23,7 +23,7 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/no-multi-spaces.html'
     },
-    fixable: 'whitespace', // or "code" or "whitespace"
+    fixable: 'whitespace',
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-multiple-template-root.js
+++ b/lib/rules/no-multiple-template-root.js
@@ -15,7 +15,13 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-multiple-template-root.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      multipleRoot: 'The template root requires exactly one element.',
+      textRoot: 'The template root requires an element rather than texts.',
+      disallowedElement: "The template root disallows '<{{name}}>' elements.",
+      disallowedDirective: "The template root disallows 'v-for' directives."
+    }
   },
   /**
    * @param {RuleContext} context - The rule context.
@@ -57,13 +63,13 @@ module.exports = {
           context.report({
             node: extraText,
             loc: extraText.loc,
-            message: 'The template root requires an element rather than texts.'
+            messageId: 'textRoot'
           })
         } else if (extraElement != null) {
           context.report({
             node: extraElement,
             loc: extraElement.loc,
-            message: 'The template root requires exactly one element.'
+            messageId: 'multipleRoot'
           })
         } else {
           for (const element of rootElements) {
@@ -74,7 +80,7 @@ module.exports = {
               context.report({
                 node: tag,
                 loc: tag.loc,
-                message: "The template root disallows '<{{name}}>' elements.",
+                messageId: 'disallowedElement',
                 data: { name }
               })
             }
@@ -82,7 +88,7 @@ module.exports = {
               context.report({
                 node: tag,
                 loc: tag.loc,
-                message: "The template root disallows 'v-for' directives."
+                messageId: 'disallowedDirective'
               })
             }
           }

--- a/lib/rules/no-mutating-props.js
+++ b/lib/rules/no-mutating-props.js
@@ -109,7 +109,7 @@ module.exports = {
       categories: ['vue3-essential', 'essential'],
       url: 'https://eslint.vuejs.org/rules/no-mutating-props.html'
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-mutating-props.js
+++ b/lib/rules/no-mutating-props.js
@@ -120,7 +120,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      unexpectedMutation: 'Unexpected mutation of "{{key}}" prop.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -137,7 +140,7 @@ module.exports = {
     function report(node, name) {
       context.report({
         node,
-        message: 'Unexpected mutation of "{{key}}" prop.',
+        messageId: 'unexpectedMutation',
         data: {
           key: name
         }

--- a/lib/rules/no-parsing-error.js
+++ b/lib/rules/no-parsing-error.js
@@ -67,7 +67,10 @@ module.exports = {
         ),
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      parsingError: 'Parsing error: {{message}}.'
+    }
   },
   /**
    * @param {RuleContext} context - The rule context.
@@ -91,7 +94,7 @@ module.exports = {
           context.report({
             node,
             loc: { line: error.lineNumber, column: error.column },
-            message: 'Parsing error: {{message}}.',
+            messageId: 'parsingError',
             data: {
               message: error.message.endsWith('.')
                 ? error.message.slice(0, -1)

--- a/lib/rules/no-potential-component-option-typo.js
+++ b/lib/rules/no-potential-component-option-typo.js
@@ -8,7 +8,6 @@ const utils = require('../utils')
 const vueComponentOptions = require('../utils/vue-component-options.json')
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'disallow a potential typo in your component property',
@@ -17,6 +16,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-potential-component-option-typo.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-potential-component-option-typo.js
+++ b/lib/rules/no-potential-component-option-typo.js
@@ -43,7 +43,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      potentialTypo: `'{{name}}' may be a typo, which is similar to option [{{option}}].`
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -103,7 +106,7 @@ module.exports = {
         if (potentialTypoList.length > 0) {
           context.report({
             node: id,
-            message: `'{{name}}' may be a typo, which is similar to option [{{option}}].`,
+            messageId: 'potentialTypo',
             data: {
               name,
               option: potentialTypoList.map(({ option }) => option).join(',')

--- a/lib/rules/no-required-prop-with-default.js
+++ b/lib/rules/no-required-prop-with-default.js
@@ -14,7 +14,6 @@ const utils = require('../utils')
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'problem',
     docs: {
       description: 'enforce props with default values to be optional',
@@ -22,6 +21,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-required-prop-with-default.html'
     },
     fixable: 'code',
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-restricted-class.js
+++ b/lib/rules/no-restricted-class.js
@@ -110,14 +110,14 @@ module.exports = {
       categories: undefined
     },
     fixable: null,
-    messages: {
-      forbiddenClass: "'{{class}}' class is not allowed."
-    },
     schema: {
       type: 'array',
       items: {
         type: 'string'
       }
+    },
+    messages: {
+      forbiddenClass: "'{{class}}' class is not allowed."
     }
   },
 

--- a/lib/rules/no-restricted-component-names.js
+++ b/lib/rules/no-restricted-component-names.js
@@ -68,7 +68,6 @@ function createSuggest(property, suggest) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'disallow specific component names',
@@ -76,6 +75,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-restricted-component-names.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: {
       type: 'array',
       items: {

--- a/lib/rules/no-restricted-custom-event.js
+++ b/lib/rules/no-restricted-custom-event.js
@@ -88,7 +88,6 @@ function getCalleeMemberNode(node) {
 }
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'disallow specific custom event',
@@ -96,6 +95,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-restricted-custom-event.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: {
       type: 'array',
       items: {

--- a/lib/rules/no-restricted-html-elements.js
+++ b/lib/rules/no-restricted-html-elements.js
@@ -33,6 +33,11 @@ module.exports = {
       },
       uniqueItems: true,
       minItems: 0
+    },
+    messages: {
+      forbiddenElement: 'Unexpected use of forbidden HTML element {{name}}.',
+      // eslint-disable-next-line eslint-plugin/report-message-format
+      customMessage: '{{message}}'
     }
   },
   /**
@@ -50,14 +55,15 @@ module.exports = {
         }
 
         for (const option of context.options) {
-          const message =
-            option.message ||
-            `Unexpected use of forbidden HTML element ${node.rawName}.`
           const element = option.element || option
 
           if (element === node.rawName) {
             context.report({
-              message,
+              messageId: option.message ? 'customMessage' : 'forbiddenElement',
+              data: {
+                name: node.rawName,
+                message: option.message
+              },
               node: node.startTag
             })
           }

--- a/lib/rules/no-restricted-props.js
+++ b/lib/rules/no-restricted-props.js
@@ -53,7 +53,6 @@ function parseOption(option) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'disallow specific props',
@@ -61,6 +60,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-restricted-props.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: {
       type: 'array',
       items: {

--- a/lib/rules/no-root-v-if.js
+++ b/lib/rules/no-root-v-if.js
@@ -16,7 +16,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-root-v-if.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      noRootVIf: '`v-if` should not be used on root element without `v-else`.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -36,8 +39,7 @@ module.exports = {
           context.report({
             node: element,
             loc: element.loc,
-            message:
-              '`v-if` should not be used on root element without `v-else`.'
+            messageId: 'noRootVIf'
           })
         }
       }

--- a/lib/rules/no-shared-component-data.js
+++ b/lib/rules/no-shared-component-data.js
@@ -46,7 +46,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-shared-component-data.html'
     },
     fixable: 'code',
-    schema: []
+    schema: [],
+    messages: {
+      dataPropertyMustBeFunction:
+        '`data` property in component must be a function.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -64,7 +68,7 @@ module.exports = {
       if (invalidData) {
         context.report({
           node: invalidData,
-          message: '`data` property in component must be a function.',
+          messageId: 'dataPropertyMustBeFunction',
           fix(fixer) {
             const tokens = getFirstAndLastTokens(invalidData.value, sourceCode)
 

--- a/lib/rules/no-side-effects-in-computed-properties.js
+++ b/lib/rules/no-side-effects-in-computed-properties.js
@@ -24,7 +24,13 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-side-effects-in-computed-properties.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      unexpectedSideEffectInFunction:
+        'Unexpected side effect in computed function.',
+      unexpectedSideEffectInProperty:
+        'Unexpected side effect in "{{key}}" computed property.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -102,7 +108,7 @@ module.exports = {
           if (invalid) {
             context.report({
               node: invalid.node,
-              message: 'Unexpected side effect in "{{key}}" computed property.',
+              messageId: 'unexpectedSideEffectInProperty',
               data: { key: computedProperty.key || 'Unknown' }
             })
           }
@@ -163,7 +169,7 @@ module.exports = {
         if (invalid) {
           context.report({
             node: invalid.node,
-            message: 'Unexpected side effect in computed function.'
+            messageId: 'unexpectedSideEffectInFunction'
           })
         }
       }

--- a/lib/rules/no-spaces-around-equal-signs-in-attribute.js
+++ b/lib/rules/no-spaces-around-equal-signs-in-attribute.js
@@ -15,7 +15,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-spaces-around-equal-signs-in-attribute.html'
     },
     fixable: 'whitespace',
-    schema: []
+    schema: [],
+    messages: {
+      unexpectedSpaces: 'Unexpected spaces found around equal signs.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -37,8 +40,7 @@ module.exports = {
               start: node.key.loc.end,
               end: node.value.loc.start
             },
-            message: 'Unexpected spaces found around equal signs.',
-            data: {},
+            messageId: 'unexpectedSpaces',
             fix: (fixer) => fixer.replaceTextRange(range, expect)
           })
         }

--- a/lib/rules/no-template-shadow.js
+++ b/lib/rules/no-template-shadow.js
@@ -30,7 +30,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-template-shadow.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      alreadyDeclaredInUpperScope:
+        "Variable '{{name}}' is already declared in the upper scope."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -105,8 +109,7 @@ module.exports = {
               context.report({
                 node: varNode,
                 loc: varNode.loc,
-                message:
-                  "Variable '{{name}}' is already declared in the upper scope.",
+                messageId: 'alreadyDeclaredInUpperScope',
                 data: {
                   name
                 }

--- a/lib/rules/no-template-target-blank.js
+++ b/lib/rules/no-template-target-blank.js
@@ -116,7 +116,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      missingRel:
+        'Using target="_blank" without rel="noopener noreferrer" is a security risk.'
+    }
   },
 
   /**
@@ -144,8 +148,7 @@ module.exports = {
         if (hasDangerHref) {
           context.report({
             node,
-            message:
-              'Using target="_blank" without rel="noopener noreferrer" is a security risk.',
+            messageId: 'missingRel',
             suggest: [getSuggestion(node)]
           })
         }

--- a/lib/rules/no-textarea-mustache.js
+++ b/lib/rules/no-textarea-mustache.js
@@ -16,7 +16,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-textarea-mustache.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      unexpected: "Unexpected mustache. Use 'v-model' instead."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -30,7 +33,7 @@ module.exports = {
         context.report({
           node,
           loc: node.loc,
-          message: "Unexpected mustache. Use 'v-model' instead."
+          messageId: 'unexpected'
         })
       }
     })

--- a/lib/rules/no-unused-components.js
+++ b/lib/rules/no-unused-components.js
@@ -27,7 +27,10 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      unused: 'The "{{name}}" component has been registered but not used.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -124,8 +127,7 @@ module.exports = {
 
             context.report({
               node,
-              message:
-                'The "{{name}}" component has been registered but not used.',
+              messageId: 'unused',
               data: {
                 name
               }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -70,7 +70,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      unusedVariable: "'{{name}}' is defined but never used.",
+      replaceWithUnderscore: 'Replace the {{name}} with _{{name}}'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -113,7 +117,7 @@ module.exports = {
             context.report({
               node: variable.id,
               loc: variable.id.loc,
-              message: `'{{name}}' is defined but never used.`,
+              messageId: 'unusedVariable',
               data: {
                 name: variable.id.name
               },
@@ -121,7 +125,8 @@ module.exports = {
                 ignorePattern === '^_'
                   ? [
                       {
-                        desc: `Replace the ${variable.id.name} with _${variable.id.name}`,
+                        messageId: 'replaceWithUnderscore',
+                        data: { name: variable.id.name },
                         fix(fixer) {
                           return fixer.replaceText(
                             variable.id,

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -73,7 +73,8 @@ module.exports = {
     ],
     messages: {
       unusedVariable: "'{{name}}' is defined but never used.",
-      replaceWithUnderscore: 'Replace the {{name}} with _{{name}}'
+      replaceWithUnderscore:
+        'Replace `{{name}}` with `_{{name}}` to ignore the unused variable.'
     }
   },
   /** @param {RuleContext} context */

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -51,7 +51,6 @@ function isDestructuringVar(variable) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description:
@@ -60,6 +59,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-unused-vars.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',

--- a/lib/rules/no-use-v-if-with-v-for.js
+++ b/lib/rules/no-use-v-if-with-v-for.js
@@ -53,7 +53,12 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      movedToWrapper: "This 'v-if' should be moved to the wrapper element.",
+      shouldUseComputed:
+        "The '{{iteratorName}}' {{kind}} inside 'v-for' directive should be replaced with a computed property that returns filtered array instead. You should not mix 'v-for' with 'v-if'."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -80,8 +85,7 @@ module.exports = {
               context.report({
                 node,
                 loc: node.loc,
-                message:
-                  "The '{{iteratorName}}' {{kind}} inside 'v-for' directive should be replaced with a computed property that returns filtered array instead. You should not mix 'v-for' with 'v-if'.",
+                messageId: 'shouldUseComputed',
                 data: {
                   iteratorName:
                     iteratorNode.type === 'Identifier'
@@ -98,7 +102,7 @@ module.exports = {
             context.report({
               node,
               loc: node.loc,
-              message: "This 'v-if' should be moved to the wrapper element."
+              messageId: 'movedToWrapper'
             })
           }
         }

--- a/lib/rules/no-useless-mustaches.js
+++ b/lib/rules/no-useless-mustaches.js
@@ -31,16 +31,13 @@ function stripQuotesForHTML(text) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow unnecessary mustache interpolations',
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-useless-mustaches.html'
     },
     fixable: 'code',
-    messages: {
-      unexpected:
-        'Unexpected mustache interpolation with a string literal value.'
-    },
     schema: [
       {
         type: 'object',
@@ -55,7 +52,10 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    type: 'suggestion'
+    messages: {
+      unexpected:
+        'Unexpected mustache interpolation with a string literal value.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/no-useless-v-bind.js
+++ b/lib/rules/no-useless-v-bind.js
@@ -11,15 +11,13 @@ const SINGLE_QUOTES_RE = /'/gu
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow unnecessary `v-bind` directives',
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-useless-v-bind.html'
     },
     fixable: 'code',
-    messages: {
-      unexpected: 'Unexpected `v-bind` with a string literal value.'
-    },
     schema: [
       {
         type: 'object',
@@ -34,7 +32,9 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    type: 'suggestion'
+    messages: {
+      unexpected: 'Unexpected `v-bind` with a string literal value.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/no-v-html.js
+++ b/lib/rules/no-v-html.js
@@ -14,7 +14,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-v-html.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      unexpected: "'v-html' directive can lead to XSS attack."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -24,7 +27,7 @@ module.exports = {
         context.report({
           node,
           loc: node.loc,
-          message: "'v-html' directive can lead to XSS attack."
+          messageId: 'unexpected'
         })
       }
     })

--- a/lib/rules/no-v-text.js
+++ b/lib/rules/no-v-text.js
@@ -14,7 +14,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-v-text.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      unexpected: "Don't use 'v-text'."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -24,7 +27,7 @@ module.exports = {
         context.report({
           node,
           loc: node.loc,
-          message: "Don't use 'v-text'."
+          messageId: 'unexpected'
         })
       }
     })

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -228,7 +228,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      order:
+        'The "{{name}}" property should be above the "{{firstUnorderedPropertyName}}" property on line {{line}}.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -285,7 +289,7 @@ module.exports = {
           const line = firstUnorderedProperty.node.loc.start.line
           context.report({
             node: property.node,
-            message: `The "{{name}}" property should be above the "{{firstUnorderedPropertyName}}" property on line {{line}}.`,
+            messageId: 'order',
             data: {
               name: property.name,
               firstUnorderedPropertyName: firstUnorderedProperty.name,

--- a/lib/rules/prefer-prop-type-boolean-first.js
+++ b/lib/rules/prefer-prop-type-boolean-first.js
@@ -53,7 +53,6 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/prefer-prop-type-boolean-first.html'
     },
     fixable: null,
-    // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions -- `context.report` with suggestion is not recognized in `checkArrayExpression`
     hasSuggestions: true,
     schema: [],
     messages: {

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -30,7 +30,7 @@ function create(context) {
       if (!checker(propName)) {
         context.report({
           node: item.node,
-          message: 'Prop "{{name}}" is not in {{caseType}}.',
+          messageId: 'invalidCase',
           data: {
             name: propName,
             caseType
@@ -65,7 +65,10 @@ module.exports = {
       {
         enum: allowedCaseOptions
       }
-    ]
+    ],
+    messages: {
+      invalidCase: 'Prop "{{name}}" is not in {{caseType}}.'
+    }
   },
   create
 }

--- a/lib/rules/require-component-is.js
+++ b/lib/rules/require-component-is.js
@@ -16,7 +16,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-component-is.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      requireComponentIs:
+        "Expected '<component>' elements to have 'v-bind:is' attribute."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -27,8 +31,7 @@ module.exports = {
           context.report({
             node,
             loc: node.loc,
-            message:
-              "Expected '<component>' elements to have 'v-bind:is' attribute."
+            messageId: 'requireComponentIs'
           })
         }
       }

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -51,7 +51,7 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/require-default-prop.html'
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: [],
     messages: {
       missingDefault: `Prop '{{propName}}' requires default value to be set.`

--- a/lib/rules/require-direct-export.js
+++ b/lib/rules/require-direct-export.js
@@ -14,7 +14,7 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/require-direct-export.html'
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: [
       {
         type: 'object',

--- a/lib/rules/require-direct-export.js
+++ b/lib/rules/require-direct-export.js
@@ -23,7 +23,11 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      expectedDirectExport:
+        'Expected the component literal to be directly exported.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -96,7 +100,7 @@ module.exports = {
 
         context.report({
           node: node.parent,
-          message: `Expected the component literal to be directly exported.`
+          messageId: 'expectedDirectExport'
         })
       },
       ...(disallowFunctional
@@ -133,7 +137,7 @@ module.exports = {
               if (!maybeVue3Functional.hasReturnArgument) {
                 context.report({
                   node,
-                  message: `Expected the component literal to be directly exported.`
+                  messageId: 'expectedDirectExport'
                 })
               }
             }

--- a/lib/rules/require-emit-validator.js
+++ b/lib/rules/require-emit-validator.js
@@ -12,7 +12,6 @@ const utils = require('../utils')
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'require type definitions in emits',
@@ -20,13 +19,14 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-emit-validator.html'
     },
     fixable: null,
+    hasSuggestions: true,
+    schema: [],
     messages: {
       missing: 'Emit "{{name}}" should define at least its validator function.',
       skipped:
         'Emit "{{name}}" should not skip validation, or you may define a validator function with no parameters.',
       emptyValidation: 'Replace with a validator function with no parameters.'
-    },
-    schema: []
+    }
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -73,7 +73,6 @@ function getNameParamNode(node) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'require `emits` option with name triggered by `$emit()`',
@@ -81,6 +80,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-explicit-emits.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',

--- a/lib/rules/require-expose.js
+++ b/lib/rules/require-expose.js
@@ -55,7 +55,6 @@ function getCalleeMemberNode(node) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'require declare public properties using `expose`',
@@ -63,6 +62,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-expose.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: [],
     messages: {
       requireExpose:

--- a/lib/rules/require-macro-variable-name.js
+++ b/lib/rules/require-macro-variable-name.js
@@ -16,7 +16,6 @@ const DEFAULT_OPTIONS = {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description: 'require a certain macro variable name',
@@ -24,6 +23,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-macro-variable-name.html'
     },
     fixable: null,
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',

--- a/lib/rules/require-name-property.js
+++ b/lib/rules/require-name-property.js
@@ -51,7 +51,11 @@ module.exports = {
     },
     fixable: null,
     hasSuggestions: true,
-    schema: []
+    schema: [],
+    messages: {
+      missingName: 'Required name property is not set.',
+      addName: 'Add name property to component.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -70,10 +74,10 @@ module.exports = {
 
       context.report({
         node: component,
-        message: 'Required name property is not set.',
+        messageId: 'missingName',
         suggest: [
           {
-            desc: 'Add name property to component.',
+            messageId: 'addName',
             fix(fixer) {
               const extension = path.extname(context.getFilename())
               const filename = path.basename(context.getFilename(), extension)

--- a/lib/rules/require-prop-type-constructor.js
+++ b/lib/rules/require-prop-type-constructor.js
@@ -11,8 +11,6 @@ const { isDef } = require('../utils')
  * @typedef {import('../utils').ComponentProp} ComponentProp
  */
 
-const message = 'The "{{name}}" property should be a constructor.'
-
 const forbiddenTypes = new Set([
   'Literal',
   'TemplateLiteral',
@@ -39,7 +37,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-prop-type-constructor.html'
     },
     fixable: 'code',
-    schema: []
+    schema: [],
+    messages: {
+      propTypeConstructor: 'The "{{name}}" property should be a constructor.'
+    }
   },
 
   /** @param {RuleContext} context */
@@ -58,7 +59,7 @@ module.exports = {
 
         context.report({
           node: prop,
-          message,
+          messageId: 'propTypeConstructor',
           data: {
             name: propName
           },

--- a/lib/rules/require-prop-type-constructor.js
+++ b/lib/rules/require-prop-type-constructor.js
@@ -38,7 +38,7 @@ module.exports = {
       categories: ['vue3-essential', 'essential'],
       url: 'https://eslint.vuejs.org/rules/require-prop-type-constructor.html'
     },
-    fixable: 'code', // or "code" or "whitespace"
+    fixable: 'code',
     schema: []
   },
 

--- a/lib/rules/require-prop-types.js
+++ b/lib/rules/require-prop-types.js
@@ -19,7 +19,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-prop-types.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      requireType: 'Prop "{{name}}" should define at least its type.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -82,7 +85,7 @@ module.exports = {
           'Unknown prop'
         context.report({
           node,
-          message: 'Prop "{{name}}" should define at least its type.',
+          messageId: 'requireType',
           data: {
             name
           }

--- a/lib/rules/require-prop-types.js
+++ b/lib/rules/require-prop-types.js
@@ -18,10 +18,8 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/require-prop-types.html'
     },
-    fixable: null, // or "code" or "whitespace"
-    schema: [
-      // fill in your schema
-    ]
+    fixable: null,
+    schema: []
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -14,7 +14,7 @@ module.exports = {
       categories: ['vue3-essential', 'essential'],
       url: 'https://eslint.vuejs.org/rules/require-render-return.html'
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: []
   },
   /** @param {RuleContext} context */

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -15,7 +15,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-render-return.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      expectedReturn: 'Expected to return a value in render function.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -33,7 +36,7 @@ module.exports = {
         if (key) {
           context.report({
             node: key,
-            message: 'Expected to return a value in render function.'
+            messageId: 'expectedReturn'
           })
         }
       })

--- a/lib/rules/require-typed-object-prop.js
+++ b/lib/rules/require-typed-object-prop.js
@@ -121,7 +121,6 @@ module.exports = {
     },
     fixable: null,
     schema: [],
-    // eslint-disable-next-line eslint-plugin/require-meta-has-suggestions -- `context.report` with suggestion is not recognized in `checkPropIdentifierType`
     hasSuggestions: true,
     messages: {
       expectedTypeAnnotation: 'Expected type annotation on object prop.',

--- a/lib/rules/require-typed-object-prop.js
+++ b/lib/rules/require-typed-object-prop.js
@@ -120,8 +120,8 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-typed-object-prop.html'
     },
     fixable: null,
-    schema: [],
     hasSuggestions: true,
+    schema: [],
     messages: {
       expectedTypeAnnotation: 'Expected type annotation on object prop.',
       addTypeAnnotation: 'Add `{{ type }}` type annotation.'

--- a/lib/rules/require-typed-ref.js
+++ b/lib/rules/require-typed-ref.js
@@ -31,11 +31,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-typed-ref.html'
     },
     fixable: null,
+    schema: [],
     messages: {
       noType:
         'Specify type parameter for `{{name}}` function, otherwise created variable will not be typechecked.'
-    },
-    schema: []
+    }
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/require-v-for-key.js
+++ b/lib/rules/require-v-for-key.js
@@ -16,7 +16,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-v-for-key.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      requireKey:
+        "Elements in iteration expect to have 'v-bind:key' directives."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -38,8 +42,7 @@ module.exports = {
         context.report({
           node: element.startTag,
           loc: element.startTag.loc,
-          message:
-            "Elements in iteration expect to have 'v-bind:key' directives."
+          messageId: 'requireKey'
         })
       }
     }

--- a/lib/rules/require-valid-default-prop.js
+++ b/lib/rules/require-valid-default-prop.js
@@ -79,7 +79,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/require-valid-default-prop.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      invalidType:
+        "Type of the default value for '{{name}}' prop must be a {{types}}."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -237,8 +241,7 @@ module.exports = {
           : `[${context.getSourceCode().getText(prop.node.key)}]`
       context.report({
         node,
-        message:
-          "Type of the default value for '{{name}}' prop must be a {{types}}.",
+        messageId: 'invalidType',
         data: {
           name: propName,
           types: [...expectedTypeNames].join(' or ').toLowerCase()

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -30,7 +30,13 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    messages: {
+      expectedReturnInFunction:
+        'Expected to return a value in computed function.',
+      expectedReturnInProperty:
+        'Expected to return a value in "{{name}}" computed property.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -83,8 +89,7 @@ module.exports = {
             if (cp.value && cp.value.parent === node) {
               context.report({
                 node,
-                message:
-                  'Expected to return a value in "{{name}}" computed property.',
+                messageId: 'expectedReturnInProperty',
                 data: {
                   name: cp.key || 'Unknown'
                 }
@@ -95,7 +100,7 @@ module.exports = {
             if (cf === node) {
               context.report({
                 node,
-                message: 'Expected to return a value in computed function.'
+                messageId: 'expectedReturnInFunction'
               })
             }
           }

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -19,7 +19,7 @@ module.exports = {
       categories: ['vue3-essential', 'essential'],
       url: 'https://eslint.vuejs.org/rules/return-in-computed-property.html'
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: [
       {
         type: 'object',

--- a/lib/rules/return-in-emits-validator.js
+++ b/lib/rules/return-in-emits-validator.js
@@ -40,7 +40,7 @@ module.exports = {
       categories: ['vue3-essential', 'essential'],
       url: 'https://eslint.vuejs.org/rules/return-in-emits-validator.html'
     },
-    fixable: null, // or "code" or "whitespace"
+    fixable: null,
     schema: []
   },
   /** @param {RuleContext} context */

--- a/lib/rules/return-in-emits-validator.js
+++ b/lib/rules/return-in-emits-validator.js
@@ -41,7 +41,13 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/return-in-emits-validator.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      expectedTrue:
+        'Expected to return a true value in "{{name}}" emits validator.',
+      expectedBoolean:
+        'Expected to return a boolean value in "{{name}}" emits validator.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -127,9 +133,9 @@ module.exports = {
             if (emits) {
               context.report({
                 node,
-                message: scopeStack.hasReturnValue
-                  ? 'Expected to return a true value in "{{name}}" emits validator.'
-                  : 'Expected to return a boolean value in "{{name}}" emits validator.',
+                messageId: scopeStack.hasReturnValue
+                  ? 'expectedTrue'
+                  : 'expectedBoolean',
                 data: {
                   name: emits.emitName || 'Unknown'
                 }

--- a/lib/rules/script-indent.js
+++ b/lib/rules/script-indent.js
@@ -7,6 +7,7 @@
 const indentCommon = require('../utils/indent-common')
 
 module.exports = {
+  // eslint-disable-next-line eslint-plugin/prefer-message-ids
   meta: {
     type: 'layout',
     docs: {

--- a/lib/rules/script-setup-uses-vars.js
+++ b/lib/rules/script-setup-uses-vars.js
@@ -28,8 +28,8 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/script-setup-uses-vars.html'
     },
-    deprecated: true,
-    schema: []
+    schema: [],
+    deprecated: true
   },
   /**
    * @param {RuleContext} context - The rule context.

--- a/lib/rules/script-setup-uses-vars.js
+++ b/lib/rules/script-setup-uses-vars.js
@@ -19,6 +19,7 @@ function camelize(str) {
 }
 
 module.exports = {
+  // eslint-disable-next-line eslint-plugin/prefer-message-ids
   meta: {
     type: 'problem',
     docs: {

--- a/lib/rules/static-class-names-order.js
+++ b/lib/rules/static-class-names-order.js
@@ -15,7 +15,10 @@ module.exports = {
       categories: undefined
     },
     fixable: 'code',
-    schema: []
+    schema: [],
+    messages: {
+      shouldBeOrdered: 'Classes should be ordered alphabetically.'
+    }
   },
   /** @param {RuleContext} context */
   create: (context) =>
@@ -44,7 +47,7 @@ module.exports = {
           context.report({
             node,
             loc: node.loc,
-            message: 'Classes should be ordered alphabetically.',
+            messageId: 'shouldBeOrdered',
             fix: (fixer) => fixer.replaceText(value, `"${classListSorted}"`)
           })
         }

--- a/lib/rules/this-in-template.js
+++ b/lib/rules/this-in-template.js
@@ -20,7 +20,11 @@ module.exports = {
       {
         enum: ['always', 'never']
       }
-    ]
+    ],
+    messages: {
+      unexpected: "Unexpected usage of 'this'.",
+      expected: "Expected 'this'."
+    }
   },
 
   /**
@@ -87,7 +91,7 @@ module.exports = {
                   // node.parent should be some code like `this.test`, `this?.['result']`
                   return fixer.replaceText(node.parent, propertyName)
                 },
-                message: "Unexpected usage of 'this'."
+                messageId: 'unexpected'
               })
             }
           }
@@ -112,7 +116,7 @@ module.exports = {
                     context.report({
                       node: reference.id,
                       loc: reference.id.loc,
-                      message: "Expected 'this'.",
+                      messageId: 'expected',
                       fix(fixer) {
                         return fixer.insertTextBefore(reference.id, 'this.')
                       }

--- a/lib/rules/use-v-on-exact.js
+++ b/lib/rules/use-v-on-exact.js
@@ -168,7 +168,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/use-v-on-exact.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      considerExact: "Consider to use '.exact' modifier."
+    }
   },
 
   /**
@@ -209,7 +212,7 @@ module.exports = {
             context.report({
               node: e.node,
               loc: e.node.loc,
-              message: "Consider to use '.exact' modifier."
+              messageId: 'considerExact'
             })
           }
         }

--- a/lib/rules/v-bind-style.js
+++ b/lib/rules/v-bind-style.js
@@ -16,7 +16,12 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/v-bind-style.html'
     },
     fixable: 'code',
-    schema: [{ enum: ['shorthand', 'longform'] }]
+    schema: [{ enum: ['shorthand', 'longform'] }],
+    messages: {
+      expectedLonghand: "Expected 'v-bind' before ':'.",
+      unexpectedLonghand: "Unexpected 'v-bind' before ':'.",
+      expectedLonghandForProp: "Expected 'v-bind:' instead of '.'."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -33,17 +38,17 @@ module.exports = {
           return
         }
 
-        let message = "Expected 'v-bind' before ':'."
+        let messageId = 'expectedLonghand'
         if (preferShorthand) {
-          message = "Unexpected 'v-bind' before ':'."
+          messageId = 'unexpectedLonghand'
         } else if (shorthandProp) {
-          message = "Expected 'v-bind:' instead of '.'."
+          messageId = 'expectedLonghandForProp'
         }
 
         context.report({
           node,
           loc: node.loc,
-          message,
+          messageId,
           *fix(fixer) {
             if (preferShorthand) {
               yield fixer.remove(node.key.name)

--- a/lib/rules/v-for-delimiter-style.js
+++ b/lib/rules/v-for-delimiter-style.js
@@ -18,7 +18,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/v-for-delimiter-style.html'
     },
     fixable: 'code',
-    schema: [{ enum: ['in', 'of'] }]
+    schema: [{ enum: ['in', 'of'] }],
+    messages: {
+      expected:
+        "Expected '{{preferredDelimiter}}' instead of '{{usedDelimiter}}' in 'v-for'."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -48,7 +52,7 @@ module.exports = {
         context.report({
           node,
           loc: node.loc,
-          message: `Expected '{{preferredDelimiter}}' instead of '{{usedDelimiter}}' in 'v-for'.`,
+          messageId: 'expected',
           data: {
             preferredDelimiter,
             usedDelimiter: delimiterToken.value

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -5,6 +5,7 @@ const casing = require('../utils/casing')
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description:
         'enforce v-on event naming style on custom components in template',
@@ -36,7 +37,6 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    type: 'suggestion',
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       mustBeHyphenated: "v-on event '{{text}}' must be hyphenated.",

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -36,7 +36,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    type: 'suggestion'
+    type: 'suggestion',
+    messages: {
+      // eslint-disable-next-line eslint-plugin/report-message-format
+      mustBeHyphenated: "v-on event '{{text}}' must be hyphenated.",
+      // eslint-disable-next-line eslint-plugin/report-message-format
+      cannotBeHyphenated: "v-on event '{{text}}' can't be hyphenated."
+    }
   },
 
   /** @param {RuleContext} context */
@@ -64,9 +70,7 @@ module.exports = {
       context.report({
         node: node.key,
         loc: node.loc,
-        message: useHyphenated
-          ? "v-on event '{{text}}' must be hyphenated."
-          : "v-on event '{{text}}' can't be hyphenated.",
+        messageId: useHyphenated ? 'mustBeHyphenated' : 'cannotBeHyphenated',
         data: {
           text
         },

--- a/lib/rules/v-on-function-call.js
+++ b/lib/rules/v-on-function-call.js
@@ -84,7 +84,12 @@ module.exports = {
       }
     ],
     deprecated: true,
-    replacedBy: ['v-on-handler-style']
+    replacedBy: ['v-on-handler-style'],
+    messages: {
+      always: "Method calls inside of 'v-on' directives must have parentheses.",
+      never:
+        "Method calls without arguments inside of 'v-on' directives must not have parentheses."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -98,8 +103,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message:
-              "Method calls inside of 'v-on' directives must have parentheses."
+            messageId: 'always'
           })
         }
       })
@@ -153,8 +157,7 @@ module.exports = {
 
           context.report({
             node: expression,
-            message:
-              "Method calls without arguments inside of 'v-on' directives must not have parentheses.",
+            messageId: 'never',
             fix: hasComment
               ? null /* The comment is included and cannot be fixed. */
               : (fixer) => {

--- a/lib/rules/v-on-function-call.js
+++ b/lib/rules/v-on-function-call.js
@@ -83,13 +83,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
-    deprecated: true,
-    replacedBy: ['v-on-handler-style'],
     messages: {
       always: "Method calls inside of 'v-on' directives must have parentheses.",
       never:
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-    }
+    },
+    deprecated: true,
+    replacedBy: ['v-on-handler-style']
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/v-on-style.js
+++ b/lib/rules/v-on-style.js
@@ -16,7 +16,11 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/v-on-style.html'
     },
     fixable: 'code',
-    schema: [{ enum: ['shorthand', 'longform'] }]
+    schema: [{ enum: ['shorthand', 'longform'] }],
+    messages: {
+      expectedShorthand: "Expected '@' instead of 'v-on:'.",
+      expectedLonghand: "Expected 'v-on:' instead of '@'."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -36,9 +40,7 @@ module.exports = {
         context.report({
           node,
           loc: node.loc,
-          message: preferShorthand
-            ? "Expected '@' instead of 'v-on:'."
-            : "Expected 'v-on:' instead of '@'.",
+          messageId: preferShorthand ? 'expectedShorthand' : 'expectedLonghand',
           fix: (fixer) =>
             preferShorthand
               ? fixer.replaceTextRange([pos, pos + 5], '@')

--- a/lib/rules/valid-model-definition.js
+++ b/lib/rules/valid-model-definition.js
@@ -17,7 +17,10 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/valid-model-definition.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      invalidKey: "Invalid key '{{name}}' in model option."
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -38,7 +41,7 @@ module.exports = {
         if (!VALID_MODEL_KEYS.has(name)) {
           context.report({
             node: p,
-            message: "Invalid key '{{name}}' in model option.",
+            messageId: 'invalidKey',
             data: {
               name
             }

--- a/lib/rules/valid-next-tick.js
+++ b/lib/rules/valid-next-tick.js
@@ -110,7 +110,6 @@ function isAwaitedPromise(callExpression) {
 
 module.exports = {
   meta: {
-    hasSuggestions: true,
     type: 'problem',
     docs: {
       description: 'enforce valid `nextTick` function calls',
@@ -118,6 +117,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/valid-next-tick.html'
     },
     fixable: 'code',
+    hasSuggestions: true,
     schema: [],
     messages: {
       shouldBeFunction: '`nextTick` is a function.',

--- a/lib/rules/valid-next-tick.js
+++ b/lib/rules/valid-next-tick.js
@@ -118,7 +118,16 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/valid-next-tick.html'
     },
     fixable: 'code',
-    schema: []
+    schema: [],
+    messages: {
+      shouldBeFunction: '`nextTick` is a function.',
+      missingCallbackOrAwait:
+        'Await the Promise returned by `nextTick` or pass a callback function.',
+      addAwait: 'Add missing `await` statement.',
+      tooManyParameters: '`nextTick` expects zero or one parameters.',
+      eitherAwaitOrCallback:
+        'Either await the Promise or pass a callback function to `nextTick`.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -156,7 +165,7 @@ module.exports = {
         if (parentNode.type !== 'CallExpression') {
           context.report({
             node,
-            message: '`nextTick` is a function.',
+            messageId: 'shouldBeFunction',
             fix(fixer) {
               return fixer.insertTextAfter(node, '()')
             }
@@ -168,11 +177,10 @@ module.exports = {
           if (!isAwaitedPromise(parentNode)) {
             context.report({
               node,
-              message:
-                'Await the Promise returned by `nextTick` or pass a callback function.',
+              messageId: 'missingCallbackOrAwait',
               suggest: [
                 {
-                  desc: 'Add missing `await` statement.',
+                  messageId: 'addAwait',
                   fix(fixer) {
                     return fixer.insertTextBefore(parentNode, 'await ')
                   }
@@ -186,7 +194,7 @@ module.exports = {
         if (parentNode.arguments.length > 1) {
           context.report({
             node,
-            message: '`nextTick` expects zero or one parameters.'
+            messageId: 'tooManyParameters'
           })
           return
         }
@@ -194,8 +202,7 @@ module.exports = {
         if (isAwaitedPromise(parentNode)) {
           context.report({
             node,
-            message:
-              'Either await the Promise or pass a callback function to `nextTick`.'
+            messageId: 'eitherAwaitOrCallback'
           })
         }
       }

--- a/lib/rules/valid-template-root.js
+++ b/lib/rules/valid-template-root.js
@@ -16,7 +16,12 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/valid-template-root.html'
     },
     fixable: null,
-    schema: []
+    schema: [],
+    messages: {
+      emptySrc:
+        "The template root with 'src' attribute is required to be empty.",
+      noChild: 'The template requires child element.'
+    }
   },
   /** @param {RuleContext} context */
   create(context) {
@@ -44,15 +49,14 @@ module.exports = {
             context.report({
               node: element,
               loc: element.loc,
-              message:
-                "The template root with 'src' attribute is required to be empty."
+              messageId: 'emptySrc'
             })
           }
         } else if (rootElements.length === 0 && !hasSrc) {
           context.report({
             node: element,
             loc: element.loc,
-            message: 'The template requires child element.'
+            messageId: 'noChild'
           })
         }
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "esbuild": "^0.15.15",
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-eslint-plugin": "^5.1.1",
+    "eslint-plugin-eslint-plugin": "~5.1.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsonc": "^2.2.1",
     "eslint-plugin-node-dependencies": ">=0.5.0 <1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "esbuild": "^0.15.15",
     "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-eslint-plugin": "^3.5.3",
+    "eslint-plugin-eslint-plugin": "^5.1.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsonc": "^2.2.1",
     "eslint-plugin-node-dependencies": ">=0.5.0 <1.0.0",

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -55,20 +55,20 @@ tester.run('array-bracket-newline', rule, {
     },
     {
       code: '<template><div :attr="[\na]" /></template>',
-      options: ['never'],
       output: '<template><div :attr="[a]" /></template>',
+      options: ['never'],
       errors: ["There should be no linebreak after '['."]
     },
     {
       code: '<template><div :attr="[a\n]" /></template>',
-      options: ['never'],
       output: '<template><div :attr="[a]" /></template>',
+      options: ['never'],
       errors: ["There should be no linebreak before ']'."]
     },
     {
       code: '<template><div :attr="[\na\n]" /></template>',
-      options: ['never'],
       output: '<template><div :attr="[a]" /></template>',
+      options: ['never'],
       errors: [
         "There should be no linebreak after '['.",
         "There should be no linebreak before ']'."
@@ -76,20 +76,20 @@ tester.run('array-bracket-newline', rule, {
     },
     {
       code: '<template><div :attr="[\na]" /></template>',
-      options: ['always'],
       output: '<template><div :attr="[\na\n]" /></template>',
+      options: ['always'],
       errors: ["A linebreak is required before ']'."]
     },
     {
       code: '<template><div :attr="[a\n]" /></template>',
-      options: ['always'],
       output: '<template><div :attr="[\na\n]" /></template>',
+      options: ['always'],
       errors: ["A linebreak is required after '['."]
     },
     {
       code: '<template><div :attr="[a]" /></template>',
-      options: ['always'],
       output: '<template><div :attr="[\na\n]" /></template>',
+      options: ['always'],
       errors: [
         "A linebreak is required after '['.",
         "A linebreak is required before ']'."
@@ -97,8 +97,8 @@ tester.run('array-bracket-newline', rule, {
     },
     {
       code: '<template><div :[[attr]]="[a]" /></template>',
-      options: ['always'],
       output: '<template><div :[[attr]]="[\na\n]" /></template>',
+      options: ['always'],
       errors: [
         "A linebreak is required after '['.",
         "A linebreak is required before ']'."

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -54,20 +54,20 @@ tester.run('array-bracket-spacing', rule, {
     },
     {
       code: '<template><div :attr="[ a]" /></template>',
-      options: ['never'],
       output: '<template><div :attr="[a]" /></template>',
+      options: ['never'],
       errors: ["There should be no space after '['."]
     },
     {
       code: '<template><div :attr="[a ]" /></template>',
-      options: ['never'],
       output: '<template><div :attr="[a]" /></template>',
+      options: ['never'],
       errors: ["There should be no space before ']'."]
     },
     {
       code: '<template><div :attr="[ a ]" /></template>',
-      options: ['never'],
       output: '<template><div :attr="[a]" /></template>',
+      options: ['never'],
       errors: [
         "There should be no space after '['.",
         "There should be no space before ']'."
@@ -75,20 +75,20 @@ tester.run('array-bracket-spacing', rule, {
     },
     {
       code: '<template><div :attr="[ a]" /></template>',
-      options: ['always'],
       output: '<template><div :attr="[ a ]" /></template>',
+      options: ['always'],
       errors: ["A space is required before ']'."]
     },
     {
       code: '<template><div :attr="[a ]" /></template>',
-      options: ['always'],
       output: '<template><div :attr="[ a ]" /></template>',
+      options: ['always'],
       errors: ["A space is required after '['."]
     },
     {
       code: '<template><div :attr="[a]" /></template>',
-      options: ['always'],
       output: '<template><div :attr="[ a ]" /></template>',
+      options: ['always'],
       errors: [
         "A space is required after '['.",
         "A space is required before ']'."
@@ -96,8 +96,8 @@ tester.run('array-bracket-spacing', rule, {
     },
     {
       code: '<template><div :[[attr]]="[a]" /></template>',
-      options: ['always'],
       output: '<template><div :[[attr]]="[ a ]" /></template>',
+      options: ['always'],
       errors: [
         "A space is required after '['.",
         "A space is required before ']'."

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -105,11 +105,11 @@ tester.run('arrow-spacing', rule, {
         <template>
           <div :attr="() => a" />
         </template>`,
-      options: [{ before: false, after: false }],
       output: `
         <template>
           <div :attr="()=>a" />
         </template>`,
+      options: [{ before: false, after: false }],
       errors: [
         {
           message: 'Unexpected space before =>.',

--- a/tests/lib/rules/attributes-order.js
+++ b/tests/lib/rules/attributes-order.js
@@ -716,6 +716,8 @@ tester.run('attributes-order', rule, {
     {
       filename: 'test.vue',
       code: '<template><div ref="header" propone="prop" is="header" ></div></template>',
+      output:
+        '<template><div ref="header" is="header" propone="prop" ></div></template>',
       options: [
         {
           order: [
@@ -733,8 +735,6 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      output:
-        '<template><div ref="header" is="header" propone="prop" ></div></template>',
       errors: [
         {
           message: 'Attribute "is" should go before "propone".',
@@ -837,6 +837,21 @@ tester.run('attributes-order', rule, {
               >
             </div>
           </template>`,
+      output: `<template>
+            <div
+              v-if="!visible"
+              v-for="item in items"
+              is="header"
+              v-once
+              v-on:click="functionCall"
+              ref="header"
+              :prop="headerData"
+              id="uniqueID"
+              v-text="textContent"
+              myProp="prop"
+              >
+            </div>
+          </template>`,
       options: [
         {
           order: [
@@ -854,21 +869,6 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      output: `<template>
-            <div
-              v-if="!visible"
-              v-for="item in items"
-              is="header"
-              v-once
-              v-on:click="functionCall"
-              ref="header"
-              :prop="headerData"
-              id="uniqueID"
-              v-text="textContent"
-              myProp="prop"
-              >
-            </div>
-          </template>`,
       errors: [
         {
           message: 'Attribute "is" should go before "v-once".',
@@ -902,6 +902,15 @@ tester.run('attributes-order', rule, {
               >
             </div>
           </template>`,
+      output: `<template>
+            <div
+              v-if="!visible"
+              class="content"
+              v-model="foo"
+              v-text="textContent"
+              >
+            </div>
+          </template>`,
       options: [
         {
           order: [
@@ -917,15 +926,6 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      output: `<template>
-            <div
-              v-if="!visible"
-              class="content"
-              v-model="foo"
-              v-text="textContent"
-              >
-            </div>
-          </template>`,
       errors: [
         {
           message: 'Attribute "v-if" should go before "class".',
@@ -965,13 +965,13 @@ tester.run('attributes-order', rule, {
             a-prop="A">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             a-prop="A"
             z-prop="Z">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "a-prop" should go before "z-prop".',
@@ -987,13 +987,13 @@ tester.run('attributes-order', rule, {
             :a-prop="A">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             :a-prop="A"
             :z-prop="Z">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute ":a-prop" should go before ":z-prop".',
@@ -1009,13 +1009,13 @@ tester.run('attributes-order', rule, {
             @change="foo">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             @change="foo"
             @input="bar">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "@change" should go before "@input".',
@@ -1031,13 +1031,13 @@ tester.run('attributes-order', rule, {
             boolean-prop>
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             boolean-prop
             z-prop="value">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "boolean-prop" should go before "z-prop".',
@@ -1053,13 +1053,13 @@ tester.run('attributes-order', rule, {
             v-on:[c]="functionCall">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             v-on:[c]="functionCall"
             v-on:click="functionCall">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "v-on:[c]" should go before "v-on:click".',
@@ -1075,13 +1075,13 @@ tester.run('attributes-order', rule, {
             v-on:click="functionCall">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             v-on:click="functionCall"
             v-text="textContent">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "v-on:click" should go before "v-text".',
@@ -1097,13 +1097,13 @@ tester.run('attributes-order', rule, {
             class="bar">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             class="bar"
             :class="foo">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "class" should go before ":class".'
@@ -1118,13 +1118,13 @@ tester.run('attributes-order', rule, {
             v-if="bar">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             v-if="bar"
             v-show="foo">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "v-if" should go before "v-show".'
@@ -1139,13 +1139,13 @@ tester.run('attributes-order', rule, {
             v-bar="bar">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             v-bar="bar"
             v-foo="foo">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "v-bar" should go before "v-foo".'
@@ -1160,13 +1160,13 @@ tester.run('attributes-order', rule, {
             v-foo.a="a">
           </div>
         </template>`,
-      options: [{ alphabetical: true }],
       output: `<template>
           <div
             v-foo.a="a"
             v-foo.b="b">
           </div>
         </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         {
           message: 'Attribute "v-foo.a" should go before "v-foo.b".'
@@ -1256,7 +1256,6 @@ tester.run('attributes-order', rule, {
           v-bind="b">
         </div>
       </template>`,
-      options: [{ alphabetical: true }],
       output: `
       <template>
         <div
@@ -1265,6 +1264,7 @@ tester.run('attributes-order', rule, {
           v-bind="b">
         </div>
       </template>`,
+      options: [{ alphabetical: true }],
       errors: ['Attribute "v-bind:id" should go before "v-on:click".']
     },
     {
@@ -1277,7 +1277,6 @@ tester.run('attributes-order', rule, {
           v-bind="b">
         </div>
       </template>`,
-      options: [{ alphabetical: true }],
       output: `
       <template>
         <div
@@ -1286,6 +1285,7 @@ tester.run('attributes-order', rule, {
           v-on:click="x">
         </div>
       </template>`,
+      options: [{ alphabetical: true }],
       errors: ['Attribute "v-bind" should go before "v-on:click".']
     },
     {
@@ -1298,7 +1298,6 @@ tester.run('attributes-order', rule, {
           v-bind:id="a">
         </div>
       </template>`,
-      options: [{ alphabetical: true }],
       output: `
       <template>
         <div
@@ -1307,6 +1306,7 @@ tester.run('attributes-order', rule, {
           v-on:click="x">
         </div>
       </template>`,
+      options: [{ alphabetical: true }],
       errors: ['Attribute "v-bind:id" should go before "v-on:click".']
     },
     {
@@ -1320,7 +1320,6 @@ tester.run('attributes-order', rule, {
           v-if="x">
         </div>
       </template>`,
-      options: [{ alphabetical: true }],
       output: `
       <template>
         <div
@@ -1330,6 +1329,7 @@ tester.run('attributes-order', rule, {
           v-if="x">
         </div>
       </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         'Attribute "v-bind:a" should go before "v-on:click".',
         'Attribute "v-if" should go before "v-on:click".'
@@ -1346,7 +1346,6 @@ tester.run('attributes-order', rule, {
           v-if="x">
         </div>
       </template>`,
-      options: [{ alphabetical: true }],
       output: `
       <template>
         <div
@@ -1356,6 +1355,7 @@ tester.run('attributes-order', rule, {
           v-if="x">
         </div>
       </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         'Attribute "v-bind" should go before "v-on:click".',
         'Attribute "v-if" should go before "v-on:click".'
@@ -1371,7 +1371,6 @@ tester.run('attributes-order', rule, {
           v-if="x">
         </div>
       </template>`,
-      options: [{ alphabetical: true }],
       output: `
       <template>
         <div
@@ -1380,6 +1379,7 @@ tester.run('attributes-order', rule, {
           v-bind="x">
         </div>
       </template>`,
+      options: [{ alphabetical: true }],
       errors: ['Attribute "v-if" should go before "a".']
     },
     {
@@ -1392,7 +1392,6 @@ tester.run('attributes-order', rule, {
           v-if="x">
         </div>
       </template>`,
-      options: [{ alphabetical: true }],
       output: `
       <template>
         <div
@@ -1401,6 +1400,7 @@ tester.run('attributes-order', rule, {
           v-if="x">
         </div>
       </template>`,
+      options: [{ alphabetical: true }],
       errors: [
         'Attribute "v-bind" should go before "v-on:click".',
         'Attribute "v-if" should go before "v-on:click".'
@@ -1462,7 +1462,6 @@ tester.run('attributes-order', rule, {
           v-for="a in items">
         </div>
       </template>`,
-      options: [{ order: ['LIST_RENDERING', 'CONDITIONALS'] }],
       output: `
       <template>
         <div
@@ -1471,6 +1470,7 @@ tester.run('attributes-order', rule, {
           attr="a">
         </div>
       </template>`,
+      options: [{ order: ['LIST_RENDERING', 'CONDITIONALS'] }],
       errors: ['Attribute "v-for" should go before "v-if".']
     },
     {
@@ -1483,7 +1483,6 @@ tester.run('attributes-order', rule, {
           v-for="a in items">
         </div>
       </template>`,
-      options: [{ order: ['LIST_RENDERING', 'CONDITIONALS'] }],
       output: `
       <template>
         <div
@@ -1492,12 +1491,16 @@ tester.run('attributes-order', rule, {
           v-if="a">
         </div>
       </template>`,
+      options: [{ order: ['LIST_RENDERING', 'CONDITIONALS'] }],
       errors: ['Attribute "v-for" should go before "v-if".']
     },
 
     // slot
     {
       filename: 'test.vue',
+      code: '<template><div ref="foo" v-slot="{ qux }" bar="baz"></div></template>',
+      output:
+        '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
       options: [
         {
           order: [
@@ -1516,9 +1519,6 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      code: '<template><div ref="foo" v-slot="{ qux }" bar="baz"></div></template>',
-      output:
-        '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
       errors: [
         {
           message: 'Attribute "bar" should go before "v-slot".'
@@ -1528,6 +1528,9 @@ tester.run('attributes-order', rule, {
 
     {
       filename: 'test.vue',
+      code: '<template><div bar="baz" ref="foo" v-slot="{ qux }"></div></template>',
+      output:
+        '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
       options: [
         {
           order: [
@@ -1546,9 +1549,6 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      code: '<template><div bar="baz" ref="foo" v-slot="{ qux }"></div></template>',
-      output:
-        '<template><div ref="foo" bar="baz" v-slot="{ qux }"></div></template>',
       errors: [
         {
           message: 'Attribute "ref" should go before "bar".'
@@ -1630,7 +1630,6 @@ tester.run('attributes-order', rule, {
           v-bind="object"
           @input="handleInput"/>
       </template>`,
-      options: [{ order: ['UNIQUE', 'EVENTS', 'OTHER_ATTR'] }],
       output: `
       <template>
         <div
@@ -1639,6 +1638,7 @@ tester.run('attributes-order', rule, {
           @input="handleInput"
           v-bind="object"/>
       </template>`,
+      options: [{ order: ['UNIQUE', 'EVENTS', 'OTHER_ATTR'] }],
       errors: ['Attribute "@input" should go before "v-bind".']
     },
 
@@ -1651,7 +1651,6 @@ tester.run('attributes-order', rule, {
           @click="handleClick"
           attr="foo"/>
       </template>`,
-      options: [{ order: ['UNIQUE', 'EVENTS', 'OTHER_ATTR'] }],
       output: `
       <template>
         <div
@@ -1659,6 +1658,7 @@ tester.run('attributes-order', rule, {
           v-bind="object"
           attr="foo"/>
       </template>`,
+      options: [{ order: ['UNIQUE', 'EVENTS', 'OTHER_ATTR'] }],
       errors: ['Attribute "@click" should go before "v-bind".']
     },
 
@@ -1671,7 +1671,6 @@ tester.run('attributes-order', rule, {
           prop-two="b"
           :prop-three="c"/>
       </template>`,
-      options: [{ order: ['ATTR_STATIC', 'ATTR_DYNAMIC'] }],
       output: `
       <template>
         <div
@@ -1679,6 +1678,7 @@ tester.run('attributes-order', rule, {
           v-bind:prop-one="a"
           :prop-three="c"/>
       </template>`,
+      options: [{ order: ['ATTR_STATIC', 'ATTR_DYNAMIC'] }],
       errors: ['Attribute "prop-two" should go before "v-bind:prop-one".']
     },
 
@@ -1691,6 +1691,16 @@ tester.run('attributes-order', rule, {
           v-model="value"
           prop-two="b"
           :prop-three="c"
+          class="class"
+          boolean-prop/>
+      </template>`,
+      output: `
+      <template>
+        <div
+          v-model="value"
+          :prop-one="a"
+          :prop-three="c"
+          prop-two="b"
           class="class"
           boolean-prop/>
       </template>`,
@@ -1709,16 +1719,6 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      output: `
-      <template>
-        <div
-          v-model="value"
-          :prop-one="a"
-          :prop-three="c"
-          prop-two="b"
-          class="class"
-          boolean-prop/>
-      </template>`,
       errors: [
         'Attribute "v-model" should go before ":prop-one".',
         'Attribute ":prop-three" should go before "prop-two".'
@@ -1732,6 +1732,15 @@ tester.run('attributes-order', rule, {
         <div
           :prop-one="a"
           v-model="value"
+          boolean-prop
+          prop-two="b"
+          :prop-three="c"/>
+      </template>`,
+      output: `
+      <template>
+        <div
+          v-model="value"
+          :prop-one="a"
           boolean-prop
           prop-two="b"
           :prop-three="c"/>
@@ -1754,15 +1763,6 @@ tester.run('attributes-order', rule, {
           ]
         }
       ],
-      output: `
-      <template>
-        <div
-          v-model="value"
-          :prop-one="a"
-          boolean-prop
-          prop-two="b"
-          :prop-three="c"/>
-      </template>`,
       errors: ['Attribute "v-model" should go before ":prop-one".']
     }
   ]

--- a/tests/lib/rules/block-lang.js
+++ b/tests/lib/rules/block-lang.js
@@ -27,11 +27,11 @@ tester.run('block-lang', rule, {
       code: '<i18n></i18n><i18n lang="json"></i18n>',
       options: [{ i18n: { lang: 'json', allowNoLang: true } }]
     },
-    {
-      code: `<template></template>
+    `
+      <template></template>
       <script></script>
-      <style></style>`
-    }
+      <style></style>
+    `
   ],
   invalid: [
     {

--- a/tests/lib/rules/block-spacing.js
+++ b/tests/lib/rules/block-spacing.js
@@ -86,11 +86,11 @@ tester.run('block-spacing', rule, {
         <template>
           <div :attr="function foo() { return true; }" />
         </template>`,
-      options: ['never'],
       output: `
         <template>
           <div :attr="function foo() {return true;}" />
         </template>`,
+      options: ['never'],
       errors: [
         {
           messageId: 'extra',

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -38,12 +38,11 @@ tester.run('comma-dangle', rule, {
         }
       ]
     },
-    {
-      code: `
+    `
       <template>
         <button :[[a,b][1]]="a" ></button>
-      </template>`
-    },
+      </template>
+    `,
     {
       code: `
       <template>

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -74,15 +74,15 @@ tester.run('comma-dangle', rule, {
         <template>
           <CustomButton @click="($event, ) => fn()" />
         </template>`,
+      output: `
+        <template>
+          <CustomButton @click="($event ) => fn()" />
+        </template>`,
       options: [
         {
           functions: 'never'
         }
       ],
-      output: `
-        <template>
-          <CustomButton @click="($event ) => fn()" />
-        </template>`,
       errors: [
         {
           message: 'Unexpected trailing comma.',
@@ -101,7 +101,6 @@ tester.run('comma-dangle', rule, {
             ])
           }"></button>
         </template>`,
-      options: ['always-multiline'],
       output: `
         <template>
           <button @click="() => {
@@ -112,6 +111,7 @@ tester.run('comma-dangle', rule, {
             ])
           }"></button>
         </template>`,
+      options: ['always-multiline'],
       errors: [
         {
           message: 'Unexpected trailing comma.',

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -268,13 +268,13 @@ tester.run('comma-spacing', rule, {
             fn(a, b)
           "/>
         </template>`,
-      options: [{ before: true, after: false }],
       output: `
         <template>
           <button @click="
             fn(a ,b)
           "/>
         </template>`,
+      options: [{ before: true, after: false }],
       errors: [
         {
           message: "A space is required before ','.",

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -82,12 +82,12 @@ tester.run('comma-style', rule, {
           <CustomButton @click="($event
             , data) => fn()" />
         </template>`,
-      options: ['last', { exceptions: { ArrowFunctionExpression: false } }],
       output: `
         <template>
           <CustomButton @click="($event,
              data) => fn()" />
         </template>`,
+      options: ['last', { exceptions: { ArrowFunctionExpression: false } }],
       errors: [
         {
           message: "',' should be placed last.",
@@ -101,12 +101,12 @@ tester.run('comma-style', rule, {
           <CustomButton @click="($event,
             data) => fn()" />
         </template>`,
-      options: ['first', { exceptions: { ArrowFunctionExpression: false } }],
       output: `
         <template>
           <CustomButton @click="($event
             ,data) => fn()" />
         </template>`,
+      options: ['first', { exceptions: { ArrowFunctionExpression: false } }],
       errors: [
         {
           message: "',' should be placed first."
@@ -122,7 +122,6 @@ tester.run('comma-style', rule, {
             <div/>
           </CustomButton>
         </template>`,
-      options: ['first', { exceptions: { FunctionExpression: false } }],
       output: `
         <template>
           <CustomButton v-slot="foo
@@ -130,6 +129,7 @@ tester.run('comma-style', rule, {
             <div/>
           </CustomButton>
         </template>`,
+      options: ['first', { exceptions: { FunctionExpression: false } }],
       errors: [
         {
           message: "',' should be placed first."
@@ -144,13 +144,13 @@ tester.run('comma-style', rule, {
             b
             ,c" />
         </template>`,
-      options: ['last', { exceptions: { FunctionExpression: false } }],
       output: `
         <template>
           <CustomButton v-slot="a,
             b,
             c" />
         </template>`,
+      options: ['last', { exceptions: { FunctionExpression: false } }],
       errors: [
         {
           message: "',' should be placed last."

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -35,14 +35,13 @@ tester.run('comma-style', rule, {
         </template>`,
       options: ['first', { exceptions: { ArrowFunctionExpression: false } }]
     },
-    {
-      code: `
-        <template>
-          <CustomButton v-slot="a,
-            b
-            ,c" />
-        </template>`
-    },
+    `
+      <template>
+        <CustomButton v-slot="a,
+          b
+          ,c" />
+      </template>
+    `,
     {
       code: `
         <template>

--- a/tests/lib/rules/component-api-style.js
+++ b/tests/lib/rules/component-api-style.js
@@ -43,7 +43,6 @@ tester.run('component-api-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: [['options']],
       code: `
       <script>
       export default {
@@ -56,7 +55,8 @@ tester.run('component-api-style', rule, {
         // ...
       }
       </script>
-      `
+      `,
+      options: [['options']]
     },
     {
       filename: 'test.js',
@@ -76,7 +76,6 @@ tester.run('component-api-style', rule, {
     },
     {
       filename: 'test.js',
-      options: [['options']],
       code: `
       import { defineComponent } from 'vue'
       defineComponent({
@@ -88,21 +87,21 @@ tester.run('component-api-style', rule, {
         },
         // ...
       })
-      `
+      `,
+      options: [['options']]
     },
     {
       filename: 'test.vue',
-      options: [['script-setup']],
       code: `
       <script setup>
       import { ref } from 'vue'
       const msg = ref('Hello World!')
       </script>
-      `
+      `,
+      options: [['script-setup']]
     },
     {
       filename: 'test.js',
-      options: [['script-setup']],
       code: `
       import { ref, defineComponent } from 'vue'
       defineComponent({
@@ -115,11 +114,11 @@ tester.run('component-api-style', rule, {
           }
         }
       })
-      `
+      `,
+      options: [['script-setup']]
     },
     {
       filename: 'test.js',
-      options: [['script-setup']],
       code: `
       import { defineComponent } from 'vue'
       defineComponent({
@@ -131,11 +130,11 @@ tester.run('component-api-style', rule, {
         },
         // ...
       })
-      `
+      `,
+      options: [['script-setup']]
     },
     {
       filename: 'test.vue',
-      options: [['composition']],
       code: `
       <script>
       import { ref } from 'vue'
@@ -150,11 +149,11 @@ tester.run('component-api-style', rule, {
         }
       }
       </script>
-      `
+      `,
+      options: [['composition']]
     },
     {
       filename: 'test.vue',
-      options: [['composition-vue2']],
       code: `
       <script>
       import { ref } from 'vue'
@@ -172,12 +171,12 @@ tester.run('component-api-style', rule, {
         }
       }
       </script>
-      `
+      `,
+      options: [['composition-vue2']]
     },
     {
       // https://github.com/vuejs/eslint-plugin-vue/issues/1720
       filename: 'test.vue',
-      options: [['composition']],
       code: `
       <template>
         <div id="app">
@@ -201,7 +200,8 @@ tester.run('component-api-style', rule, {
           Navigation,
         },
       })
-      </script>`
+      </script>`,
+      options: [['composition']]
     }
   ],
   invalid: [
@@ -351,7 +351,6 @@ tester.run('component-api-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: [['script-setup']],
       code: `
       <script>
       export default {
@@ -365,6 +364,7 @@ tester.run('component-api-style', rule, {
       }
       </script>
       `,
+      options: [['script-setup']],
       errors: [
         {
           message:
@@ -392,7 +392,6 @@ tester.run('component-api-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: [['composition']],
       code: `
       <script>
       export default {
@@ -406,6 +405,7 @@ tester.run('component-api-style', rule, {
       }
       </script>
       `,
+      options: [['composition']],
       errors: [
         {
           message:
@@ -417,7 +417,6 @@ tester.run('component-api-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: [['composition']],
       code: `
       <script>
       export default {
@@ -452,6 +451,7 @@ tester.run('component-api-style', rule, {
       }
       </script>
       `,
+      options: [['composition']],
       errors: [
         {
           message:
@@ -623,7 +623,6 @@ tester.run('component-api-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: [['composition-vue2']],
       code: `
       <script>
       export default {
@@ -637,6 +636,7 @@ tester.run('component-api-style', rule, {
       }
       </script>
       `,
+      options: [['composition-vue2']],
       errors: [
         {
           message:
@@ -648,7 +648,6 @@ tester.run('component-api-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: [['composition-vue2']],
       code: `
       <script>
       export default {
@@ -683,6 +682,7 @@ tester.run('component-api-style', rule, {
       }
       </script>
       `,
+      options: [['composition-vue2']],
       errors: [
         {
           message:

--- a/tests/lib/rules/component-definition-name-casing.js
+++ b/tests/lib/rules/component-definition-name-casing.js
@@ -336,8 +336,8 @@ ruleTester.run('component-definition-name-casing', rule, {
       filename: 'test.vue',
       code: `(Vue as VueConstructor<Vue>).component('foo-bar', component)`,
       output: `(Vue as VueConstructor<Vue>).component('FooBar', component)`,
-      parserOptions,
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions,
       errors: [
         {
           message: 'Property name "foo-bar" is not PascalCase.',

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -19,6 +19,7 @@ tester.run('component-name-in-template-casing', rule, {
   valid: [
     // default
     {
+      filename: 'test.vue',
       code: `
         <template>
           <!-- ✓ GOOD -->
@@ -33,8 +34,7 @@ tester.run('component-name-in-template-casing', rule, {
           }
         }
         </script>
-      `,
-      filename: 'test.vue'
+      `
     },
 
     // element types test
@@ -126,6 +126,7 @@ tester.run('component-name-in-template-casing', rule, {
     },
     // regexp ignores
     {
+      filename: 'test.vue',
       code: `
         <template>
           <global-button />
@@ -133,7 +134,6 @@ tester.run('component-name-in-template-casing', rule, {
           <global-grid />
         </template>
       `,
-      filename: 'test.vue',
       options: [
         'PascalCase',
         { registeredComponentsOnly: false, ignores: ['/^global/'] }
@@ -164,12 +164,12 @@ tester.run('component-name-in-template-casing', rule, {
     },
 
     {
+      filename: 'test.vue',
       code: `
         <template><div/></template>
         <script setup>const Div = 0</script>
       `,
-      options: ['PascalCase'],
-      filename: 'test.vue'
+      options: ['PascalCase']
     },
 
     // globals
@@ -234,6 +234,7 @@ tester.run('component-name-in-template-casing', rule, {
   ],
   invalid: [
     {
+      filename: 'test.vue',
       code: `
         <template>
           <!-- ✗ BAD -->
@@ -249,7 +250,6 @@ tester.run('component-name-in-template-casing', rule, {
         }
         </script>
       `,
-      filename: 'test.vue',
       output: `
         <template>
           <!-- ✗ BAD -->
@@ -290,6 +290,7 @@ tester.run('component-name-in-template-casing', rule, {
       ]
     },
     {
+      filename: 'test.vue',
       code: `
         <template>
           <!-- ✗ BAD -->
@@ -305,8 +306,6 @@ tester.run('component-name-in-template-casing', rule, {
         }
         </script>
       `,
-      filename: 'test.vue',
-      options: ['kebab-case'],
       output: `
         <template>
           <!-- ✗ BAD -->
@@ -322,6 +321,7 @@ tester.run('component-name-in-template-casing', rule, {
         }
         </script>
       `,
+      options: ['kebab-case'],
       errors: [
         {
           message: 'Component name "CoolComponent" is not kebab-case.',
@@ -338,6 +338,7 @@ tester.run('component-name-in-template-casing', rule, {
       ]
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <svg>
@@ -350,8 +351,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <svg>
@@ -364,9 +363,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component id="id">
@@ -379,8 +380,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent id="id">
@@ -393,9 +392,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component :is="componentName">
@@ -408,8 +409,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent :is="componentName">
@@ -422,9 +421,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component id="id"/>
@@ -435,8 +436,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent id="id"/>
@@ -447,9 +446,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <TheComponent id="id">
@@ -462,8 +463,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['kebab-case'],
       output: `
       <template>
         <the-component id="id">
@@ -476,6 +475,7 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['kebab-case'],
       errors: ['Component name "TheComponent" is not kebab-case.']
     },
     {
@@ -484,15 +484,16 @@ tester.run('component-name-in-template-casing', rule, {
         <TheComponent id="id"/>
       </template>
       `,
-      options: ['kebab-case', { registeredComponentsOnly: false }],
       output: `
       <template>
         <the-component id="id"/>
       </template>
       `,
+      options: ['kebab-case', { registeredComponentsOnly: false }],
       errors: ['Component name "TheComponent" is not kebab-case.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component
@@ -504,8 +505,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent
@@ -517,9 +516,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component/>
@@ -530,8 +531,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent/>
@@ -542,9 +541,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component></the-component>
@@ -555,8 +556,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent>
@@ -567,9 +566,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <theComponent/>
@@ -580,8 +581,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent/>
@@ -592,9 +591,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "theComponent" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <theComponent/>
@@ -605,8 +606,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['kebab-case'],
       output: `
       <template>
         <the-component/>
@@ -617,9 +616,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['kebab-case'],
       errors: ['Component name "theComponent" is not kebab-case.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <The-component/>
@@ -630,8 +631,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent/>
@@ -642,9 +641,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "The-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <The-component/>
@@ -655,8 +656,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['kebab-case'],
       output: `
       <template>
         <the-component/>
@@ -667,6 +666,7 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['kebab-case'],
       errors: ['Component name "The-component" is not kebab-case.']
     },
     {
@@ -675,15 +675,16 @@ tester.run('component-name-in-template-casing', rule, {
         <Thecomponent/>
       </template>
       `,
-      options: ['kebab-case', { registeredComponentsOnly: false }],
       output: `
       <template>
         <thecomponent/>
       </template>
       `,
+      options: ['kebab-case', { registeredComponentsOnly: false }],
       errors: ['Component name "Thecomponent" is not kebab-case.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component></the-component  >
@@ -694,8 +695,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent  >
@@ -706,9 +705,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component></the-component
@@ -720,8 +721,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent
@@ -733,9 +732,11 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
+      filename: 'test.vue',
       code: `
       <template>
         <the-component></the-component end-tag-attr="attr" >
@@ -746,8 +747,6 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
-      filename: 'test.vue',
-      options: ['PascalCase'],
       output: `
       <template>
         <TheComponent></TheComponent end-tag-attr="attr" >
@@ -758,6 +757,7 @@ tester.run('component-name-in-template-casing', rule, {
       }
       </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
 
@@ -886,7 +886,6 @@ tester.run('component-name-in-template-casing', rule, {
           import TheComponent from '@/components/theComponent.vue'
         </script>
       `,
-      options: ['PascalCase'],
       output: `
         <template>
           <TheComponent />
@@ -895,6 +894,7 @@ tester.run('component-name-in-template-casing', rule, {
           import TheComponent from '@/components/theComponent.vue'
         </script>
       `,
+      options: ['PascalCase'],
       errors: ['Component name "the-component" is not PascalCase.']
     },
     {
@@ -906,7 +906,6 @@ tester.run('component-name-in-template-casing', rule, {
           import TheComponent from '@/components/theComponent.vue'
         </script>
       `,
-      options: ['kebab-case'],
       output: `
         <template>
           <the-component />
@@ -915,6 +914,7 @@ tester.run('component-name-in-template-casing', rule, {
           import TheComponent from '@/components/theComponent.vue'
         </script>
       `,
+      options: ['kebab-case'],
       errors: ['Component name "TheComponent" is not kebab-case.']
     },
     {
@@ -923,12 +923,12 @@ tester.run('component-name-in-template-casing', rule, {
           <router-view />
         </template>
       `,
-      options: ['PascalCase', { globals: ['RouterView'] }],
       output: `
         <template>
           <RouterView />
         </template>
       `,
+      options: ['PascalCase', { globals: ['RouterView'] }],
       errors: [
         {
           message: 'Component name "router-view" is not PascalCase.',
@@ -943,12 +943,12 @@ tester.run('component-name-in-template-casing', rule, {
           <RouterView />
         </template>
       `,
-      options: ['kebab-case', { globals: ['RouterView'] }],
       output: `
         <template>
           <router-view />
         </template>
       `,
+      options: ['kebab-case', { globals: ['RouterView'] }],
       errors: [
         {
           message: 'Component name "RouterView" is not kebab-case.',
@@ -963,12 +963,12 @@ tester.run('component-name-in-template-casing', rule, {
           <RouterView />
         </template>
       `,
-      options: ['kebab-case', { globals: ['router-view'] }],
       output: `
         <template>
           <router-view />
         </template>
       `,
+      options: ['kebab-case', { globals: ['router-view'] }],
       errors: [
         {
           message: 'Component name "RouterView" is not kebab-case.',

--- a/tests/lib/rules/component-name-in-template-casing.js
+++ b/tests/lib/rules/component-name-in-template-casing.js
@@ -151,17 +151,15 @@ tester.run('component-name-in-template-casing', rule, {
     },
 
     // built-in components (behave the same way as other components)
-    {
-      code: `
-        <template>
-          <component />
-          <suspense />
-          <teleport />
-          <client-only />
-          <keep-alive />
-        </template>
-      `
-    },
+    `
+      <template>
+        <component />
+        <suspense />
+        <teleport />
+        <client-only />
+        <keep-alive />
+      </template>
+    `,
 
     {
       filename: 'test.vue',

--- a/tests/lib/rules/component-options-name-casing.js
+++ b/tests/lib/rules/component-options-name-casing.js
@@ -117,32 +117,10 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
-      errors: [
-        {
-          messageId: 'caseNotMatched',
-          data: {
-            component: 'fooBar',
-            caseType: 'PascalCase'
-          },
-          line: 4,
-          column: 13,
-          endColumn: 19
-        }
-      ],
       output: `
         export default {
           components: {
             FooBar: fooBar
-          }
-        }
-      `
-    },
-    {
-      filename: 'test.vue',
-      code: `
-        export default {
-          components: {
-            fooBar: FooBar
           }
         }
       `,
@@ -157,14 +135,36 @@ tester.run('component-options-name-casing', rule, {
           column: 13,
           endColumn: 19
         }
-      ],
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          components: {
+            fooBar: FooBar
+          }
+        }
+      `,
       output: `
         export default {
           components: {
             FooBar: FooBar
           }
         }
-      `
+      `,
+      errors: [
+        {
+          messageId: 'caseNotMatched',
+          data: {
+            component: 'fooBar',
+            caseType: 'PascalCase'
+          },
+          line: 4,
+          column: 13,
+          endColumn: 19
+        }
+      ]
     },
     {
       filename: 'test.vue',
@@ -175,33 +175,10 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
-      options: ['PascalCase'],
-      errors: [
-        {
-          messageId: 'caseNotMatched',
-          data: {
-            component: 'fooBar',
-            caseType: 'PascalCase'
-          },
-          line: 4,
-          column: 13,
-          endColumn: 19
-        }
-      ],
       output: `
         export default {
           components: {
             FooBar: fooBar
-          }
-        }
-      `
-    },
-    {
-      filename: 'test.vue',
-      code: `
-        export default {
-          components: {
-            fooBar: FooBar
           }
         }
       `,
@@ -217,14 +194,37 @@ tester.run('component-options-name-casing', rule, {
           column: 13,
           endColumn: 19
         }
-      ],
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          components: {
+            fooBar: FooBar
+          }
+        }
+      `,
       output: `
         export default {
           components: {
             FooBar: FooBar
           }
         }
-      `
+      `,
+      options: ['PascalCase'],
+      errors: [
+        {
+          messageId: 'caseNotMatched',
+          data: {
+            component: 'fooBar',
+            caseType: 'PascalCase'
+          },
+          line: 4,
+          column: 13,
+          endColumn: 19
+        }
+      ]
     },
     {
       filename: 'test.vue',
@@ -232,6 +232,13 @@ tester.run('component-options-name-casing', rule, {
         export default {
           components: {
             'foo-bar': FooBar
+          }
+        }
+      `,
+      output: `
+        export default {
+          components: {
+            FooBar: FooBar
           }
         }
       `,
@@ -247,14 +254,7 @@ tester.run('component-options-name-casing', rule, {
           column: 13,
           endColumn: 22
         }
-      ],
-      output: `
-        export default {
-          components: {
-            FooBar: FooBar
-          }
-        }
-      `
+      ]
     },
     {
       filename: 'test.vue',
@@ -265,6 +265,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['camelCase'],
       errors: [
         {
@@ -290,8 +291,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -302,6 +302,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['camelCase'],
       errors: [
         {
@@ -327,8 +328,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -339,6 +339,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['camelCase'],
       errors: [
         {
@@ -364,8 +365,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -376,6 +376,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['kebab-case'],
       errors: [
         {
@@ -401,8 +402,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -413,6 +413,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['kebab-case'],
       errors: [
         {
@@ -438,8 +439,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -450,6 +450,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['kebab-case'],
       errors: [
         {
@@ -475,8 +476,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -487,6 +487,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['kebab-case'],
       errors: [
         {
@@ -512,8 +513,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -525,6 +525,7 @@ tester.run('component-options-name-casing', rule, {
           }
         }
       `,
+      output: null,
       options: ['kebab-case'],
       errors: [
         {
@@ -551,8 +552,7 @@ tester.run('component-options-name-casing', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     }
   ]
 })

--- a/tests/lib/rules/component-tags-order.js
+++ b/tests/lib/rules/component-tags-order.js
@@ -195,6 +195,7 @@ tester.run('component-tags-order', rule, {
   invalid: [
     {
       code: '<style></style><template></template><script></script>',
+      output: '<template></template><style></style><script></script>',
       errors: [
         {
           message: "'<template>' should be above '<style>' on line 1.",
@@ -206,11 +207,11 @@ tester.run('component-tags-order', rule, {
           line: 1,
           column: 37
         }
-      ],
-      output: '<template></template><style></style><script></script>'
+      ]
     },
     {
       code: '<template></template><script></script><style></style>',
+      output: '<script></script><template></template><style></style>',
       options: [{ order: ['script', 'template', 'style'] }],
       errors: [
         {
@@ -218,8 +219,7 @@ tester.run('component-tags-order', rule, {
           line: 1,
           column: 22
         }
-      ],
-      output: '<script></script><template></template><style></style>'
+      ]
     },
     {
       code: `
@@ -228,19 +228,19 @@ tester.run('component-tags-order', rule, {
         <style></style>
 
         <script></script>`,
-      errors: [
-        {
-          message: "'<script>' should be above '<style>' on line 4.",
-          line: 6
-        }
-      ],
       output:
         '\n' +
         '        <template></template>\n' +
         '\n' +
         '        <script></script>\n' +
         '\n' +
-        '        <style></style>'
+        '        <style></style>',
+      errors: [
+        {
+          message: "'<script>' should be above '<style>' on line 4.",
+          line: 6
+        }
+      ]
     },
     {
       code: `
@@ -248,19 +248,19 @@ tester.run('component-tags-order', rule, {
         <script></script>
         <style></style>
       `,
+      output:
+        '\n' +
+        '        <script></script>\n' +
+        '        <template></template>\n' +
+        '        <style></style>\n' +
+        '      ',
       options: [{ order: ['script', 'template', 'style'] }],
       errors: [
         {
           message: "'<script>' should be above '<template>' on line 2.",
           line: 3
         }
-      ],
-      output:
-        '\n' +
-        '        <script></script>\n' +
-        '        <template></template>\n' +
-        '        <style></style>\n' +
-        '      '
+      ]
     },
     {
       code: `
@@ -268,19 +268,19 @@ tester.run('component-tags-order', rule, {
         <template></template>
         <style></style>
       `,
+      output:
+        '\n' +
+        '        <template></template>\n' +
+        '        <script></script>\n' +
+        '        <style></style>\n' +
+        '      ',
       options: [{ order: ['template', 'script', 'style'] }],
       errors: [
         {
           message: "'<template>' should be above '<script>' on line 2.",
           line: 3
         }
-      ],
-      output:
-        '\n' +
-        '        <template></template>\n' +
-        '        <script></script>\n' +
-        '        <style></style>\n' +
-        '      '
+      ]
     },
     {
       code: `
@@ -289,20 +289,20 @@ tester.run('component-tags-order', rule, {
         <script></script>
         <style></style>
       `,
+      output:
+        '\n' +
+        '        <docs></docs>\n' +
+        '        <template></template>\n' +
+        '        <script></script>\n' +
+        '        <style></style>\n' +
+        '      ',
       options: [{ order: ['docs', 'template', 'script', 'style'] }],
       errors: [
         {
           message: "'<docs>' should be above '<template>' on line 2.",
           line: 3
         }
-      ],
-      output:
-        '\n' +
-        '        <docs></docs>\n' +
-        '        <template></template>\n' +
-        '        <script></script>\n' +
-        '        <style></style>\n' +
-        '      '
+      ]
     },
     {
       code: `
@@ -311,20 +311,20 @@ tester.run('component-tags-order', rule, {
         <script></script>
         <style></style>
       `,
-      options: [{ order: ['script', 'template', 'style'] }],
-      errors: [
-        {
-          message: "'<script>' should be above '<template>' on line 2.",
-          line: 4
-        }
-      ],
       output:
         '\n' +
         '        <script></script>\n' +
         '        <template></template>\n' +
         '        <docs></docs>\n' +
         '        <style></style>\n' +
-        '      '
+        '      ',
+      options: [{ order: ['script', 'template', 'style'] }],
+      errors: [
+        {
+          message: "'<script>' should be above '<template>' on line 2.",
+          line: 4
+        }
+      ]
     },
     {
       code: `
@@ -334,13 +334,6 @@ tester.run('component-tags-order', rule, {
         <script></script>
         <style></style>
       `,
-      options: [{ order: ['script', 'template', 'style'] }],
-      errors: [
-        {
-          message: "'<script>' should be above '<template>' on line 2.",
-          line: 5
-        }
-      ],
       output:
         '\n' +
         '        <script></script>\n' +
@@ -348,22 +341,29 @@ tester.run('component-tags-order', rule, {
         '        <docs>\n' +
         '        </docs>\n' +
         '        <style></style>\n' +
-        '      '
+        '      ',
+      options: [{ order: ['script', 'template', 'style'] }],
+      errors: [
+        {
+          message: "'<script>' should be above '<template>' on line 2.",
+          line: 5
+        }
+      ]
     },
     {
       code: `
         <script></script>
         <template></template>
       `,
+      output:
+        '\n        <template></template>\n        <script></script>\n      ',
       options: [{ order: ['template', 'script'] }],
       errors: [
         {
           message: "'<template>' should be above '<script>' on line 2.",
           line: 3
         }
-      ],
-      output:
-        '\n        <template></template>\n        <script></script>\n      '
+      ]
     },
     {
       code: `
@@ -371,6 +371,12 @@ tester.run('component-tags-order', rule, {
         <template></template>
         <script></script>
       `,
+      output:
+        '\n' +
+        '        <template></template>\n' +
+        '        <style></style>\n' +
+        '        <script></script>\n' +
+        '      ',
       errors: [
         {
           message: "'<template>' should be above '<style>' on line 2.",
@@ -380,13 +386,7 @@ tester.run('component-tags-order', rule, {
           message: "'<script>' should be above '<style>' on line 2.",
           line: 4
         }
-      ],
-      output:
-        '\n' +
-        '        <template></template>\n' +
-        '        <style></style>\n' +
-        '        <script></script>\n' +
-        '      '
+      ]
     },
     {
       code: `
@@ -395,6 +395,13 @@ tester.run('component-tags-order', rule, {
         <template></template>
         <script></script>
       `,
+      output:
+        '\n' +
+        '        <template></template>\n' +
+        '        <style></style>\n' +
+        '        <docs></docs>\n' +
+        '        <script></script>\n' +
+        '      ',
       errors: [
         {
           message: "'<template>' should be above '<style>' on line 2.",
@@ -404,14 +411,7 @@ tester.run('component-tags-order', rule, {
           message: "'<script>' should be above '<style>' on line 2.",
           line: 5
         }
-      ],
-      output:
-        '\n' +
-        '        <template></template>\n' +
-        '        <style></style>\n' +
-        '        <docs></docs>\n' +
-        '        <script></script>\n' +
-        '      '
+      ]
     },
     // no <template>
     {
@@ -419,13 +419,13 @@ tester.run('component-tags-order', rule, {
         <style></style>
         <script></script>
       `,
+      output: '\n        <script></script>\n        <style></style>\n      ',
       errors: [
         {
           message: "'<script>' should be above '<style>' on line 2.",
           line: 3
         }
-      ],
-      output: '\n        <script></script>\n        <style></style>\n      '
+      ]
     },
     {
       code: '<i18n locale="ja"></i18n><i18n locale="en"></i18n>',

--- a/tests/lib/rules/define-emits-declaration.js
+++ b/tests/lib/rules/define-emits-declaration.js
@@ -49,10 +49,10 @@ tester.run('define-emits-declaration', rule, {
         }>()
         </script>
        `,
+      options: ['type-based'],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      options: ['type-based']
+      }
     },
     {
       filename: 'test.vue',
@@ -118,13 +118,13 @@ tester.run('define-emits-declaration', rule, {
        const emit = defineEmits(['change', 'update'])
        </script>
        `,
+      options: ['type-based'],
       errors: [
         {
           message: 'Use type-based declaration instead of runtime declaration.',
           line: 3
         }
-      ],
-      options: ['type-based']
+      ]
     },
     {
       filename: 'test.vue',
@@ -136,6 +136,7 @@ tester.run('define-emits-declaration', rule, {
         }>()
         </script>
        `,
+      options: ['runtime'],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },
@@ -144,8 +145,7 @@ tester.run('define-emits-declaration', rule, {
           message: 'Use runtime declaration instead of type-based declaration.',
           line: 3
         }
-      ],
-      options: ['runtime']
+      ]
     }
   ]
 })

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -328,10 +328,10 @@ tester.run('define-macros-order', rule, {
           })
         </script>
       `,
+      options: optionsEmitsFirst,
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },
-      options: optionsEmitsFirst,
       errors: [
         {
           message: message('defineEmits'),
@@ -417,10 +417,10 @@ tester.run('define-macros-order', rule, {
           console.log('test3')
         </script>
       `,
+      options: optionsEmitsFirst,
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },
-      options: optionsEmitsFirst,
       errors: [
         {
           message: message('defineEmits'),

--- a/tests/lib/rules/define-props-declaration.js
+++ b/tests/lib/rules/define-props-declaration.js
@@ -39,10 +39,10 @@ tester.run('define-props-declaration', rule, {
       }>()
       </script>
       `,
+      options: ['type-based'],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      options: ['type-based']
+      }
     },
     {
       filename: 'test.vue',
@@ -125,13 +125,13 @@ tester.run('define-props-declaration', rule, {
       })
       </script>
       `,
+      options: ['type-based'],
       errors: [
         {
           message: 'Use type-based declaration instead of runtime declaration.',
           line: 3
         }
-      ],
-      options: ['type-based']
+      ]
     },
     {
       filename: 'test.vue',
@@ -142,10 +142,10 @@ tester.run('define-props-declaration', rule, {
       }>()
       </script>
       `,
+      options: ['runtime'],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },
-      options: ['runtime'],
       errors: [
         {
           message: 'Use runtime declaration instead of type-based declaration.',

--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -61,7 +61,6 @@ tester.run('dot-location', rule, {
             bar"
         />
       </template>`,
-      options: ['property'],
       output: `
       <template>
         <div
@@ -69,6 +68,7 @@ tester.run('dot-location', rule, {
             .bar"
         />
       </template>`,
+      options: ['property'],
       errors: [
         {
           message: 'Expected dot to be on same line as property.',

--- a/tests/lib/rules/first-attribute-linebreak.js
+++ b/tests/lib/rules/first-attribute-linebreak.js
@@ -14,14 +14,12 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('first-attribute-linebreak', rule, {
   valid: [
-    {
-      code: `
+    `
       <template>
         <component></component>
-      </template>`
-    },
-    {
-      code: `
+      </template>
+    `,
+    `
       <template>
         <component
           name="John Doe"
@@ -33,8 +31,8 @@ ruleTester.run('first-attribute-linebreak', rule, {
         ></component>
         <component name="John Doe"
         ></component>
-      </template>`
-    },
+      </template>
+    `,
     {
       code: `
       <template>

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -75,12 +75,12 @@ tester.run('func-call-spacing', rule, {
         <div :foo="foo()" />
       </template>
       `,
-      options: ['always'],
       output: `
       <template>
         <div :foo="foo ()" />
       </template>
       `,
+      options: ['always'],
       errors: [
         {
           message: 'Missing space between function name and paren.',

--- a/tests/lib/rules/html-button-has-type.js
+++ b/tests/lib/rules/html-button-has-type.js
@@ -95,8 +95,8 @@ ruleTester.run('html-button-has-type', rule, {
     },
     {
       filename: 'test.vue',
-      options: [{ button: false }],
       code: '<template><button type="button">Hello World</button></template>',
+      options: [{ button: false }],
       errors: [
         {
           message: 'button is a forbidden value for button type attribute.',
@@ -106,8 +106,8 @@ ruleTester.run('html-button-has-type', rule, {
     },
     {
       filename: 'test.vue',
-      options: [{ submit: false }],
       code: '<template><button type="submit">Hello World</button></template>',
+      options: [{ submit: false }],
       errors: [
         {
           message: 'submit is a forbidden value for button type attribute.',
@@ -117,8 +117,8 @@ ruleTester.run('html-button-has-type', rule, {
     },
     {
       filename: 'test.vue',
-      options: [{ reset: false }],
       code: '<template><button type="reset">Hello World</button></template>',
+      options: [{ reset: false }],
       errors: [
         {
           message: 'reset is a forbidden value for button type attribute.',
@@ -128,12 +128,12 @@ ruleTester.run('html-button-has-type', rule, {
     },
     {
       filename: 'test.vue',
-      options: [{ button: false, submit: false, reset: false }],
       code: `<template>
                 <button type="button">Hello World</button>
                 <button type="submit">Hello World</button>
                 <button type="reset">Hello World</button>
              </template>`,
+      options: [{ button: false, submit: false, reset: false }],
       errors: [
         {
           message: 'button is a forbidden value for button type attribute.',
@@ -154,7 +154,6 @@ ruleTester.run('html-button-has-type', rule, {
     },
     {
       filename: 'test.vue',
-      options: [{ button: true, submit: true, reset: false }],
       code: `<template>
                 <button type="button">Hello World</button>
                 <button type="submit">Hello World</button>
@@ -162,6 +161,7 @@ ruleTester.run('html-button-has-type', rule, {
                 <button type="">Hello World</button>
                 <button type="foo">Hello World</button>
              </template>`,
+      options: [{ button: true, submit: true, reset: false }],
       errors: [
         {
           message: 'reset is a forbidden value for button type attribute.',

--- a/tests/lib/rules/html-comment-content-newline.js
+++ b/tests/lib/rules/html-comment-content-newline.js
@@ -290,13 +290,13 @@ tester.run('html-comment-content-newline', rule, {
           <!--  comment  -->
         </template>
         `,
-      options: ['always'],
       output: `
         <template>
           <!--\ncomment\n-->
           <!--\n  comment  \n-->
         </template>
         `,
+      options: ['always'],
       errors: [
         {
           message: "Expected line break after '<!--'.",
@@ -332,12 +332,12 @@ comment
 -->
         </template>
         `,
-      options: ['never'],
       output: `
         <template>
           <!-- comment -->
         </template>
         `,
+      options: ['never'],
       errors: [
         {
           message: "Unexpected line breaks after '<!--'.",
@@ -361,12 +361,12 @@ comment
           <!-- \t \t  \t\tcomment \t \t  \t\t-->
         </template>
         `,
-      options: ['always'],
       output: `
         <template>
           <!--\n \t \t  \t\tcomment \t \t  \t\t\n-->
         </template>
         `,
+      options: ['always'],
       errors: [
         {
           message: "Expected line break after '<!--'.",
@@ -389,8 +389,8 @@ comment
           <!--++++++++++++++++comment++++++++++++++++-->
         </template>
         `,
-      options: ['always', { exceptions: ['+'] }],
       output: null,
+      options: ['always', { exceptions: ['+'] }],
       errors: [
         'Expected line break after exception block.',
         'Expected line break before exception block.'
@@ -402,8 +402,8 @@ comment
           <!--*****comment**-->
         </template>
         `,
-      options: ['always', { exceptions: ['*'] }],
       output: null,
+      options: ['always', { exceptions: ['*'] }],
       errors: [
         'Expected line break after exception block.',
         'Expected line break before exception block.'
@@ -415,12 +415,12 @@ comment
           <!--#+#-#+#-#+#-comment #+#-->
         </template>
         `,
-      options: ['always', { exceptions: ['#+#-'] }],
       output: `
         <template>
           <!--#+#-#+#-#+#-comment #+#\n-->
         </template>
         `,
+      options: ['always', { exceptions: ['#+#-'] }],
       errors: [
         'Expected line break after exception block.',
         "Expected line break before '-->'."
@@ -432,8 +432,8 @@ comment
           <!--*****comment++++-->
         </template>
         `,
-      options: ['always', { exceptions: ['*', '++'] }],
       output: null,
+      options: ['always', { exceptions: ['*', '++'] }],
       errors: [
         'Expected line break after exception block.',
         {
@@ -449,8 +449,8 @@ comment
           <!--*****comment+++++-->
         </template>
         `,
-      options: ['always', { exceptions: ['*', '++'] }],
       output: null,
+      options: ['always', { exceptions: ['*', '++'] }],
       errors: [
         'Expected line break after exception block.',
         {

--- a/tests/lib/rules/html-comment-content-newline.js
+++ b/tests/lib/rules/html-comment-content-newline.js
@@ -16,17 +16,15 @@ const tester = new RuleTester({
 })
 tester.run('html-comment-content-newline', rule, {
   valid: [
-    {
-      code: `
-        <template>
-          <!-- comment -->
-          <!--
-            multiline
-            comment
-          -->
-        </template>
-        `
-    },
+    `
+      <template>
+        <!-- comment -->
+        <!--
+          multiline
+          comment
+        -->
+      </template>
+    `,
     {
       code: `
         <template>
@@ -216,24 +214,20 @@ tester.run('html-comment-content-newline', rule, {
     },
 
     // IE conditional comments
-    {
-      code: `
-        <template>
-          <!--[if IE 8]>
-          <div>IE8 only</div>
-          <![endif]-->
-        </template>
-        `
-    },
-    {
-      code: `
-        <template>
-          <!--[if !IE]><!-->
-          <div>not IE only</div>
-          <!--<![endif]-->
-        </template>
-        `
-    }
+    `
+      <template>
+        <!--[if IE 8]>
+        <div>IE8 only</div>
+        <![endif]-->
+      </template>
+    `,
+    `
+      <template>
+        <!--[if !IE]><!-->
+        <div>not IE only</div>
+        <!--<![endif]-->
+      </template>
+    `
   ],
 
   invalid: [

--- a/tests/lib/rules/html-comment-content-spacing.js
+++ b/tests/lib/rules/html-comment-content-spacing.js
@@ -16,13 +16,11 @@ const tester = new RuleTester({
 })
 tester.run('html-comment-content-spacing', rule, {
   valid: [
-    {
-      code: `
-        <template>
-          <!-- comment -->
-        </template>
-        `
-    },
+    `
+      <template>
+        <!-- comment -->
+      </template>
+    `,
     {
       code: `
         <template>
@@ -178,24 +176,20 @@ tester.run('html-comment-content-spacing', rule, {
     },
 
     // IE conditional comments
-    {
-      code: `
-        <template>
-          <!--[if IE 8]>
-          <div>IE8 only</div>
-          <![endif]-->
-        </template>
-        `
-    },
-    {
-      code: `
-        <template>
-          <!--[if !IE]><!-->
-          <div>not IE only</div>
-          <!--<![endif]-->
-        </template>
-        `
-    }
+    `
+      <template>
+        <!--[if IE 8]>
+        <div>IE8 only</div>
+        <![endif]-->
+      </template>
+    `,
+    `
+      <template>
+        <!--[if !IE]><!-->
+        <div>not IE only</div>
+        <!--<![endif]-->
+      </template>
+    `
   ],
 
   invalid: [

--- a/tests/lib/rules/html-comment-content-spacing.js
+++ b/tests/lib/rules/html-comment-content-spacing.js
@@ -205,12 +205,12 @@ tester.run('html-comment-content-spacing', rule, {
           <!--comment-->
         </template>
         `,
-      options: ['always'],
       output: `
         <template>
           <!-- comment -->
         </template>
         `,
+      options: ['always'],
       errors: [
         {
           message: "Expected space after '<!--'.",
@@ -232,12 +232,12 @@ tester.run('html-comment-content-spacing', rule, {
           <!-- comment -->
         </template>
         `,
-      options: ['never'],
       output: `
         <template>
           <!--comment-->
         </template>
         `,
+      options: ['never'],
       errors: [
         {
           message: "Unexpected space after '<!--'.",
@@ -259,12 +259,12 @@ tester.run('html-comment-content-spacing', rule, {
           <!-- \t \t  \t\tcomment \t \t  \t\t-->
         </template>
         `,
-      options: ['never'],
       output: `
         <template>
           <!--comment-->
         </template>
         `,
+      options: ['never'],
       errors: [
         {
           message: "Unexpected space after '<!--'.",
@@ -287,8 +287,8 @@ tester.run('html-comment-content-spacing', rule, {
           <!--++++++++++++++++comment++++++++++++++++-->
         </template>
         `,
-      options: ['always', { exceptions: ['+'] }],
       output: null,
+      options: ['always', { exceptions: ['+'] }],
       errors: [
         'Expected space after exception block.',
         'Expected space before exception block.'
@@ -300,8 +300,8 @@ tester.run('html-comment-content-spacing', rule, {
           <!--*****comment**-->
         </template>
         `,
-      options: ['always', { exceptions: ['*'] }],
       output: null,
+      options: ['always', { exceptions: ['*'] }],
       errors: [
         'Expected space after exception block.',
         'Expected space before exception block.'
@@ -313,12 +313,12 @@ tester.run('html-comment-content-spacing', rule, {
           <!--#+#-#+#-#+#-comment #+#-->
         </template>
         `,
-      options: ['always', { exceptions: ['#+#-'] }],
       output: `
         <template>
           <!--#+#-#+#-#+#-comment #+# -->
         </template>
         `,
+      options: ['always', { exceptions: ['#+#-'] }],
       errors: [
         'Expected space after exception block.',
         "Expected space before '-->'."
@@ -330,8 +330,8 @@ tester.run('html-comment-content-spacing', rule, {
           <!--*****comment++++-->
         </template>
         `,
-      options: ['always', { exceptions: ['*', '++'] }],
       output: null,
+      options: ['always', { exceptions: ['*', '++'] }],
       errors: [
         'Expected space after exception block.',
         {
@@ -347,8 +347,8 @@ tester.run('html-comment-content-spacing', rule, {
           <!--*****comment+++++-->
         </template>
         `,
-      options: ['always', { exceptions: ['*', '++'] }],
       output: null,
+      options: ['always', { exceptions: ['*', '++'] }],
       errors: [
         'Expected space after exception block.',
         {

--- a/tests/lib/rules/html-comment-indent.js
+++ b/tests/lib/rules/html-comment-indent.js
@@ -232,7 +232,6 @@ tester.run('html-comment-indent', rule, {
            -->
         </template>
         `,
-      options: ['tab'],
       output: `
         <template>
           <!-- comment
@@ -248,6 +247,7 @@ tester.run('html-comment-indent', rule, {
             -->
         </template>
         `,
+      options: ['tab'],
       errors: [
         {
           message: 'Expected relative indentation of 1 tab but found 0 tabs.',
@@ -318,7 +318,6 @@ tester.run('html-comment-indent', rule, {
           -->
         </template>
         `,
-      options: [4],
       output: `
         <template>
           <!-- comment
@@ -334,6 +333,7 @@ tester.run('html-comment-indent', rule, {
             -->
         </template>
         `,
+      options: [4],
       errors: [
         {
           message:
@@ -407,7 +407,6 @@ tester.run('html-comment-indent', rule, {
           -->
         </template>
         `,
-      options: [0],
       output: `
         <template>
           <!--
@@ -423,6 +422,7 @@ tester.run('html-comment-indent', rule, {
             -->
         </template>
         `,
+      options: [0],
       errors: [
         {
           message:

--- a/tests/lib/rules/html-comment-indent.js
+++ b/tests/lib/rules/html-comment-indent.js
@@ -16,23 +16,21 @@ const tester = new RuleTester({
 })
 tester.run('html-comment-indent', rule, {
   valid: [
-    {
-      code: `
-        <template>
-          <!-- comment
-            comment
-          -->
+    `
+      <template>
+        <!-- comment
+          comment
+        -->
+        <!--
+          comment
+          comment
+        -->
           <!--
             comment
             comment
           -->
-            <!--
-              comment
-              comment
-            -->
-        </template>
-        `
-    },
+      </template>
+    `,
     {
       code: `
         <template>
@@ -87,44 +85,38 @@ tester.run('html-comment-indent', rule, {
         `,
       options: [0]
     },
-    {
-      code: `
-        <template>
-          <!-- comment
-        \t
-            comment
-            \t
-            comment
+    `
+      <template>
+        <!-- comment
+      \t
+          comment
           \t
-          -->
-          <!--
+          comment
         \t
-          -->
-          <!--
-          -->
-        </template>
-        `
-    },
+        -->
+        <!--
+      \t
+        -->
+        <!--
+        -->
+      </template>
+    `,
 
     // IE conditional comments
-    {
-      code: `
-        <template>
-          <!--[if IE 8]>
-          <div>IE8 only</div>
-          <![endif]-->
-        </template>
-        `
-    },
-    {
-      code: `
-        <template>
-          <!--[if !IE]><!-->
-          <div>not IE only</div>
-          <!--<![endif]-->
-        </template>
-        `
-    }
+    `
+      <template>
+        <!--[if IE 8]>
+        <div>IE8 only</div>
+        <![endif]-->
+      </template>
+    `,
+    `
+      <template>
+        <!--[if !IE]><!-->
+        <div>not IE only</div>
+        <!--<![endif]-->
+      </template>
+    `
   ],
 
   invalid: [

--- a/tests/lib/rules/html-end-tags.js
+++ b/tests/lib/rules/html-end-tags.js
@@ -62,6 +62,7 @@ tester.run('html-end-tags', rule, {
 
     // https://github.com/vuejs/eslint-plugin-vue/issues/1403
     {
+      filename: 'test.vue',
       code: `
       <template>
         <div>
@@ -72,8 +73,7 @@ tester.run('html-end-tags', rule, {
           </p>
         </div>
       </template>
-      `,
-      filename: 'test.vue'
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/html-self-closing.js
+++ b/tests/lib/rules/html-self-closing.js
@@ -69,6 +69,7 @@ tester.run('html-self-closing', rule, {
 
     // https://github.com/vuejs/eslint-plugin-vue/issues/1403
     {
+      filename: 'test.vue',
       code: `
       <template>
         <div>
@@ -79,8 +80,7 @@ tester.run('html-self-closing', rule, {
           </p>
         </div>
       </template>
-      `,
-      filename: 'test.vue'
+      `
     }
 
     // other cases are in `invalid` tests.

--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -27,8 +27,7 @@ linter.defineRule('jsx-uses-vars', rule)
 describe('jsx-uses-vars', () => {
   ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     valid: [
-      {
-        code: `
+      `
         /* eslint jsx-uses-vars: 1 */
         import SomeComponent from './SomeComponent.jsx';
         export default {
@@ -38,10 +37,8 @@ describe('jsx-uses-vars', () => {
             )
           },
         };
+      `,
       `
-      },
-      {
-        code: `
         /* eslint jsx-uses-vars: 1 */
         import SomeComponent from './SomeComponent.vue';
         import OtherComponent from './OtherComponent.vue';
@@ -63,10 +60,8 @@ describe('jsx-uses-vars', () => {
             )
           }
         }
+      `,
       `
-      },
-      {
-        code: `
         /* eslint jsx-uses-vars: 1 */
         export default {
           render () {
@@ -76,7 +71,6 @@ describe('jsx-uses-vars', () => {
           }
         }
       `
-      }
     ],
 
     invalid: [

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -31,8 +31,8 @@ tester.run('key-spacing', rule, {
     },
     {
       code: '<template><div :[{a:1}[`a`]]="{a:1}[`a`]" /></template>',
-      options: [{ beforeColon: true }],
       output: '<template><div :[{a:1}[`a`]]="{a : 1}[`a`]" /></template>',
+      options: [{ beforeColon: true }],
       errors: [
         "Missing space after key 'a'.",
         "Missing space before value for key 'a'."

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -101,7 +101,6 @@ tester.run('keyword-spacing', rule, {
           }
         " />
       </template>`,
-      options: [{ before: false, after: false }],
       output: `<template>
         <div @event="
           if(foo) {
@@ -113,6 +112,7 @@ tester.run('keyword-spacing', rule, {
           }
         " />
       </template>`,
+      options: [{ before: false, after: false }],
       errors: [
         {
           message: 'Unexpected space(s) after "if".',

--- a/tests/lib/rules/max-attributes-per-line.js
+++ b/tests/lib/rules/max-attributes-per-line.js
@@ -14,23 +14,17 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('max-attributes-per-line', rule, {
   valid: [
-    {
-      code: `<template><component></component></template>`
-    },
-    {
-      code: `<template><component
+    `<template><component></component></template>`,
+    `<template><component
         name="John Doe"
         age="30"
         job="Vet"
-      ></component></template>`
-    },
-    {
-      code: `<template><component
+      ></component></template>`,
+    `<template><component
         name="John Doe"
         age="30"
       >
-      </component></template>`
-    },
+      </component></template>`,
     {
       code: `<template><component
         name="John Doe"
@@ -39,13 +33,11 @@ ruleTester.run('max-attributes-per-line', rule, {
       </template>`,
       options: [{ singleline: 1 }]
     },
-    {
-      code: `<template><component job="Vet"
+    `<template><component job="Vet"
         name="John Doe"
         age="30">
         </component>
       </template>`
-    }
   ],
 
   invalid: [

--- a/tests/lib/rules/max-attributes-per-line.js
+++ b/tests/lib/rules/max-attributes-per-line.js
@@ -93,9 +93,9 @@ v-bind:age="user.age"></component></template>`,
     },
     {
       code: `<template><component name="John Doe" age="30" job="Vet"></component></template>`,
-      options: [{ singleline: { max: 2 } }],
       output: `<template><component name="John Doe" age="30"
 job="Vet"></component></template>`,
+      options: [{ singleline: { max: 2 } }],
       errors: [
         {
           message: "'job' should be on a new line.",
@@ -110,13 +110,13 @@ job="Vet"></component></template>`,
         job="Vet">
         </component>
       </template>`,
-      options: [{ singleline: 3, multiline: 1 }],
       output: `<template><component
         name="John Doe"
 age="30"
         job="Vet">
         </component>
       </template>`,
+      options: [{ singleline: 3, multiline: 1 }],
       errors: [
         {
           message: "'age' should be on a new line.",
@@ -131,13 +131,13 @@ age="30"
         job="Vet">
         </component>
       </template>`,
-      options: [{ multiline: { max: 1 } }],
       output: `<template><component
         name="John Doe"
 age="30"
         job="Vet">
         </component>
       </template>`,
+      options: [{ multiline: { max: 1 } }],
       errors: [
         {
           message: "'age' should be on a new line.",

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -1075,33 +1075,33 @@ var a = /regexploooooooooooooooooooooooooooooooooooooooooooooooooooooong/.test(b
     {
       filename: 'test.vue',
       code: `<template><div> 41 cols </div></template>`,
-      errors: ['This line has a length of 41. Maximum allowed is 40.'],
-      options: [40]
+      options: [40],
+      errors: ['This line has a length of 41. Maximum allowed is 40.']
     },
     {
       filename: 'test.vue',
       code: `<template><div> 41 cols </div></template>`,
-      errors: ['This line has a length of 41. Maximum allowed is 40.'],
-      options: [{ code: 40 }]
+      options: [{ code: 40 }],
+      errors: ['This line has a length of 41. Maximum allowed is 40.']
     },
     // tabWidth
     {
       filename: 'test.vue',
       code: `<template><div>\t41\tcols\t</div></template>`,
-      errors: ['This line has a length of 45. Maximum allowed is 40.'],
-      options: [40, 4]
+      options: [40, 4],
+      errors: ['This line has a length of 45. Maximum allowed is 40.']
     },
     {
       filename: 'test.vue',
       code: `<template><div>\t41\tcols\t</div></template>`,
-      errors: ['This line has a length of 45. Maximum allowed is 40.'],
-      options: [{ code: 40, tabWidth: 4 }]
+      options: [{ code: 40, tabWidth: 4 }],
+      errors: ['This line has a length of 45. Maximum allowed is 40.']
     },
     {
       filename: 'test.vue',
       code: `<template><div>\t41\tcols\t</div></template>`,
-      errors: ['This line has a length of 44. Maximum allowed is 40.'],
-      options: [{ code: 40, tabWidth: 3 }]
+      options: [{ code: 40, tabWidth: 3 }],
+      errors: ['This line has a length of 44. Maximum allowed is 40.']
     },
     // comments
     {
@@ -1122,6 +1122,7 @@ var a;  // 41 cols comment                      *
 */
 </script>
 `,
+      options: [{ comments: 40 }],
       errors: [
         {
           message:
@@ -1148,8 +1149,7 @@ var a;  // 41 cols comment                      *
             'This line has a comment length of 41. Maximum allowed is 40.',
           line: 13
         }
-      ],
-      options: [{ comments: 40 }]
+      ]
     },
     // .js
     {
@@ -1159,6 +1159,7 @@ var a = '81 columns                                                            '
 var b = \`81 columns                                                            \`;
 /* 81 columns                                                                  */
       `,
+      options: [],
       errors: [
         {
           message: 'This line has a length of 81. Maximum allowed is 80.',
@@ -1172,8 +1173,7 @@ var b = \`81 columns                                                            
           message: 'This line has a length of 81. Maximum allowed is 80.',
           line: 4
         }
-      ],
-      options: []
+      ]
     },
     {
       filename: 'test.js',
@@ -1182,6 +1182,7 @@ var a = '81 columns          ignoreStrings                                     '
 var b = \`81 columns                                                            \`;
 /* 81 columns                                                                  */
       `,
+      options: [{ ignoreStrings: true }],
       errors: [
         {
           message: 'This line has a length of 81. Maximum allowed is 80.',
@@ -1191,8 +1192,7 @@ var b = \`81 columns                                                            
           message: 'This line has a length of 81. Maximum allowed is 80.',
           line: 4
         }
-      ],
-      options: [{ ignoreStrings: true }]
+      ]
     },
     {
       filename: 'test.js',
@@ -1201,6 +1201,7 @@ var a = '81 columns                                                            '
 var b = \`81 columns                                                            \`;
 /* 81 columns                                                                  */
       `,
+      options: [{ ignoreComments: true }],
       errors: [
         {
           message: 'This line has a length of 81. Maximum allowed is 80.',
@@ -1210,8 +1211,7 @@ var b = \`81 columns                                                            
           message: 'This line has a length of 81. Maximum allowed is 80.',
           line: 3
         }
-      ],
-      options: [{ ignoreComments: true }]
+      ]
     },
     // only script comment
     {
@@ -1222,6 +1222,7 @@ var b = \`81 columns                                                            
 41 cols                                 *
 */
 `,
+      options: [{ comments: 40 }],
       errors: [
         {
           message:
@@ -1238,8 +1239,7 @@ var b = \`81 columns                                                            
             'This line has a comment length of 41. Maximum allowed is 40.',
           line: 4
         }
-      ],
-      options: [{ comments: 40 }]
+      ]
     }
   ]
 })

--- a/tests/lib/rules/multi-word-component-names.js
+++ b/tests/lib/rules/multi-word-component-names.js
@@ -165,14 +165,14 @@ tester.run('multi-word-component-names', rule, {
     },
     {
       filename: 'test.vue',
-      options: [{ ignores: ['Todo'] }],
       code: `
       <script>
       export default {
         name: 'Todo'
       }
       </script>
-      `
+      `,
+      options: [{ ignores: ['Todo'] }]
     },
     {
       filename: 'test.js',
@@ -314,7 +314,6 @@ tester.run('multi-word-component-names', rule, {
     },
     {
       filename: 'test.vue',
-      options: [{ ignores: ['Todo'] }],
       code: `
       <script>
       export default {
@@ -322,6 +321,7 @@ tester.run('multi-word-component-names', rule, {
       }
       </script>
       `,
+      options: [{ ignores: ['Todo'] }],
       errors: [
         {
           message: 'Component name "Item" should always be multi-word.',

--- a/tests/lib/rules/multiline-html-element-content-newline.js
+++ b/tests/lib/rules/multiline-html-element-content-newline.js
@@ -566,7 +566,6 @@ content
           <div
             class="panel"></div>
         </template>`,
-      options: [{ allowEmptyLines: true, ignoreWhenEmpty: false }],
       output: `
         <template>
           <div
@@ -577,6 +576,7 @@ content
             class="panel">
 </div>
         </template>`,
+      options: [{ allowEmptyLines: true, ignoreWhenEmpty: false }],
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
       ]
@@ -594,7 +594,6 @@ content
             content</div>
         </template>
       `,
-      options: [{ allowEmptyLines: true }],
       output: `
         <template>
           <div>
@@ -609,6 +608,7 @@ content
 </div>
         </template>
       `,
+      options: [{ allowEmptyLines: true }],
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
         'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'

--- a/tests/lib/rules/multiline-ternary.js
+++ b/tests/lib/rules/multiline-ternary.js
@@ -92,6 +92,7 @@ tester.run('multiline-ternary', rule, {
         </template>
         `
         : null,
+      options: ['always-multiline'],
       errors: [
         {
           message:
@@ -99,8 +100,7 @@ tester.run('multiline-ternary', rule, {
           line: 5,
           column: 15
         }
-      ],
-      options: ['always-multiline']
+      ]
     },
     {
       filename: 'test.vue',
@@ -123,6 +123,7 @@ tester.run('multiline-ternary', rule, {
         </template>
         `
         : null,
+      options: ['never'],
       errors: [
         {
           message:
@@ -130,8 +131,7 @@ tester.run('multiline-ternary', rule, {
           line: 4,
           column: 21
         }
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',

--- a/tests/lib/rules/new-line-between-multi-line-property.js
+++ b/tests/lib/rules/new-line-between-multi-line-property.js
@@ -280,7 +280,6 @@ ruleTester.run('new-line-between-multi-line-property', rule, {
     // test set insertLine and minLineOfMultilineProperty to 5
     {
       filename: 'test.vue',
-      options: [{ minLineOfMultilineProperty: 5 }],
       code: `
       <script>
       export default {
@@ -320,6 +319,7 @@ ruleTester.run('new-line-between-multi-line-property', rule, {
       }
       </script>
       `,
+      options: [{ minLineOfMultilineProperty: 5 }],
       errors: [
         {
           message:
@@ -331,7 +331,6 @@ ruleTester.run('new-line-between-multi-line-property', rule, {
     // test js comments
     {
       filename: 'test.vue',
-      options: [{ minLineOfMultilineProperty: 5 }],
       code: `
       <script>
       export default {
@@ -373,6 +372,7 @@ ruleTester.run('new-line-between-multi-line-property', rule, {
       }
       </script>
       `,
+      options: [{ minLineOfMultilineProperty: 5 }],
       errors: [
         {
           message:
@@ -384,7 +384,6 @@ ruleTester.run('new-line-between-multi-line-property', rule, {
     // test js doc
     {
       filename: 'test.vue',
-      options: [],
       code: `
       <script>
       export default {
@@ -436,6 +435,7 @@ ruleTester.run('new-line-between-multi-line-property', rule, {
       }
       </script>
       `,
+      options: [],
       errors: [
         {
           message:

--- a/tests/lib/rules/next-tick-style.js
+++ b/tests/lib/rules/next-tick-style.js
@@ -40,7 +40,6 @@ tester.run('next-tick-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: ['promise'],
       code: `<script>import { nextTick as nt } from 'vue';
       export default {
         async mounted() {
@@ -52,11 +51,11 @@ tester.run('next-tick-style', rule, {
           await Vue.nextTick(); callback();
           await nt(); callback();
         }
-      }</script>`
+      }</script>`,
+      options: ['promise']
     },
     {
       filename: 'test.vue',
-      options: ['callback'],
       code: `<script>import { nextTick as nt } from 'vue';
       export default {
         mounted() {
@@ -68,13 +67,13 @@ tester.run('next-tick-style', rule, {
           Vue.nextTick(callback);
           nt(callback);
         }
-      }</script>`
+      }</script>`,
+      options: ['callback']
     },
 
     // https://github.com/vuejs/eslint-plugin-vue/pull/1400#discussion_r550937977
     {
       filename: 'test.vue',
-      options: ['promise'],
       code: `<script>import { nextTick as nt } from 'vue';
       export default {
         mounted() {
@@ -86,11 +85,11 @@ tester.run('next-tick-style', rule, {
           foo.then(Vue.nextTick, catchHandler);
           foo.then(this.$nextTick, catchHandler);
         }
-      }</script>`
+      }</script>`,
+      options: ['promise']
     },
     {
       filename: 'test.vue',
-      options: ['callback'],
       code: `<script>import { nextTick as nt } from 'vue';
       export default {
         mounted() {
@@ -102,7 +101,8 @@ tester.run('next-tick-style', rule, {
           foo.then(Vue.nextTick, catchHandler);
           foo.then(this.$nextTick, catchHandler);
         }
-      }</script>`
+      }</script>`,
+      options: ['callback']
     }
   ],
   invalid: [
@@ -173,7 +173,6 @@ tester.run('next-tick-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: ['promise'],
       code: `<script>import { nextTick as nt } from 'vue';
       export default {
         mounted() {
@@ -198,6 +197,7 @@ tester.run('next-tick-style', rule, {
           nt().then(callback);
         }
       }</script>`,
+      options: ['promise'],
       errors: [
         {
           message:
@@ -239,7 +239,6 @@ tester.run('next-tick-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: ['callback'],
       code: `<script>import { nextTick as nt } from 'vue';
       export default {
         async mounted() {
@@ -253,6 +252,7 @@ tester.run('next-tick-style', rule, {
         }
       }</script>`,
       output: null,
+      options: ['callback'],
       errors: [
         {
           message:

--- a/tests/lib/rules/no-async-in-computed-properties.js
+++ b/tests/lib/rules/no-async-in-computed-properties.js
@@ -303,11 +303,6 @@ ruleTester.run('no-async-in-computed-properties', rule, {
     {
       // https://github.com/vuejs/eslint-plugin-vue/issues/1690
       filename: 'test.vue',
-      parser,
-      parserOptions: {
-        sourceType: 'module',
-        ecmaVersion: 2020
-      },
       code: `
       <template>
         <div class="f-c" style="height: 100%;">
@@ -323,7 +318,12 @@ ruleTester.run('no-async-in-computed-properties', rule, {
         components: {
         },
       }
-      </script>`
+      </script>`,
+      parser,
+      parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 2020
+      }
     }
   ],
 

--- a/tests/lib/rules/no-boolean-default.js
+++ b/tests/lib/rules/no-boolean-default.js
@@ -248,8 +248,8 @@ ruleTester.run('no-boolean-default', rule, {
       })
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser'),
-      options: ['default-false']
+      options: ['default-false'],
+      parser: require.resolve('vue-eslint-parser')
     },
     {
       filename: 'test.vue',
@@ -279,11 +279,11 @@ ruleTester.run('no-boolean-default', rule, {
       })
       </script>
       `,
+      options: ['default-false'],
       parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      options: ['default-false']
+      }
     },
     {
       filename: 'test.vue',
@@ -437,8 +437,8 @@ ruleTester.run('no-boolean-default', rule, {
       })
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser'),
       options: ['default-false'],
+      parser: require.resolve('vue-eslint-parser'),
       errors: [
         {
           message: 'Boolean prop should only be defaulted to false.',

--- a/tests/lib/rules/no-child-content.js
+++ b/tests/lib/rules/no-child-content.js
@@ -57,8 +57,8 @@ ruleTester.run('no-child-content', rule, {
     {
       // self-closing element with v-t directive
       filename: 'test.vue',
-      options: [{ additionalDirectives: ['t'] }],
-      code: '<template><div v-t="foo" /></template>'
+      code: '<template><div v-t="foo" /></template>',
+      options: [{ additionalDirectives: ['t'] }]
     },
     {
       // self-closing element with v-html directive and sibling comment element
@@ -182,8 +182,8 @@ ruleTester.run('no-child-content', rule, {
     {
       // v-t directive and text content
       filename: 'test.vue',
-      options: [{ additionalDirectives: ['t'] }],
       code: '<template><div v-t="foo">bar</div></template>',
+      options: [{ additionalDirectives: ['t'] }],
       errors: [
         {
           message:
@@ -199,8 +199,8 @@ ruleTester.run('no-child-content', rule, {
     {
       // v-html directive and text content while v-t directive is configured
       filename: 'test.vue',
-      options: [{ additionalDirectives: ['t'] }],
       code: '<template><div v-html="foo">baz</div></template>',
+      options: [{ additionalDirectives: ['t'] }],
       errors: [
         {
           message:

--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -487,17 +487,7 @@ tester.run('no-deprecated-slot-attribute', rule, {
           </template>
         </my-component>
       </template>`,
-      output: `
-      <template>
-        <my-component>
-          <template slot="one">
-            A
-          </template>
-          <template slot="one">
-            B
-          </template>
-        </my-component>
-      </template>`,
+      output: null,
       errors: [
         '`slot` attributes are deprecated.',
         '`slot` attributes are deprecated.'

--- a/tests/lib/rules/no-deprecated-v-bind-sync.js
+++ b/tests/lib/rules/no-deprecated-v-bind-sync.js
@@ -68,7 +68,7 @@ ruleTester.run('no-deprecated-v-bind-sync', rule, {
     {
       filename: 'test.vue',
       code: "<template><MyComponent v-bind.sync='bar'/></template>",
-      output: "<template><MyComponent v-bind.sync='bar'/></template>",
+      output: null,
       errors: [
         "'.sync' modifier on 'v-bind' directive is deprecated. Use 'v-model:propName' instead."
       ]
@@ -76,7 +76,7 @@ ruleTester.run('no-deprecated-v-bind-sync', rule, {
     {
       filename: 'test.vue',
       code: '<template><MyComponent :foo.sync.unknown="foo" /></template>',
-      output: '<template><MyComponent :foo.sync.unknown="foo" /></template>',
+      output: null,
       errors: [
         "'.sync' modifier on 'v-bind' directive is deprecated. Use 'v-model:propName' instead."
       ]
@@ -84,8 +84,7 @@ ruleTester.run('no-deprecated-v-bind-sync', rule, {
     {
       filename: 'test.vue',
       code: '<template><MyComponent :[dynamicArg].sync.unknown="foo" /></template>',
-      output:
-        '<template><MyComponent :[dynamicArg].sync.unknown="foo" /></template>',
+      output: null,
       errors: [
         "'.sync' modifier on 'v-bind' directive is deprecated. Use 'v-model:propName' instead."
       ]

--- a/tests/lib/rules/no-duplicate-attributes.js
+++ b/tests/lib/rules/no-duplicate-attributes.js
@@ -73,26 +73,26 @@ tester.run('no-duplicate-attributes', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><div style :style></div></div></template>',
-      errors: ["Duplicate attribute 'style'."],
-      options: [{ allowCoexistStyle: false }]
+      options: [{ allowCoexistStyle: false }],
+      errors: ["Duplicate attribute 'style'."]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div class :class></div></div></template>',
-      errors: ["Duplicate attribute 'class'."],
-      options: [{ allowCoexistClass: false }]
+      options: [{ allowCoexistClass: false }],
+      errors: ["Duplicate attribute 'class'."]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div :style style></div></div></template>',
-      errors: ["Duplicate attribute 'style'."],
-      options: [{ allowCoexistStyle: false }]
+      options: [{ allowCoexistStyle: false }],
+      errors: ["Duplicate attribute 'style'."]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div :class class></div></div></template>',
-      errors: ["Duplicate attribute 'class'."],
-      options: [{ allowCoexistClass: false }]
+      options: [{ allowCoexistClass: false }],
+      errors: ["Duplicate attribute 'class'."]
     }
   ]
 })

--- a/tests/lib/rules/no-multiple-template-root.js
+++ b/tests/lib/rules/no-multiple-template-root.js
@@ -49,6 +49,7 @@ ruleTester.run('no-multiple-template-root', rule, {
 
     // https://github.com/vuejs/eslint-plugin-vue/issues/1439
     {
+      filename: 'test.vue',
       code: `
       <template>
         <Link :to="to" class="flex items-center">
@@ -61,8 +62,7 @@ ruleTester.run('no-multiple-template-root', rule, {
           <slot />
         </Link>
       </template>
-      `,
-      filename: 'test.vue'
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-parsing-error.js
+++ b/tests/lib/rules/no-parsing-error.js
@@ -206,6 +206,7 @@ tester.run('no-parsing-error', rule, {
 
     // https://github.com/vuejs/eslint-plugin-vue/issues/1403
     {
+      filename: 'test.vue',
       code: `
       <template>
         <div>
@@ -216,8 +217,7 @@ tester.run('no-parsing-error', rule, {
           </p>
         </div>
       </template>
-      `,
-      filename: 'test.vue'
+      `
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-potential-component-option-typo.js
+++ b/tests/lib/rules/no-potential-component-option-typo.js
@@ -174,6 +174,7 @@ tester.run('no-potential-component-option-typo', rule, {
         method: {}
       }
       </script>`,
+      options: [{ custom: ['data', 'methods'] }],
       errors: [
         {
           message: "'dat' may be a typo, which is similar to option [data].",
@@ -209,8 +210,7 @@ tester.run('no-potential-component-option-typo', rule, {
             }
           ]
         }
-      ],
-      options: [{ custom: ['data', 'methods'] }]
+      ]
     },
     // test if user define custom rule is duplicate with presets
     //  test custom option that is not available in the presets
@@ -224,6 +224,9 @@ tester.run('no-potential-component-option-typo', rule, {
         custo: {}
       }
       </script>`,
+      options: [
+        { custom: ['data', 'methods', 'custom', 'foo'], presets: ['all'] }
+      ],
       errors: [
         {
           message: "'dat' may be a typo, which is similar to option [data].",
@@ -279,9 +282,6 @@ tester.run('no-potential-component-option-typo', rule, {
             }
           ]
         }
-      ],
-      options: [
-        { custom: ['data', 'methods', 'custom', 'foo'], presets: ['all'] }
       ]
     },
     // test if report correctly, only have preset option
@@ -294,6 +294,7 @@ tester.run('no-potential-component-option-typo', rule, {
         method: {}
       }
       </script>`,
+      options: [{ presets: ['vue'] }],
       errors: [
         {
           message: "'dat' may be a typo, which is similar to option [data].",
@@ -329,8 +330,7 @@ tester.run('no-potential-component-option-typo', rule, {
             }
           ]
         }
-      ],
-      options: [{ presets: ['vue'] }]
+      ]
     },
     // multi preset report typo
     {
@@ -343,6 +343,7 @@ tester.run('no-potential-component-option-typo', rule, {
         method: {}
       }
       </script>`,
+      options: [{ presets: ['vue', 'vue-router'] }],
       errors: [
         {
           message: "'dat' may be a typo, which is similar to option [data].",
@@ -399,8 +400,7 @@ tester.run('no-potential-component-option-typo', rule, {
             }
           ]
         }
-      ],
-      options: [{ presets: ['vue', 'vue-router'] }]
+      ]
     },
     // test multi suggestion
     {
@@ -411,6 +411,7 @@ tester.run('no-potential-component-option-typo', rule, {
         method: {}
       }
       </script>`,
+      options: [{ custom: ['data', 'methods'], threshold: 10, presets: [] }],
       errors: [
         {
           message: `'method' may be a typo, which is similar to option [methods,data].`,
@@ -437,8 +438,7 @@ tester.run('no-potential-component-option-typo', rule, {
             }
           ]
         }
-      ],
-      options: [{ custom: ['data', 'methods'], threshold: 10, presets: [] }]
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -131,26 +131,21 @@ tester.run('no-ref-as-operand', rule, {
     const count = ref(0)
     const foo = count
     `,
-    {
-      code: `
+    `
       <script>
         import { ref, computed, toRef, customRef, shallowRef } from 'vue'
         const foo = shallowRef({})
         foo[bar] = 123
       </script>
-      `
-    },
-    {
-      code: `
+    `,
+    `
       <script>
         import { ref, computed, toRef, customRef, shallowRef } from 'vue'
         const foo = shallowRef({})
         const isComp = foo.effect
       </script>
-      `
-    },
-    {
-      code: `
+    `,
+    `
       <script>
       import { ref } from 'vue'
       let foo;
@@ -159,10 +154,8 @@ tester.run('no-ref-as-operand', rule, {
         foo = ref(5);
       }
       </script>
-      `
-    },
-    {
-      code: `
+    `,
+    `
       <script>
       import { ref } from 'vue'
       let foo = undefined;
@@ -171,8 +164,7 @@ tester.run('no-ref-as-operand', rule, {
         foo = ref(5);
       }
       </script>
-      `
-    }
+    `
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-required-prop-with-default.js
+++ b/tests/lib/rules/no-required-prop-with-default.js
@@ -196,7 +196,6 @@ tester.run('no-required-prop-with-default', rule, {
           );
         </script>
       `,
-      options: [{ autofix: true }],
       output: `
         <script setup lang="ts">
           interface TestPropType {
@@ -211,6 +210,7 @@ tester.run('no-required-prop-with-default', rule, {
           );
         </script>
       `,
+      options: [{ autofix: true }],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },
@@ -237,7 +237,6 @@ tester.run('no-required-prop-with-default', rule, {
           );
         </script>
       `,
-      options: [{ autofix: true }],
       output: `
         <script setup lang="ts">
           interface TestPropType {
@@ -252,6 +251,7 @@ tester.run('no-required-prop-with-default', rule, {
           );
         </script>
       `,
+      options: [{ autofix: true }],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },
@@ -647,7 +647,6 @@ tester.run('no-required-prop-with-default', rule, {
           );
         </script>
       `,
-      options: [{ autofix: true }],
       output: `
         <script setup lang="ts">
           interface TestPropType {
@@ -662,6 +661,7 @@ tester.run('no-required-prop-with-default', rule, {
           );
         </script>
       `,
+      options: [{ autofix: true }],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },

--- a/tests/lib/rules/no-required-prop-with-default.js
+++ b/tests/lib/rules/no-required-prop-with-default.js
@@ -868,19 +868,7 @@ tester.run('no-required-prop-with-default', rule, {
         })
         </script>
       `,
-      output: `
-        <script>
-        import { defineComponent } from 'vue'
-        export default defineComponent({
-          props: {
-            name: {
-              required: true,
-              default: 'Hello'
-            }
-          }
-        })
-        </script>
-      `,
+      output: null,
       errors: [
         {
           message: 'Prop "name" should be optional.',

--- a/tests/lib/rules/no-restricted-call-after-await.js
+++ b/tests/lib/rules/no-restricted-call-after-await.js
@@ -147,8 +147,8 @@ tester.run('no-restricted-call-after-await', rule, {
       useI18n()
       </script>
       `,
-      parserOptions: { ecmaVersion: 2022 },
-      options: [{ module: 'vue-i18n', path: 'useI18n' }]
+      options: [{ module: 'vue-i18n', path: 'useI18n' }],
+      parserOptions: { ecmaVersion: 2022 }
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-restricted-class.js
+++ b/tests/lib/rules/no-restricted-class.js
@@ -40,93 +40,93 @@ ruleTester.run('no-restricted-class', rule, {
   invalid: [
     {
       code: `<template><div class="forbidden allowed" /></template>`,
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'VAttribute'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: `<template><div :class="'forbidden' + ' ' + 'allowed' + someVar" /></template>`,
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'Literal'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: `<template><div :class="{'forbidden': someBool, someVar: true}" /></template>`,
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'Literal'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: `<template><div :class="{forbidden: someBool}" /></template>`,
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'Identifier'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: '<template><div :class="`forbidden ${someVar}`" /></template>',
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'TemplateElement'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: `<template><div :class="'forbidden'" /></template>`,
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'Literal'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: `<template><div :class="['forbidden', 'allowed']" /></template>`,
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'Literal'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: `<template><div :class="['allowed forbidden', someString]" /></template>`,
+      options: ['forbidden'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'Literal'
         }
-      ],
-      options: ['forbidden']
+      ]
     },
     {
       code: `<template><div class="forbidden allowed" /></template>`,
+      options: ['/^for(bidden|gotten)/'],
       errors: [
         {
           message: "'forbidden' class is not allowed.",
           type: 'VAttribute'
         }
-      ],
-      options: ['/^for(bidden|gotten)/']
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-restricted-class.js
+++ b/tests/lib/rules/no-restricted-class.js
@@ -14,7 +14,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-restricted-class', rule, {
   valid: [
-    { code: `<template><div class="allowed">Content</div></template>` },
+    `<template><div class="allowed">Content</div></template>`,
     {
       code: `<template><div class="allowed"">Content</div></template>`,
       options: ['forbidden']

--- a/tests/lib/rules/no-restricted-html-elements.js
+++ b/tests/lib/rules/no-restricted-html-elements.js
@@ -38,38 +38,38 @@ tester.run('no-restricted-html-elements', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><button type="button"></button><div></template>',
+      options: ['button'],
       errors: [
         {
           message: 'Unexpected use of forbidden HTML element button.',
           line: 1,
           column: 16
         }
-      ],
-      options: ['button']
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div class="foo"><button type="button"></button></div></template>',
+      options: ['div'],
       errors: [
         {
           message: 'Unexpected use of forbidden HTML element div.',
           line: 1,
           column: 11
         }
-      ],
-      options: ['div']
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><marquee>foo</marquee></template>',
+      options: [{ element: 'marquee', message: 'Custom error' }],
       errors: [
         {
           message: 'Custom error',
           line: 1,
           column: 11
         }
-      ],
-      options: [{ element: 'marquee', message: 'Custom error' }]
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-restricted-props.js
+++ b/tests/lib/rules/no-restricted-props.js
@@ -386,10 +386,10 @@ tester.run('no-restricted-props', rule, {
       }>()
       </script>
       `,
+      options: [{ name: 'foo', suggest: 'Foo' }],
       parserOptions: {
         parser: require.resolve('@typescript-eslint/parser')
       },
-      options: [{ name: 'foo', suggest: 'Foo' }],
       errors: [
         {
           message: 'Using `foo` props is not allowed.',

--- a/tests/lib/rules/no-setup-props-destructure.js
+++ b/tests/lib/rules/no-setup-props-destructure.js
@@ -160,12 +160,11 @@ tester.run('no-setup-props-destructure', rule, {
       </script>
       `
     },
-    {
-      code: `
+    `
       Vue.component('test', {
         el: a = b
-      })`
-    },
+      })
+    `,
     {
       filename: 'test.vue',
       code: `

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -392,13 +392,13 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
           }
         });
       `,
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [
         {
           line: 5,
           message: 'Unexpected side effect in "test1" computed property.'
         }
-      ],
-      parser: require.resolve('@typescript-eslint/parser')
+      ]
     },
 
     {

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -19,8 +19,8 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-side-effects-in-computed-properties', rule, {
   valid: [
-    {
-      code: `Vue.component('test', {
+    `
+      Vue.component('test', {
         ...foo,
         computed: {
           ...test0({}),
@@ -97,10 +97,10 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             this.someArray.forEach(arr => console.log(arr))
           }
         }
-      })`
-    },
-    {
-      code: `Vue.component('test', {
+      })
+    `,
+    `
+      Vue.component('test', {
         computed: {
           ...mapGetters(['example']),
           test1() {
@@ -115,18 +115,18 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             return something.b
           }
         }
-      })`
-    },
-    {
-      code: `Vue.component('test', {
+      })
+    `,
+    `
+      Vue.component('test', {
         name: 'something',
         data() {
           return {}
         }
-      })`
-    },
-    {
-      code: `Vue.component('test', {
+      })
+    `,
+    `
+      Vue.component('test', {
         computed: {
           test () {
             let a;
@@ -134,10 +134,10 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             return a
           },
         }
-      })`
-    },
-    {
-      code: `Vue.component('test', {
+      })
+    `,
+    `
+      Vue.component('test', {
         computed: {
           test () {
             return {
@@ -153,32 +153,32 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
             }
           },
         }
-      })`
-    },
-    {
-      code: `Vue.component('test', {
+      })
+    `,
+    `
+      Vue.component('test', {
         computed: {
           test () {
             return this.something['a']().reverse()
           },
         }
-      })`
-    },
-    {
-      code: `const test = { el: '#app' }
+      })
+    `,
+    `
+      const test = { el: '#app' }
         Vue.component('test', {
         el: test.el
-      })`
-    },
-    {
-      code: `Vue.component('test', {
+      })
+    `,
+    `
+      Vue.component('test', {
         computed: {
           test () {
             return [...this.items].reverse()
           },
         }
-      })`
-    },
+      })
+    `,
     {
       filename: 'test.vue',
       code: `

--- a/tests/lib/rules/no-template-target-blank.js
+++ b/tests/lib/rules/no-template-target-blank.js
@@ -15,31 +15,21 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-template-target-blank', rule, {
   valid: [
-    { code: '<template><a>link</a></template>' },
-    { code: '<template><a attr>link</a></template>' },
-    { code: '<template><a target>link</a></template>' },
-    {
-      code: '<template><a href="https://eslint.vuejs.org">link</a></template>'
-    },
-    { code: '<template><a :href="link">link</a></template>' },
-    {
-      code: '<template><a :href="link" target="_blank" rel="noopener noreferrer">link</a></template>'
-    },
-    {
-      code: '<template><a href="https://eslint.vuejs.org" target="_blank" rel="noopener noreferrer">link</a></template>'
-    },
+    '<template><a>link</a></template>',
+    '<template><a attr>link</a></template>',
+    '<template><a target>link</a></template>',
+    '<template><a href="https://eslint.vuejs.org">link</a></template>',
+    '<template><a :href="link">link</a></template>',
+    '<template><a :href="link" target="_blank" rel="noopener noreferrer">link</a></template>',
+    '<template><a href="https://eslint.vuejs.org" target="_blank" rel="noopener noreferrer">link</a></template>',
     {
       code: '<template><a href="https://eslint.vuejs.org" target="_blank" rel="noopener">link</a></template>',
       options: [{ allowReferrer: true }]
     },
-    { code: '<template><a href="/foo" target="_blank">link</a></template>' },
-    {
-      code: '<template><a href="/foo" target="_blank" rel="noopener noreferrer">link</a></template>'
-    },
-    { code: '<template><a href="foo/bar" target="_blank">link</a></template>' },
-    {
-      code: '<template><a href="foo/bar" target="_blank" rel="noopener noreferrer">link</a></template>'
-    },
+    '<template><a href="/foo" target="_blank">link</a></template>',
+    '<template><a href="/foo" target="_blank" rel="noopener noreferrer">link</a></template>',
+    '<template><a href="foo/bar" target="_blank">link</a></template>',
+    '<template><a href="foo/bar" target="_blank" rel="noopener noreferrer">link</a></template>',
     {
       code: '<template><a :href="link" target="_blank">link</a></template>',
       options: [{ enforceDynamicLinks: 'never' }]

--- a/tests/lib/rules/no-this-in-before-route-enter.js
+++ b/tests/lib/rules/no-this-in-before-route-enter.js
@@ -83,8 +83,8 @@ export default {
   ],
   invalid: [
     {
+      filename: 'ValidComponent.vue',
       code: template(`this.xxx();`),
-      filename: 'ValidComponent.vue',
       errors: [
         {
           message:
@@ -97,8 +97,8 @@ export default {
       ]
     },
     {
+      filename: 'ValidComponent.vue',
       code: functionTemplate('this.method();'),
-      filename: 'ValidComponent.vue',
       errors: [
         {
           message:
@@ -111,8 +111,8 @@ export default {
       ]
     },
     {
+      filename: 'ValidComponent.vue',
       code: template('this.attr = this.method();'),
-      filename: 'ValidComponent.vue',
       errors: [
         {
           message:
@@ -133,8 +133,8 @@ export default {
       ]
     },
     {
+      filename: 'ValidComponent.vue',
       code: functionTemplate('this.attr = this.method();'),
-      filename: 'ValidComponent.vue',
       errors: [
         {
           message:
@@ -155,10 +155,10 @@ export default {
       ]
     },
     {
+      filename: 'ValidComponent.vue',
       code: template(`
                 if (this.method()) {}
             `),
-      filename: 'ValidComponent.vue',
       errors: [
         {
           message:
@@ -171,10 +171,10 @@ export default {
       ]
     },
     {
+      filename: 'ValidComponent.vue',
       code: functionTemplate(`
                 if (true) { this.method(); }
             `),
-      filename: 'ValidComponent.vue',
       errors: [
         {
           message:

--- a/tests/lib/rules/no-undef-components.js
+++ b/tests/lib/rules/no-undef-components.js
@@ -656,12 +656,12 @@ tester.run('no-undef-components', rule, {
         <HelloWorld1 />
       </template>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     }
   ],
   invalid: [
@@ -803,12 +803,12 @@ tester.run('no-undef-components', rule, {
         <Foo />
       </template>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
       },
-      parser: require.resolve('vue-eslint-parser'),
       errors: [
         {
           message:

--- a/tests/lib/rules/no-undef-properties.js
+++ b/tests/lib/rules/no-undef-properties.js
@@ -1169,13 +1169,13 @@ tester.run('no-undef-properties', rule, {
       <div>{{ foo }}</div>
       <div>{{ unknown }}</div>
       </template>`,
-      ...getTypeScriptFixtureTestOptions(),
       errors: [
         {
           message: "'unknown' is not defined.",
           line: 11
         }
-      ]
+      ],
+      ...getTypeScriptFixtureTestOptions()
     }
   ]
 })

--- a/tests/lib/rules/no-unsupported-features.js
+++ b/tests/lib/rules/no-unsupported-features.js
@@ -45,7 +45,6 @@ tester.run('no-unsupported-features', rule, {
           </template>
         </VList>
       </template>`,
-      options: [{ version: '^2.5.0' }],
       output: `
       <template>
         <VList>
@@ -56,6 +55,7 @@ tester.run('no-unsupported-features', rule, {
           </template>
         </VList>
       </template>`,
+      options: [{ version: '^2.5.0' }],
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',

--- a/tests/lib/rules/no-unsupported-features/define-options.js
+++ b/tests/lib/rules/no-unsupported-features/define-options.js
@@ -47,7 +47,6 @@ tester.run('no-unsupported-features/define-options', rule, {
       <script setup>
         defineOptions({ name: 'Foo' })
       </script>`,
-      options: buildOptions(),
       output: `
       <script>
 export default { name: 'Foo' }
@@ -55,6 +54,7 @@ export default { name: 'Foo' }
 <script setup>
 
       </script>`,
+      options: buildOptions(),
       errors: [
         {
           message:
@@ -68,7 +68,6 @@ export default { name: 'Foo' }
       <script setup>
         defineOptions({});
       </script>`,
-      options: buildOptions(),
       output: `
       <script>
 export default {}
@@ -76,6 +75,7 @@ export default {}
 <script setup>
 
       </script>`,
+      options: buildOptions(),
       errors: [
         {
           message:

--- a/tests/lib/rules/no-unsupported-features/slot-scope-attribute.js
+++ b/tests/lib/rules/no-unsupported-features/slot-scope-attribute.js
@@ -66,8 +66,8 @@ tester.run('no-unsupported-features/slot-scope-attribute', rule, {
           <a slot-scope />
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: null,
+      options: buildOptions(),
       errors: [
         {
           message:
@@ -83,8 +83,8 @@ tester.run('no-unsupported-features/slot-scope-attribute', rule, {
           <a slot-scope="{a}" />
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: null,
+      options: buildOptions(),
       errors: [
         {
           message:
@@ -100,8 +100,8 @@ tester.run('no-unsupported-features/slot-scope-attribute', rule, {
           <a slot-scope />
         </LinkList>
       </template>`,
-      options: buildOptions({ version: '^3.0.0' }),
       output: null,
+      options: buildOptions({ version: '^3.0.0' }),
       errors: [
         {
           message:

--- a/tests/lib/rules/no-unsupported-features/v-bind-prop-modifier-shorthand.js
+++ b/tests/lib/rules/no-unsupported-features/v-bind-prop-modifier-shorthand.js
@@ -63,11 +63,11 @@ tester.run('no-unsupported-features/v-bind-prop-modifier-shorthand', rule, {
       <template>
         <a .href="'/xxx'" />
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <a :href.prop="'/xxx'" />
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`.prop` shorthand are not supported until Vue.js "3.2.0".',
@@ -79,12 +79,12 @@ tester.run('no-unsupported-features/v-bind-prop-modifier-shorthand', rule, {
       code: `
       <template>
         <a .href="'/xxx'" />
+      </template>`,
+      output: `
+      <template>
+        <a :href.prop="'/xxx'" />
       </template>`,
       options: buildOptions({ version: '2.5.99' }),
-      output: `
-      <template>
-        <a :href.prop="'/xxx'" />
-      </template>`,
       errors: [
         {
           message: '`.prop` shorthand are not supported until Vue.js "3.2.0".',
@@ -97,11 +97,11 @@ tester.run('no-unsupported-features/v-bind-prop-modifier-shorthand', rule, {
       <template>
         <a .href="'/xxx'" />
       </template>`,
-      options: buildOptions({ version: '3.1.0' }),
       output: `
       <template>
         <a :href.prop="'/xxx'" />
       </template>`,
+      options: buildOptions({ version: '3.1.0' }),
       errors: [
         {
           message: '`.prop` shorthand are not supported until Vue.js "3.2.0".',

--- a/tests/lib/rules/no-unsupported-features/v-slot.js
+++ b/tests/lib/rules/no-unsupported-features/v-slot.js
@@ -81,13 +81,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -102,13 +102,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template #default ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot="default" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -123,13 +123,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot:name ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot="name" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -144,13 +144,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template #name ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot="name" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -165,13 +165,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot="{a}" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot-scope="{a}" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -186,13 +186,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template #default="{a}" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot="default" slot-scope="{a}" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -207,13 +207,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot:name="{a}" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot="name" slot-scope="{a}" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -228,13 +228,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template #name="{a}" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot="name" slot-scope="{a}" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -249,13 +249,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot:[name]="{a}" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template :slot="name" slot-scope="{a}" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -271,13 +271,13 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot:name="{" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: `
       <template>
         <LinkList>
           <template slot="name" slot-scope="{" ><a /></template>
         </LinkList>
       </template>`,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -292,8 +292,8 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot:[.]="{a}" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: null,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -310,8 +310,8 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <template v-slot.mod="{a}" ><a /></template>
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: null,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',
@@ -328,8 +328,8 @@ tester.run('no-unsupported-features/v-slot', rule, {
           <a />
         </LinkList>
       </template>`,
-      options: buildOptions(),
       output: null,
+      options: buildOptions(),
       errors: [
         {
           message: '`v-slot` are not supported until Vue.js "2.6.0".',

--- a/tests/lib/rules/no-unused-properties.js
+++ b/tests/lib/rules/no-unused-properties.js
@@ -1651,9 +1651,6 @@ tester.run('no-unused-properties', rule, {
     {
       // https://github.com/vuejs/eslint-plugin-vue/issues/1643
       filename: 'test.vue',
-      parserOptions: {
-        parser: '@typescript-eslint/parser'
-      },
       code: `
       <template>
         <span v-for="(item, index) of pages" :key="index" @click="changePage(item)">
@@ -1708,7 +1705,10 @@ tester.run('no-unused-properties', rule, {
 
       <style lang="scss" scoped>
       //
-      </style>`
+      </style>`,
+      parserOptions: {
+        parser: '@typescript-eslint/parser'
+      }
     },
 
     // Vue2 functional component
@@ -2975,13 +2975,13 @@ tester.run('no-unused-properties', rule, {
       <template>
       {{ foo }}{{ bar }}
       </template>`,
-      ...getTypeScriptFixtureTestOptions(),
       errors: [
         {
           message: "'baz' of property found, but never used.",
           line: 4
         }
-      ]
+      ],
+      ...getTypeScriptFixtureTestOptions()
     }
   ]
 })

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -108,6 +108,7 @@ tester.run('no-unused-vars', rule, {
     },
     {
       code: '<template><div v-for="x in items">{{value | x}}</div></template>',
+      options: [{ ignorePattern: '^_' }],
       errors: [
         {
           message: "'x' is defined but never used.",
@@ -119,8 +120,7 @@ tester.run('no-unused-vars', rule, {
             }
           ]
         }
-      ],
-      options: [{ ignorePattern: '^_' }]
+      ]
     },
     {
       code: '<template><div v-for="x in items">{{value}}</div></template>',
@@ -129,13 +129,13 @@ tester.run('no-unused-vars', rule, {
     },
     {
       code: '<template><span slot-scope="props"></span></template>',
-      errors: ["'props' is defined but never used."],
-      options: [{ ignorePattern: '^ignore' }]
+      options: [{ ignorePattern: '^ignore' }],
+      errors: ["'props' is defined but never used."]
     },
     {
       code: '<template><span><template scope="props"></template></span></template>',
-      errors: ["'props' is defined but never used."],
-      options: [{ ignorePattern: '^ignore' }]
+      options: [{ ignorePattern: '^ignore' }],
+      errors: ["'props' is defined but never used."]
     },
     {
       code: '<template><div v-for="_i in foo" ></div></template>',

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -15,36 +15,16 @@ const tester = new RuleTester({
 
 tester.run('no-unused-vars', rule, {
   valid: [
-    {
-      code: '<template><ol v-for="i in 5"><li>{{i}}</li></ol></template>'
-    },
-    {
-      code: '<template><ol v-for="i in 5"><li :prop="i"></li></ol></template>'
-    },
-    {
-      code: '<template v-for="i in 5"><comp v-for="j in 10">{{i}}{{j}}</comp></template>'
-    },
-    {
-      code: '<template><ol v-for="i in data"><li v-for="f in i">{{ f.bar.baz }}</li></ol></template>'
-    },
-    {
-      code: '<template><template scope="props">{{props}}</template></template>'
-    },
-    {
-      code: '<template><template scope="props"><span v-if="props"></span></template></template>'
-    },
-    {
-      code: '<template><div v-for="(item, key) in items" :key="key">{{item.name}}</div></template>'
-    },
-    {
-      code: '<template><div v-for="(v, i, c) in foo">{{c}}</div></template>'
-    },
-    {
-      code: '<template><div v-for="x in foo">{{value | f(x)}}</div></template>'
-    },
-    {
-      code: '<template><div v-for="x in foo" :[x]></div></template>'
-    },
+    '<template><ol v-for="i in 5"><li>{{i}}</li></ol></template>',
+    '<template><ol v-for="i in 5"><li :prop="i"></li></ol></template>',
+    '<template v-for="i in 5"><comp v-for="j in 10">{{i}}{{j}}</comp></template>',
+    '<template><ol v-for="i in data"><li v-for="f in i">{{ f.bar.baz }}</li></ol></template>',
+    '<template><template scope="props">{{props}}</template></template>',
+    '<template><template scope="props"><span v-if="props"></span></template></template>',
+    '<template><div v-for="(item, key) in items" :key="key">{{item.name}}</div></template>',
+    '<template><div v-for="(v, i, c) in foo">{{c}}</div></template>',
+    '<template><div v-for="x in foo">{{value | f(x)}}</div></template>',
+    '<template><div v-for="x in foo" :[x]></div></template>',
     {
       code: '<template><div v-for="_ in foo" ></div></template>',
       options: [{ ignorePattern: '^_' }]

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -94,7 +94,7 @@ tester.run('no-unused-vars', rule, {
           message: "'x' is defined but never used.",
           suggestions: [
             {
-              desc: 'Replace the x with _x',
+              desc: 'Replace `x` with `_x` to ignore the unused variable.',
               output:
                 '<template><div v-for="_x in items">{{value | x}}</div></template>'
             }

--- a/tests/lib/rules/no-watch-after-await.js
+++ b/tests/lib/rules/no-watch-after-await.js
@@ -92,12 +92,11 @@ tester.run('no-watch-after-await', rule, {
       </script>
       `
     },
-    {
-      code: `
+    `
       Vue.component('test', {
         el: foo()
-      })`
-    },
+      })
+    `,
     {
       filename: 'test.vue',
       code: `

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -63,20 +63,20 @@ tester.run('object-curly-spacing', rule, {
     },
     {
       code: '<template><div :attr="{ a: 1}" /></template>',
-      options: ['never'],
       output: '<template><div :attr="{a: 1}" /></template>',
+      options: ['never'],
       errors: ["There should be no space after '{'."]
     },
     {
       code: '<template><div :attr="{a: 1 }" /></template>',
-      options: ['never'],
       output: '<template><div :attr="{a: 1}" /></template>',
+      options: ['never'],
       errors: ["There should be no space before '}'."]
     },
     {
       code: '<template><div :attr="{ a: 1 }" /></template>',
-      options: ['never'],
       output: '<template><div :attr="{a: 1}" /></template>',
+      options: ['never'],
       errors: [
         "There should be no space after '{'.",
         "There should be no space before '}'."
@@ -84,20 +84,20 @@ tester.run('object-curly-spacing', rule, {
     },
     {
       code: '<template><div :attr="{ a: 1}" /></template>',
-      options: ['always'],
       output: '<template><div :attr="{ a: 1 }" /></template>',
+      options: ['always'],
       errors: ["A space is required before '}'."]
     },
     {
       code: '<template><div :attr="{a: 1 }" /></template>',
-      options: ['always'],
       output: '<template><div :attr="{ a: 1 }" /></template>',
+      options: ['always'],
       errors: ["A space is required after '{'."]
     },
     {
       code: '<template><div :attr="{a: 1}" /></template>',
-      options: ['always'],
       output: '<template><div :attr="{ a: 1 }" /></template>',
+      options: ['always'],
       errors: [
         "A space is required after '{'.",
         "A space is required before '}'."
@@ -105,8 +105,8 @@ tester.run('object-curly-spacing', rule, {
     },
     {
       code: '<template><div :[{a:1}]="{a:1}" /></template>',
-      options: ['always'],
       output: '<template><div :[{a:1}]="{ a:1 }" /></template>',
+      options: ['always'],
       errors: [
         "A space is required after '{'.",
         "A space is required before '}'."
@@ -119,18 +119,18 @@ tester.run('object-curly-spacing', rule, {
           Hello World
         </div>
       </template>`,
-      options: [
-        'never',
-        {
-          objectsInObjects: true
-        }
-      ],
       output: `
       <template>
         <div v-bind="{foo: {bar: 'baz'} }">
           Hello World
         </div>
       </template>`,
+      options: [
+        'never',
+        {
+          objectsInObjects: true
+        }
+      ],
       errors: [
         "There should be no space after '{'.",
         "There should be no space after '{'.",
@@ -145,13 +145,13 @@ tester.run('object-curly-spacing', rule, {
           Hello World
         </div>
       </template>`,
-      options: ['never'],
       output: `
       <template>
         <div v-bind="{foo: {bar: 'baz'}}">
           Hello World
         </div>
       </template>`,
+      options: ['never'],
       errors: [
         "There should be no space after '{'.",
         "There should be no space after '{'.",

--- a/tests/lib/rules/order-in-components.js
+++ b/tests/lib/rules/order-in-components.js
@@ -197,7 +197,6 @@ ruleTester.run('order-in-components', rule, {
           },
         }
       `,
-      parserOptions,
       output: `
         export default {
           name: 'app',
@@ -211,6 +210,7 @@ ruleTester.run('order-in-components', rule, {
           },
         }
       `,
+      parserOptions,
       errors: [
         {
           message:
@@ -239,11 +239,6 @@ ruleTester.run('order-in-components', rule, {
           },
         }
       `,
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module',
-        ecmaFeatures: { jsx: true }
-      },
       output: `
         export default {
           name: 'app',
@@ -262,6 +257,11 @@ ruleTester.run('order-in-components', rule, {
           },
         }
       `,
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true }
+      },
       errors: [
         {
           message:
@@ -294,7 +294,6 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
-      parserOptions: { ecmaVersion: 6 },
       output: `
         Vue.component('smart-list', {
           name: 'app',
@@ -307,6 +306,7 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
+      parserOptions: { ecmaVersion: 6 },
       errors: [
         {
           message:
@@ -329,7 +329,6 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
-      parserOptions: { ecmaVersion: 6 },
       output: `
         app.component('smart-list', {
           name: 'app',
@@ -342,6 +341,7 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
+      parserOptions: { ecmaVersion: 6 },
       errors: [
         {
           message:
@@ -365,7 +365,6 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
-      parserOptions: { ecmaVersion: 6 },
       output: `
         const { component } = Vue;
         component('smart-list', {
@@ -379,6 +378,7 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
+      parserOptions: { ecmaVersion: 6 },
       errors: [
         {
           message:
@@ -402,7 +402,6 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
-      parserOptions: { ecmaVersion: 6 },
       output: `
         new Vue({
           el: '#app',
@@ -416,6 +415,7 @@ ruleTester.run('order-in-components', rule, {
           template: '<div></div>'
         })
       `,
+      parserOptions: { ecmaVersion: 6 },
       errors: [
         {
           message:
@@ -449,7 +449,6 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: `
         export default {
           name: 'burger',
@@ -468,6 +467,7 @@ ruleTester.run('order-in-components', rule, {
           },
         };
       `,
+      parserOptions,
       errors: [
         {
           message:
@@ -486,7 +486,6 @@ ruleTester.run('order-in-components', rule, {
           test: 'ok'
         };
       `,
-      parserOptions,
       output: `
         export default {
           data() {
@@ -496,6 +495,7 @@ ruleTester.run('order-in-components', rule, {
         };
       `,
       options: [{ order: ['data', 'test', 'name'] }],
+      parserOptions,
       errors: [
         {
           message:
@@ -515,7 +515,6 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger'
         };
       `,
-      parserOptions,
       output: `
         export default {
           /** name of vue component */
@@ -525,6 +524,7 @@ ruleTester.run('order-in-components', rule, {
           }
         };
       `,
+      parserOptions,
       errors: [
         {
           message:
@@ -544,7 +544,6 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger'
         };
       `,
-      parserOptions,
       output: `
         export default {
           /** name of vue component */
@@ -554,6 +553,7 @@ ruleTester.run('order-in-components', rule, {
           }/*test*/
         };
       `,
+      parserOptions,
       errors: [
         {
           message:
@@ -565,8 +565,8 @@ ruleTester.run('order-in-components', rule, {
     {
       filename: 'example.vue',
       code: `export default {data(){},name:'burger'};`,
-      parserOptions,
       output: `export default {name:'burger',data(){}};`,
+      parserOptions,
       errors: [
         {
           message:
@@ -586,8 +586,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -607,8 +607,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -628,8 +628,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -649,8 +649,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -670,8 +670,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -691,8 +691,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -712,8 +712,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -733,8 +733,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -754,8 +754,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -775,8 +775,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -796,8 +796,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -817,8 +817,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -838,8 +838,8 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: null,
+      parserOptions,
       errors: [
         {
           message:
@@ -859,7 +859,6 @@ ruleTester.run('order-in-components', rule, {
           test: fn(),
         };
       `,
-      parserOptions,
       output: `
         export default {
           name: 'burger',
@@ -868,6 +867,7 @@ ruleTester.run('order-in-components', rule, {
           test: fn(),
         };
       `,
+      parserOptions,
       errors: [
         {
           message:
@@ -896,7 +896,6 @@ ruleTester.run('order-in-components', rule, {
           name: 'burger',
         };
       `,
-      parserOptions,
       output: `
         export default {
           name: 'burger',
@@ -914,6 +913,7 @@ ruleTester.run('order-in-components', rule, {
           testOptionalChaining: a?.b?.c,
         };
       `,
+      parserOptions,
       errors: [
         {
           message:
@@ -934,11 +934,6 @@ ruleTester.run('order-in-components', rule, {
           };
         </script>
       `,
-      parser: require.resolve('vue-eslint-parser'),
-      parserOptions: {
-        ...parserOptions,
-        parser: { ts: require.resolve('@typescript-eslint/parser') }
-      },
       output: `
         <script lang="ts">
           export default {
@@ -949,6 +944,11 @@ ruleTester.run('order-in-components', rule, {
           };
         </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: {
+        ...parserOptions,
+        parser: { ts: require.resolve('@typescript-eslint/parser') }
+      },
       errors: [
         {
           message:
@@ -967,8 +967,6 @@ ruleTester.run('order-in-components', rule, {
         })
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser'),
-      parserOptions,
       output: `
       <script setup>
         defineOptions({
@@ -977,6 +975,8 @@ ruleTester.run('order-in-components', rule, {
         })
       </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions,
       errors: [
         {
           message:

--- a/tests/lib/rules/padding-line-between-blocks.js
+++ b/tests/lib/rules/padding-line-between-blocks.js
@@ -125,12 +125,12 @@ tester.run('padding-line-between-blocks', rule, {
 
       <style></style>
       `,
-      options: ['never'],
       output: `
       <template></template>
       <script></script>
       <style></style>
       `,
+      options: ['never'],
       errors: [
         {
           message: 'Unexpected blank line before this block.',
@@ -214,7 +214,6 @@ tester.run('padding-line-between-blocks', rule, {
       <!-- comment -->
       <i18n></i18n>
       `,
-      options: ['never'],
       output: `
       <template></template>
       <!-- comment -->
@@ -225,6 +224,7 @@ tester.run('padding-line-between-blocks', rule, {
       <!-- comment -->
       <i18n></i18n>
       `,
+      options: ['never'],
       errors: [
         {
           message: 'Unexpected blank line before this block.',
@@ -290,7 +290,6 @@ tester.run('padding-line-between-blocks', rule, {
 
       <style></style>
       `,
-      options: ['never'],
       output: `
       <script></script>
       <!-- comment -->
@@ -304,6 +303,7 @@ tester.run('padding-line-between-blocks', rule, {
       TEXT
       <style></style>
       `,
+      options: ['never'],
       errors: [
         {
           message: 'Unexpected blank line before this block.',

--- a/tests/lib/rules/padding-line-between-tags.js
+++ b/tests/lib/rules/padding-line-between-tags.js
@@ -498,18 +498,18 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'always', prev: '*', next: '*' },
+          { blankLine: 'never', prev: 'br', next: '*' }
+        ]
+      ],
       errors: [
         {
           message: 'Expected blank line before this tag.',
           line: 7,
           column: 13
         }
-      ],
-      options: [
-        [
-          { blankLine: 'always', prev: '*', next: '*' },
-          { blankLine: 'never', prev: 'br', next: '*' }
-        ]
       ]
     },
     {
@@ -541,18 +541,18 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'always', prev: '*', next: '*' },
+          { blankLine: 'never', prev: '*', next: 'br' }
+        ]
+      ],
       errors: [
         {
           message: 'Expected blank line before this tag.',
           line: 8,
           column: 13
         }
-      ],
-      options: [
-        [
-          { blankLine: 'always', prev: '*', next: '*' },
-          { blankLine: 'never', prev: '*', next: 'br' }
-        ]
       ]
     },
     {
@@ -586,6 +586,7 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'never', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
@@ -597,8 +598,7 @@ tester.run('padding-line-between-tags', rule, {
           line: 11,
           column: 13
         }
-      ],
-      options: [[{ blankLine: 'never', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -624,6 +624,7 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'never', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
@@ -635,8 +636,7 @@ tester.run('padding-line-between-tags', rule, {
           line: 9,
           column: 11
         }
-      ],
-      options: [[{ blankLine: 'never', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -669,18 +669,18 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'never', prev: '*', next: '*' },
+          { blankLine: 'always', prev: 'br', next: 'div' }
+        ]
+      ],
       errors: [
         {
           message: 'Expected blank line before this tag.',
           line: 8,
           column: 13
         }
-      ],
-      options: [
-        [
-          { blankLine: 'never', prev: '*', next: '*' },
-          { blankLine: 'always', prev: 'br', next: 'div' }
-        ]
       ]
     },
     {
@@ -712,6 +712,13 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'always', prev: '*', next: '*' },
+          { blankLine: 'never', prev: 'br', next: 'div' },
+          { blankLine: 'never', prev: 'br', next: 'img' }
+        ]
+      ],
       errors: [
         {
           message: 'Expected blank line before this tag.',
@@ -728,13 +735,6 @@ tester.run('padding-line-between-tags', rule, {
           line: 9,
           column: 11
         }
-      ],
-      options: [
-        [
-          { blankLine: 'always', prev: '*', next: '*' },
-          { blankLine: 'never', prev: 'br', next: 'div' },
-          { blankLine: 'never', prev: 'br', next: 'img' }
-        ]
       ]
     },
     {
@@ -764,18 +764,18 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'always', prev: 'br', next: 'div' },
+          { blankLine: 'always', prev: 'div', next: 'br' }
+        ]
+      ],
       errors: [
         {
           message: 'Expected blank line before this tag.',
           line: 8,
           column: 11
         }
-      ],
-      options: [
-        [
-          { blankLine: 'always', prev: 'br', next: 'div' },
-          { blankLine: 'always', prev: 'div', next: 'br' }
-        ]
       ]
     },
     {
@@ -805,18 +805,18 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'always', prev: 'br', next: 'div' },
+          { blankLine: 'always', prev: 'br', next: 'br' }
+        ]
+      ],
       errors: [
         {
           message: 'Expected blank line before this tag.',
           line: 9,
           column: 11
         }
-      ],
-      options: [
-        [
-          { blankLine: 'always', prev: 'br', next: 'div' },
-          { blankLine: 'always', prev: 'br', next: 'br' }
-        ]
       ]
     },
     {
@@ -848,6 +848,12 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'always', prev: '*', next: '*' },
+          { blankLine: 'never', prev: 'br', next: 'br' }
+        ]
+      ],
       errors: [
         {
           message: 'Expected blank line before this tag.',
@@ -864,12 +870,6 @@ tester.run('padding-line-between-tags', rule, {
           line: 10,
           column: 11
         }
-      ],
-      options: [
-        [
-          { blankLine: 'always', prev: '*', next: '*' },
-          { blankLine: 'never', prev: 'br', next: 'br' }
-        ]
       ]
     },
     {
@@ -901,14 +901,14 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'never', prev: 'br', next: 'br' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
           line: 11,
           column: 11
         }
-      ],
-      options: [[{ blankLine: 'never', prev: 'br', next: 'br' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -935,14 +935,14 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'always', prev: '*', next: 'br' }]],
       errors: [
         {
           message: 'Expected blank line before this tag.',
           line: 7,
           column: 11
         }
-      ],
-      options: [[{ blankLine: 'always', prev: '*', next: 'br' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -1015,14 +1015,14 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'never', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
           line: 6,
           column: 12
         }
-      ],
-      options: [[{ blankLine: 'never', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -1045,14 +1045,14 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'never', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
           line: 7,
           column: 12
         }
-      ],
-      options: [[{ blankLine: 'never', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -1076,14 +1076,14 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'never', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
           line: 8,
           column: 12
         }
-      ],
-      options: [[{ blankLine: 'never', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -1109,14 +1109,14 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'never', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
           line: 10,
           column: 12
         }
-      ],
-      options: [[{ blankLine: 'never', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -1147,14 +1147,14 @@ tester.run('padding-line-between-tags', rule, {
         <footer></footer>
       </template>
       `,
+      options: [[{ blankLine: 'consistent', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Expected blank line before this tag.',
           line: 7,
           column: 11
         }
-      ],
-      options: [[{ blankLine: 'consistent', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -1191,6 +1191,7 @@ tester.run('padding-line-between-tags', rule, {
         <footer></footer>
       </template>
       `,
+      options: [[{ blankLine: 'consistent', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Expected blank line before this tag.',
@@ -1207,8 +1208,7 @@ tester.run('padding-line-between-tags', rule, {
           line: 9,
           column: 11
         }
-      ],
-      options: [[{ blankLine: 'consistent', prev: '*', next: '*' }]]
+      ]
     },
     {
       filename: 'test.vue',
@@ -1243,6 +1243,12 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [
+        [
+          { blankLine: 'consistent', prev: '*', next: '*' },
+          { blankLine: 'never', prev: 'br', next: 'br' }
+        ]
+      ],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
@@ -1259,12 +1265,6 @@ tester.run('padding-line-between-tags', rule, {
           line: 13,
           column: 11
         }
-      ],
-      options: [
-        [
-          { blankLine: 'consistent', prev: '*', next: '*' },
-          { blankLine: 'never', prev: 'br', next: 'br' }
-        ]
       ]
     },
     {
@@ -1288,14 +1288,14 @@ tester.run('padding-line-between-tags', rule, {
         </div>
       </template>
       `,
+      options: [[{ blankLine: 'consistent', prev: '*', next: '*' }]],
       errors: [
         {
           message: 'Unexpected blank line before this tag.',
           line: 7,
           column: 11
         }
-      ],
-      options: [[{ blankLine: 'consistent', prev: '*', next: '*' }]]
+      ]
     }
   ]
 })

--- a/tests/lib/rules/prefer-true-attribute-shorthand.js
+++ b/tests/lib/rules/prefer-true-attribute-shorthand.js
@@ -157,6 +157,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
       <template>
         <MyComp v-bind:show="true" />
       </template>`,
+      output: null,
       errors: [
         {
           messageId: 'expectShort',
@@ -172,8 +173,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -181,6 +181,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
       <template>
         <MyComp :show="true" />
       </template>`,
+      output: null,
       errors: [
         {
           messageId: 'expectShort',
@@ -196,8 +197,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -205,6 +205,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
       <template>
         <MyComp v-bind:show="true" />
       </template>`,
+      output: null,
       options: ['always'],
       errors: [
         {
@@ -221,8 +222,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -230,6 +230,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
       <template>
         <MyComp :show="true" />
       </template>`,
+      output: null,
       options: ['always'],
       errors: [
         {
@@ -246,8 +247,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     },
     {
       filename: 'test.vue',
@@ -255,6 +255,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
       <template>
         <MyComp show />
       </template>`,
+      output: null,
       options: ['never'],
       errors: [
         {
@@ -276,8 +277,7 @@ tester.run('prefer-true-attribute-shorthand', rule, {
             }
           ]
         }
-      ],
-      output: null
+      ]
     }
   ]
 })

--- a/tests/lib/rules/require-emit-validator.js
+++ b/tests/lib/rules/require-emit-validator.js
@@ -118,8 +118,8 @@ ruleTester.run('require-emit-validator', rule, {
           }
         })
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
@@ -132,8 +132,8 @@ ruleTester.run('require-emit-validator', rule, {
           },
         })
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
@@ -333,8 +333,8 @@ ruleTester.run('require-emit-validator', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           messageId: 'missing',

--- a/tests/lib/rules/require-explicit-emits.js
+++ b/tests/lib/rules/require-explicit-emits.js
@@ -1975,14 +1975,14 @@ emits: {'foo': null}
       emit('baz')
       emit('qux')
       </script>`,
-      ...getTypeScriptFixtureTestOptions(),
       errors: [
         {
           message:
             'The "qux" event has been triggered but not declared on `defineEmits`.',
           line: 8
         }
-      ]
+      ],
+      ...getTypeScriptFixtureTestOptions()
     }
   ]
 })

--- a/tests/lib/rules/require-expose.js
+++ b/tests/lib/rules/require-expose.js
@@ -95,15 +95,13 @@ tester.run('require-expose', rule, {
       </script>
       `
     },
-    {
-      code: `
+    `
       Vue.mixin({
         methods: {
           foo () {}
         }
       })
-      `
-    },
+    `,
     {
       filename: 'test.vue',
       code: `

--- a/tests/lib/rules/require-macro-variable-name.js
+++ b/tests/lib/rules/require-macro-variable-name.js
@@ -237,6 +237,7 @@ tester.run('require-macro-variable-name', rule, {
         const attrs = useAttrs({})
       </script>
       `,
+      options: [customOptions],
       errors: [
         {
           message: `The variable name of "defineSlots" must be "${customOptions.defineSlots}".`,
@@ -289,8 +290,7 @@ tester.run('require-macro-variable-name', rule, {
             }
           ]
         }
-      ],
-      options: [customOptions]
+      ]
     },
     {
       filename: 'test.vue',
@@ -300,6 +300,7 @@ tester.run('require-macro-variable-name', rule, {
         const attrsCustom = useAttrs({})
       </script>
       `,
+      options: [{ defineSlots: 'slotsCustom' }],
       errors: [
         {
           message: `The variable name of "useAttrs" must be "attrs".`,
@@ -317,8 +318,7 @@ tester.run('require-macro-variable-name', rule, {
             }
           ]
         }
-      ],
-      options: [{ defineSlots: 'slotsCustom' }]
+      ]
     }
   ]
 })

--- a/tests/lib/rules/require-prop-comment.js
+++ b/tests/lib/rules/require-prop-comment.js
@@ -265,16 +265,16 @@ tester.run('require-prop-comment', rule, {
       const props = defineProps<PropType>()
       </script>
       `,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      },
       errors: [
         {
           line: 4,
           column: 9,
           message: 'The "a" property should have a JSDoc comment.'
         }
-      ],
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/require-prop-comment.js
+++ b/tests/lib/rules/require-prop-comment.js
@@ -20,8 +20,7 @@ const tester = new RuleTester({
 
 tester.run('require-prop-comment', rule, {
   valid: [
-    {
-      code: `
+    `
       <script setup>
       export default defineComponent({
         props: {
@@ -30,8 +29,7 @@ tester.run('require-prop-comment', rule, {
         }
       })
       </script>
-      `
-    },
+    `,
     {
       code: `
       <script setup>
@@ -71,8 +69,7 @@ tester.run('require-prop-comment', rule, {
       `,
       options: [{ type: 'any' }]
     },
-    {
-      code: `
+    `
       <script lang="ts">
       export default defineComponent({
         props: {
@@ -81,8 +78,7 @@ tester.run('require-prop-comment', rule, {
         }
       })
       </script>
-      `
-    },
+    `,
     {
       code: `
       <script setup lang="ts">

--- a/tests/lib/rules/require-prop-type-constructor.js
+++ b/tests/lib/rules/require-prop-type-constructor.js
@@ -224,13 +224,13 @@ ruleTester.run('require-prop-type-constructor', rule, {
         }
       }
       `,
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [
         {
           message: 'The "a" property should be a constructor.',
           line: 5
         }
-      ],
-      parser: require.resolve('@typescript-eslint/parser')
+      ]
     },
     {
       filename: 'ExtraCommas.vue',
@@ -248,13 +248,13 @@ ruleTester.run('require-prop-type-constructor', rule, {
         }
       }
       `,
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [
         {
           message: 'The "name" property should be a constructor.',
           line: 4
         }
-      ],
-      parser: require.resolve('@typescript-eslint/parser')
+      ]
     },
     {
       filename: 'LiteralsComponent.vue',

--- a/tests/lib/rules/require-prop-types.js
+++ b/tests/lib/rules/require-prop-types.js
@@ -137,8 +137,8 @@ ruleTester.run('require-prop-types', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
@@ -151,8 +151,8 @@ ruleTester.run('require-prop-types', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
@@ -163,8 +163,8 @@ ruleTester.run('require-prop-types', rule, {
       })
       </script>
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: require.resolve('vue-eslint-parser')
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
@@ -173,12 +173,12 @@ ruleTester.run('require-prop-types', rule, {
       defineProps<{foo:string}>()
       </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     },
     {
       code: `
@@ -308,8 +308,8 @@ ruleTester.run('require-prop-types', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Prop "foo" should define at least its type.',
@@ -326,8 +326,8 @@ ruleTester.run('require-prop-types', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Prop "foo" should define at least its type.',
@@ -344,8 +344,8 @@ ruleTester.run('require-prop-types', rule, {
       })
       </script>
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Prop "foo" should define at least its type.',
@@ -360,8 +360,8 @@ ruleTester.run('require-prop-types', rule, {
       defineProps(['foo'])
       </script>
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: 'Prop "foo" should define at least its type.',

--- a/tests/lib/rules/require-typed-object-prop.js
+++ b/tests/lib/rules/require-typed-object-prop.js
@@ -14,235 +14,235 @@ ruleTester.run('require-typed-object-prop', rule, {
     // empty
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default {
         props: {}
       }
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default Vue.extend({
         props: {}
       });
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       <script setup lang="ts">
       defineProps({});
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser')
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     // array props
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default {
         props: ['foo']
       }
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default Vue.extend({
         props: ['foo']
       });
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       <script setup lang="ts">
       defineProps(['foo']);
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser')
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     // primitive props
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default {
         props: { foo: String }
       }
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default Vue.extend({
         props: { foo: String }
       });
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       <script setup lang="ts">
       defineProps({ foo: String });
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser')
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     // union
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default {
         props: { foo: [Number, String, Boolean] }
       }
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default Vue.extend({
         props: { foo: [Number, String, Boolean] }
       });
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       <script setup lang="ts">
       defineProps({ foo: [Number, String, Boolean] });
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser')
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     // function
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default {
         props: { foo: someFunction() }
       }
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default Vue.extend({
         props: { foo: someFunction() }
       });
-      `
+      `,
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       <script setup lang="ts">
       defineProps({ foo: someFunction() });
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser')
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     // typed object
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default {
         props: { foo: Object as PropType<User> }
       }
       `,
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default {
         props: { foo: Array as PropType<User[]> }
       }
       `,
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       code: `
       export default Vue.extend({
         props: { foo: Object as PropType<User> }
       });
       `,
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module',
-        parser: require.resolve('@typescript-eslint/parser')
-      },
       code: `
       <script setup lang="ts">
       defineProps({ foo: Object as PropType<User> });
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser')
-    },
-
-    {
-      filename: 'test.vue',
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
+      }
+    },
+
+    {
+      filename: 'test.vue',
       code: `
       export default {
         props: { foo: Object as () => User }
       }
       `,
-      parser: require.resolve('@typescript-eslint/parser')
-    },
-    {
-      filename: 'test.vue',
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
+      }
+    },
+    {
+      filename: 'test.vue',
       code: `
       export default Vue.extend({
         props: { foo: Object as () => User }
       });
       `,
-      parser: require.resolve('@typescript-eslint/parser')
-    },
-    {
-      filename: 'test.vue',
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
+      }
+    },
+    {
+      filename: 'test.vue',
       code: `
       <script setup lang="ts">
       defineProps({ foo: Object as () => User });
       </script>
       `,
-      parser: require.resolve('vue-eslint-parser')
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     },
     // any
     {
@@ -252,12 +252,12 @@ ruleTester.run('require-typed-object-prop', rule, {
       defineProps({ foo: { type: Object as any } });
       </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     },
     {
       filename: 'test.vue',
@@ -270,12 +270,12 @@ ruleTester.run('require-typed-object-prop', rule, {
         };
         </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     },
     {
       filename: 'test.vue',
@@ -288,12 +288,12 @@ ruleTester.run('require-typed-object-prop', rule, {
         });
         </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     },
     // unknown
     {
@@ -303,12 +303,12 @@ ruleTester.run('require-typed-object-prop', rule, {
       defineProps({ foo: { type: Object as unknown } });
       </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     },
     {
       filename: 'test.vue',
@@ -321,12 +321,12 @@ ruleTester.run('require-typed-object-prop', rule, {
         };
         </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     },
     {
       filename: 'test.vue',
@@ -339,12 +339,12 @@ ruleTester.run('require-typed-object-prop', rule, {
         });
         </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     }
   ],
   invalid: [
@@ -355,8 +355,8 @@ ruleTester.run('require-typed-object-prop', rule, {
       defineProps({ foo: Object });
       </script>
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           messageId: 'expectedTypeAnnotation',
@@ -394,8 +394,8 @@ ruleTester.run('require-typed-object-prop', rule, {
       defineProps({ foo: Array });
       </script>
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           messageId: 'expectedTypeAnnotation',
@@ -585,8 +585,8 @@ ruleTester.run('require-typed-object-prop', rule, {
       defineProps({ foo: { type: Object } });
       </script>
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           messageId: 'expectedTypeAnnotation',

--- a/tests/lib/rules/require-typed-ref.js
+++ b/tests/lib/rules/require-typed-ref.js
@@ -75,13 +75,13 @@ tester.run('require-typed-ref', rule, {
     },
     {
       filename: 'test.vue',
-      parser: require.resolve('vue-eslint-parser'),
       code: `
         <script setup>
           import { ref } from 'vue'
           const count = ref()
         </script>
-      `
+      `,
+      parser: require.resolve('vue-eslint-parser')
     },
     {
       filename: 'test.js',
@@ -197,13 +197,13 @@ tester.run('require-typed-ref', rule, {
     },
     {
       filename: 'test.vue',
-      parser: require.resolve('vue-eslint-parser'),
       code: `
         <script setup lang="ts">
           import { ref } from 'vue'
           const count = ref()
         </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       errors: [
         {
           messageId: 'noType',

--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -122,8 +122,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: require.resolve('@typescript-eslint/parser')
+      parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' }
     },
     {
       filename: 'test.vue',
@@ -214,8 +214,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: errorMessage('function')
     },
     {
@@ -229,8 +229,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: errorMessage('function')
     },
     {
@@ -244,8 +244,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: errorMessage('function')
     },
     {
@@ -264,12 +264,12 @@ ruleTester.run('require-valid-default-prop', rule, {
         num: 1
       });
       </script>`,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
-      },
-      parser: require.resolve('vue-eslint-parser')
+      }
     },
     {
       code: `
@@ -614,8 +614,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           } as PropOptions<object>
         }
       });`,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: errorMessage('function or number')
     },
 
@@ -874,8 +874,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: errorMessage('function')
     },
     {
@@ -889,8 +889,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: errorMessage('function')
     },
     {
@@ -904,8 +904,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           }
         });
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('@typescript-eslint/parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: errorMessage('function')
     },
     {
@@ -920,8 +920,8 @@ ruleTester.run('require-valid-default-prop', rule, {
         })
       </script>
       `,
-      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       parser: require.resolve('vue-eslint-parser'),
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
           message: "Type of the default value for 'foo' prop must be a string.",
@@ -938,12 +938,12 @@ ruleTester.run('require-valid-default-prop', rule, {
         })
       </script>
       `,
+      parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
         ecmaVersion: 6,
         sourceType: 'module',
         parser: require.resolve('@typescript-eslint/parser')
       },
-      parser: require.resolve('vue-eslint-parser'),
       errors: [
         {
           message: "Type of the default value for 'foo' prop must be a string.",
@@ -967,7 +967,6 @@ ruleTester.run('require-valid-default-prop', rule, {
         i: ['foo', 'bar'],
       })
       </script>`,
-      ...getTypeScriptFixtureTestOptions(),
       errors: [
         {
           message: "Type of the default value for 'a' prop must be a string.",
@@ -1006,7 +1005,8 @@ ruleTester.run('require-valid-default-prop', rule, {
           message: "Type of the default value for 'i' prop must be a function.",
           line: 13
         }
-      ]
+      ],
+      ...getTypeScriptFixtureTestOptions()
     }
   ]
 })

--- a/tests/lib/rules/return-in-computed-property.js
+++ b/tests/lib/rules/return-in-computed-property.js
@@ -94,8 +94,8 @@ ruleTester.run('return-in-computed-property', rule, {
           }
         }
       `,
-      parserOptions,
-      options: [{ treatUndefinedAsUnspecified: false }]
+      options: [{ treatUndefinedAsUnspecified: false }],
+      parserOptions
     },
     {
       filename: 'test.vue',
@@ -144,8 +144,8 @@ ruleTester.run('return-in-computed-property', rule, {
           }
         }
       `,
-      parserOptions,
-      options: [{ treatUndefinedAsUnspecified: false }]
+      options: [{ treatUndefinedAsUnspecified: false }],
+      parserOptions
     }
   ],
 
@@ -264,8 +264,8 @@ ruleTester.run('return-in-computed-property', rule, {
           }
         }
       `,
-      parserOptions,
       options: [{ treatUndefinedAsUnspecified: false }],
+      parserOptions,
       errors: [
         {
           message: 'Expected to return a value in "foo" computed property.',
@@ -284,8 +284,8 @@ ruleTester.run('return-in-computed-property', rule, {
           }
         }
       `,
-      parserOptions,
       options: [{ treatUndefinedAsUnspecified: true }],
+      parserOptions,
       errors: [
         {
           message: 'Expected to return a value in "foo" computed property.',
@@ -378,8 +378,8 @@ ruleTester.run('return-in-computed-property', rule, {
           }
         }
       `,
-      parserOptions,
       options: [{ treatUndefinedAsUnspecified: false }],
+      parserOptions,
       errors: [
         {
           message: 'Expected to return a value in computed function.',

--- a/tests/lib/rules/singleline-html-element-content-newline.js
+++ b/tests/lib/rules/singleline-html-element-content-newline.js
@@ -372,7 +372,6 @@ content
           <div>singleline content</div>
         </template>
       `,
-      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
@@ -380,6 +379,7 @@ singleline content
 </div>
         </template>
       `,
+      options: [{ ignoreWhenNoAttributes: false }],
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
         'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
@@ -391,7 +391,6 @@ singleline content
           <tr><td>singleline</td><td>children</td></tr>
         </template>
       `,
-      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <tr>
@@ -403,6 +402,7 @@ children
 </tr>
         </template>
       `,
+      options: [{ ignoreWhenNoAttributes: false }],
       errors: [
         'Expected 1 line break after opening tag (`<tr>`), but no line breaks found.',
         'Expected 1 line break after opening tag (`<td>`), but no line breaks found.',
@@ -418,7 +418,6 @@ children
           <div><!-- singleline comment --></div>
         </template>
       `,
-      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
@@ -426,6 +425,7 @@ children
 </div>
         </template>
       `,
+      options: [{ ignoreWhenNoAttributes: false }],
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
         'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
@@ -437,7 +437,6 @@ children
           <div   >   singleline element   </div   >
         </template>
       `,
-      options: [{ ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div   >
@@ -445,6 +444,7 @@ singleline element
 </div   >
         </template>
       `,
+      options: [{ ignoreWhenNoAttributes: false }],
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but no line breaks found.',
         'Expected 1 line break before closing tag (`</div>`), but no line breaks found.'
@@ -456,13 +456,13 @@ singleline element
           <div></div>
         </template>
       `,
-      options: [{ ignoreWhenEmpty: false, ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
 </div>
         </template>
       `,
+      options: [{ ignoreWhenEmpty: false, ignoreWhenNoAttributes: false }],
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
       ]
@@ -473,13 +473,13 @@ singleline element
           <div>    </div>
         </template>
       `,
-      options: [{ ignoreWhenEmpty: false, ignoreWhenNoAttributes: false }],
       output: `
         <template>
           <div>
 </div>
         </template>
       `,
+      options: [{ ignoreWhenEmpty: false, ignoreWhenNoAttributes: false }],
       errors: [
         'Expected 1 line break after opening tag (`<div>`), but no line breaks found.'
       ]

--- a/tests/lib/rules/space-in-parens.js
+++ b/tests/lib/rules/space-in-parens.js
@@ -94,13 +94,13 @@ tester.run('space-in-parens', rule, {
           @click="foo(arg)"
         />
       </template>`,
-      options: ['always'],
       output: `
       <template>
         <button
           @click="foo( arg )"
         />
       </template>`,
+      options: ['always'],
       errors: [
         errorMessage({
           messageId: 'missingOpeningSpace',
@@ -143,13 +143,13 @@ tester.run('space-in-parens', rule, {
           :value="(1 + 2) + 3"
         >
       </template>`,
-      options: ['always'],
       output: `
       <template>
         <input
           :value="( 1 + 2 ) + 3"
         >
       </template>`,
+      options: ['always'],
       errors: [
         errorMessage({
           messageId: 'missingOpeningSpace',
@@ -192,13 +192,13 @@ tester.run('space-in-parens', rule, {
           :[(1+2)]="(1 + 2) + 3"
         >
       </template>`,
-      options: ['always'],
       output: `
       <template>
         <input
           :[(1+2)]="( 1 + 2 ) + 3"
         >
       </template>`,
+      options: ['always'],
       errors: [
         errorMessage({
           messageId: 'missingOpeningSpace',

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -50,8 +50,8 @@ tester.run('space-unary-ops', rule, {
     },
     {
       code: '<template><div :[!a]="!a" /></template>',
-      options: [{ nonwords: true }],
       output: '<template><div :[!a]="! a" /></template>',
+      options: [{ nonwords: true }],
       errors: ["Unary operator '!' must be followed by whitespace."]
     },
 

--- a/tests/lib/rules/template-curly-spacing.js
+++ b/tests/lib/rules/template-curly-spacing.js
@@ -41,14 +41,13 @@ tester.run('template-curly-spacing', rule, {
     },
 
     // CSS vars injection
-    {
-      code: `
+    `
       <style>
       .text {
         padding: v-bind(\`\${a}px\`)
       }
-      </style>`
-    }
+      </style>
+    `
   ],
   invalid: [
     {

--- a/tests/lib/rules/template-curly-spacing.js
+++ b/tests/lib/rules/template-curly-spacing.js
@@ -79,12 +79,12 @@ tester.run('template-curly-spacing', rule, {
         <div :class="[\`foo-\${bar}\`]" />
       </template>
       `,
-      options: ['always'],
       output: `
       <template>
         <div :class="[\`foo-\${ bar }\`]" />
       </template>
       `,
+      options: ['always'],
       errors: [
         {
           message: "Expected space(s) after '${'.",

--- a/tests/lib/rules/this-in-template.js
+++ b/tests/lib/rules/this-in-template.js
@@ -248,14 +248,14 @@ ruleTester.run('this-in-template', rule, {
     {
       code: `<template><div v-if="fn(this.$foo)"></div></template><!-- never -->`,
       output: `<template><div v-if="fn($foo)"></div></template><!-- never -->`,
-      errors: ["Unexpected usage of 'this'."],
-      options: ['never']
+      options: ['never'],
+      errors: ["Unexpected usage of 'this'."]
     },
     {
       code: `<template><div :class="{ foo: this.$foo }"></div></template><!-- never -->`,
       output: `<template><div :class="{ foo: $foo }"></div></template><!-- never -->`,
-      errors: ["Unexpected usage of 'this'."],
-      options: ['never']
+      options: ['never'],
+      errors: ["Unexpected usage of 'this'."]
     }
   ]
 })

--- a/tests/lib/rules/use-v-on-exact.js
+++ b/tests/lib/rules/use-v-on-exact.js
@@ -15,92 +15,48 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('use-v-on-exact', rule, {
   valid: [
-    {
-      code: `<template><button @click="foo"/></template>`
-    },
-    {
-      code: `<template><button @click="foo" :click="foo"/></template>`
-    },
-    {
-      code: `<template><button @click.ctrl="foo"/></template>`
-    },
-    {
-      code: `<template><button @click.exact="foo"/></template>`
-    },
-    {
-      code: `<template><button v-on:click="foo"/></template>`
-    },
-    {
-      code: `<template><button v-on:click.ctrl="foo"/></template>`
-    },
-    {
-      code: `<template><button v-on:click.exact="foo"/></template>`
-    },
-    {
-      code: `<template><button @click="foo" @click.stop="bar"/></template>`
-    },
-    {
-      code: `<template><button @click="foo" @click.prevent="bar" @click.stop="baz"/></template>`
-    },
-    {
-      code: `<template><button @click.prevent="foo" @click.stop="bar"/></template>`
-    },
-    {
-      code: `<template><button @click.exact="foo" @click.ctrl="bar"/></template>`
-    },
-    {
-      code: `<template><button @click.exact="foo" @click.ctrl.exact="bar" @click.ctrl.shift="baz"/></template>`
-    },
-    {
-      code: `<template><button @click.ctrl.exact="foo" @click.ctrl.shift="bar"/></template>`
-    },
-    {
-      code: `<template><button @click.exact="foo" @click.ctrl="foo"/></template>`
-    },
-    {
-      code: `<template><button @click="foo" @focus="foo"/></template>`
-    },
-    {
-      code: `<template><button @click="foo" @click="foo"/></template>`
-    },
-    {
-      code: `<template><button @click="foo"/><button @click.ctrl="foo"/></template>`
-    },
-    {
-      code: `<template><button v-on:click.exact="foo" v-on:click.ctrl="foo"/></template>`
-    },
-    {
-      code: `<template><a @mouseenter="showTooltip" @mouseenter.once="attachTooltip"/></template>`
-    },
-    {
-      code: `<template><input @keypress.exact="foo" @keypress.esc.exact="bar" @keypress.ctrl="baz"></template>`
-    },
-    {
-      code: `<template><input @keypress.a="foo" @keypress.b="bar" @keypress.a.b="baz"></template>`
-    },
-    {
-      code: `<template><input @keypress.shift="foo" @keypress.ctrl="bar"></template>`
-    },
-    {
-      code: `<template>
+    `<template><button @click="foo"/></template>`,
+    `<template><button @click="foo" :click="foo"/></template>`,
+    `<template><button @click.ctrl="foo"/></template>`,
+    `<template><button @click.exact="foo"/></template>`,
+    `<template><button v-on:click="foo"/></template>`,
+    `<template><button v-on:click.ctrl="foo"/></template>`,
+    `<template><button v-on:click.exact="foo"/></template>`,
+    `<template><button @click="foo" @click.stop="bar"/></template>`,
+    `<template><button @click="foo" @click.prevent="bar" @click.stop="baz"/></template>`,
+    `<template><button @click.prevent="foo" @click.stop="bar"/></template>`,
+    `<template><button @click.exact="foo" @click.ctrl="bar"/></template>`,
+    `<template><button @click.exact="foo" @click.ctrl.exact="bar" @click.ctrl.shift="baz"/></template>`,
+    `<template><button @click.ctrl.exact="foo" @click.ctrl.shift="bar"/></template>`,
+    `<template><button @click.exact="foo" @click.ctrl="foo"/></template>`,
+    `<template><button @click="foo" @focus="foo"/></template>`,
+    `<template><button @click="foo" @click="foo"/></template>`,
+    `<template><button @click="foo"/><button @click.ctrl="foo"/></template>`,
+    `<template><button v-on:click.exact="foo" v-on:click.ctrl="foo"/></template>`,
+    `<template><a @mouseenter="showTooltip" @mouseenter.once="attachTooltip"/></template>`,
+    `<template><input @keypress.exact="foo" @keypress.esc.exact="bar" @keypress.ctrl="baz"></template>`,
+    `<template><input @keypress.a="foo" @keypress.b="bar" @keypress.a.b="baz"></template>`,
+    `<template><input @keypress.shift="foo" @keypress.ctrl="bar"></template>`,
+    `
+      <template>
         <input
           @keypress.27="foo"
           @keypress.27.middle="bar"
         >
-      </template>`
-    },
-    {
-      code: `<template>
+      </template>
+    `,
+    `
+      <template>
         <input
           @keydown.a.b.c="abc"
           @keydown.a="a"
           @keydown.b="b"
           @keydown.c="c"
         >
-      </template>`
-    },
-    {
-      code: `<template>
+      </template>
+    `,
+    `
+      <template>
         <input
           @keydown.a.b="ab"
           @keydown.a="a"
@@ -108,69 +64,49 @@ ruleTester.run('use-v-on-exact', rule, {
           @keydown.c="c"
           @keydown.a.c="ac"
         >
-      </template>`
-    },
-    {
-      code: `<template>
+      </template>
+    `,
+    `
+      <template>
         <input
           @keydown.a.b="ab"
           @keydown.a="a"
           @keydown.b="b"
           @keydown.c="c"
         >
-      </template>`
-    },
-    {
-      code: `<template><UiButton @click="foo" /></template>`
-    },
-    {
-      code: `<template><UiButton @click="foo" @click.native="bar" /></template>`
-    },
-    {
-      code: `<template><UiButton @click="foo" @click.native.ctrl="bar" /></template>`
-    },
-    {
-      code: `<template><UiButton @click="foo" @click.native.exact="bar" @click.native.ctrl="baz" /></template>`
-    },
-    {
-      code: `<template><UiButton @click.native.exact="bar" @click.ctrl.native="baz" /></template>`
-    },
-    {
-      code: `<template><UiButton @click.native.ctrl.exact="foo" @click.native.ctrl.shift="bar" /></template>`
-    },
-    {
-      code: `<template><UiButton @click.native="foo" @click.native.stop="bar" /></template>`
-    },
-    {
-      code: `<template><UiButton @click.native.stop="foo" @click.native.prevent="bar" /></template>`
-    },
-    {
-      code: `<template><button @[click]="foo"/></template>`
-    },
-    {
-      code: `<template><button @[foo]="foo" @[bar].ctrl="bar"/></template>`
-    },
-    {
-      code: `<template>
+      </template>
+    `,
+    `<template><UiButton @click="foo" /></template>`,
+    `<template><UiButton @click="foo" @click.native="bar" /></template>`,
+    `<template><UiButton @click="foo" @click.native.ctrl="bar" /></template>`,
+    `<template><UiButton @click="foo" @click.native.exact="bar" @click.native.ctrl="baz" /></template>`,
+    `<template><UiButton @click.native.exact="bar" @click.ctrl.native="baz" /></template>`,
+    `<template><UiButton @click.native.ctrl.exact="foo" @click.native.ctrl.shift="bar" /></template>`,
+    `<template><UiButton @click.native="foo" @click.native.stop="bar" /></template>`,
+    `<template><UiButton @click.native.stop="foo" @click.native.prevent="bar" /></template>`,
+    `<template><button @[click]="foo"/></template>`,
+    `<template><button @[foo]="foo" @[bar].ctrl="bar"/></template>`,
+    `
+      <template>
         <input
           @keydown.enter="foo"
           @keydown.shift.tab="bar"/>
-      </template>`
-    },
-    {
-      code: `<template>
+      </template>
+    `,
+    `
+      <template>
         <input
           @keydown.enter="foo"
           @keydown.shift.tab.prevent="bar"/>
-      </template>`
-    },
-    {
-      code: `<template>
+      </template>
+    `,
+    `
+      <template>
         <input-component
           @keydown.enter.native="foo"
           @keydown.shift.tab.native="bar"/>
-      </template>`
-    }
+      </template>
+    `
   ],
 
   invalid: [

--- a/tests/lib/rules/v-bind-style.js
+++ b/tests/lib/rules/v-bind-style.js
@@ -67,44 +67,44 @@ tester.run('v-bind-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: ['shorthand'],
       code: '<template><div v-bind:foo="foo"></div></template>',
       output: '<template><div :foo="foo"></div></template>',
+      options: ['shorthand'],
       errors: ["Unexpected 'v-bind' before ':'."]
     },
     {
       filename: 'test.vue',
-      options: ['longform'],
       code: '<template><div :foo="foo"></div></template>',
       output: '<template><div v-bind:foo="foo"></div></template>',
+      options: ['longform'],
       errors: ["Expected 'v-bind' before ':'."]
     },
     {
       filename: 'test.vue',
-      options: ['longform'],
       code: '<template><div .foo="foo"></div></template>',
       output: '<template><div v-bind:foo.prop="foo"></div></template>',
+      options: ['longform'],
       errors: ["Expected 'v-bind:' instead of '.'."]
     },
     {
       filename: 'test.vue',
-      options: ['longform'],
       code: '<template><div .foo.sync="foo"></div></template>',
       output: '<template><div v-bind:foo.prop.sync="foo"></div></template>',
+      options: ['longform'],
       errors: ["Expected 'v-bind:' instead of '.'."]
     },
     {
       filename: 'test.vue',
-      options: ['longform'],
       code: '<template><div .foo.prop="foo"></div></template>',
       output: '<template><div v-bind:foo.prop="foo"></div></template>',
+      options: ['longform'],
       errors: ["Expected 'v-bind:' instead of '.'."]
     },
     {
       filename: 'test.vue',
-      options: ['longform'],
       code: '<template><div .foo.sync.prop="foo"></div></template>',
       output: '<template><div v-bind:foo.sync.prop="foo"></div></template>',
+      options: ['longform'],
       errors: ["Expected 'v-bind:' instead of '.'."]
     }
   ]

--- a/tests/lib/rules/v-for-delimiter-style.js
+++ b/tests/lib/rules/v-for-delimiter-style.js
@@ -94,9 +94,9 @@ tester.run('v-for-delimiter-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: ['in'],
       code: '<template><div v-for="x of xs"></div></template>',
       output: '<template><div v-for="x in xs"></div></template>',
+      options: ['in'],
       errors: [
         {
           message: "Expected 'in' instead of 'of' in 'v-for'.",
@@ -106,9 +106,9 @@ tester.run('v-for-delimiter-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: ['of'],
       code: '<template><div v-for="x in xs"></div></template>',
       output: '<template><div v-for="x of xs"></div></template>',
+      options: ['of'],
       errors: [
         {
           message: "Expected 'of' instead of 'in' in 'v-for'.",

--- a/tests/lib/rules/v-on-event-hyphenation.js
+++ b/tests/lib/rules/v-on-event-hyphenation.js
@@ -73,12 +73,12 @@ tester.run('v-on-event-hyphenation', rule, {
           <VueComponent @customEvent="onEvent"/>
       </template>
       `,
-      options: ['always', { autofix: true }],
       output: `
       <template>
           <VueComponent @custom-event="onEvent"/>
       </template>
       `,
+      options: ['always', { autofix: true }],
       errors: [
         {
           message: "v-on event '@customEvent' must be hyphenated.",
@@ -95,12 +95,12 @@ tester.run('v-on-event-hyphenation', rule, {
           <VueComponent v-on:custom-event="events"/>
       </template>
       `,
-      options: ['never', { autofix: true }],
       output: `
       <template>
           <VueComponent v-on:customEvent="events"/>
       </template>
       `,
+      options: ['never', { autofix: true }],
       errors: ["v-on event 'v-on:custom-event' can't be hyphenated."]
     },
     {
@@ -110,13 +110,13 @@ tester.run('v-on-event-hyphenation', rule, {
         <VueComponent @update:model-value="foo"/>
       </template>
       `,
-      options: ['always', { autofix: true }],
       output: `
       <template>
         <VueComponent @update:model-value="foo"/>
         <VueComponent @update:model-value="foo"/>
       </template>
       `,
+      options: ['always', { autofix: true }],
       errors: ["v-on event '@update:modelValue' must be hyphenated."]
     },
     {
@@ -126,13 +126,13 @@ tester.run('v-on-event-hyphenation', rule, {
         <VueComponent @update:model-value="foo"/>
       </template>
       `,
-      options: ['never', { autofix: true }],
       output: `
       <template>
         <VueComponent @update:modelValue="foo"/>
         <VueComponent @update:modelValue="foo"/>
       </template>
       `,
+      options: ['never', { autofix: true }],
       errors: ["v-on event '@update:model-value' can't be hyphenated."]
     },
     {
@@ -144,7 +144,6 @@ tester.run('v-on-event-hyphenation', rule, {
         <VueComponent @up-date:model-value="foo"/>
       </template>
       `,
-      options: ['always', { autofix: true }],
       output: `
       <template>
         <VueComponent @up-date:model-value="foo"/>
@@ -153,6 +152,7 @@ tester.run('v-on-event-hyphenation', rule, {
         <VueComponent @up-date:model-value="foo"/>
       </template>
       `,
+      options: ['always', { autofix: true }],
       errors: [
         "v-on event '@upDate:modelValue' must be hyphenated.",
         "v-on event '@up-date:modelValue' must be hyphenated.",
@@ -168,7 +168,6 @@ tester.run('v-on-event-hyphenation', rule, {
         <VueComponent @up-date:model-value="foo"/>
       </template>
       `,
-      options: ['never', { autofix: true }],
       output: `
       <template>
         <VueComponent @upDate:modelValue="foo"/>
@@ -177,6 +176,7 @@ tester.run('v-on-event-hyphenation', rule, {
         <VueComponent @upDate:modelValue="foo"/>
       </template>
       `,
+      options: ['never', { autofix: true }],
       errors: [
         "v-on event '@up-date:modelValue' can't be hyphenated.",
         "v-on event '@upDate:model-value' can't be hyphenated.",

--- a/tests/lib/rules/v-on-function-call.js
+++ b/tests/lib/rules/v-on-function-call.js
@@ -161,37 +161,37 @@ tester.run('v-on-function-call', rule, {
       filename: 'test.vue',
       code: '<template><div @click="foo"></div></template>',
       output: null,
+      options: ['always'],
       errors: [
         "Method calls inside of 'v-on' directives must have parentheses."
-      ],
-      options: ['always']
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div @click="foo()"></div></template>',
       output: `<template><div @click="foo"></div></template>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div @click="foo( )"></div></template>',
       output: `<template><div @click="foo"></div></template>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div @click="foo(/**/)"></div></template>',
       output: null,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -204,13 +204,13 @@ tester.run('v-on-function-call', rule, {
           "></div>
       </template>`,
       output: null,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses.",
         "Method calls without arguments inside of 'v-on' directives must not have parentheses.",
         "Method calls without arguments inside of 'v-on' directives must not have parentheses.",
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -222,10 +222,10 @@ tester.run('v-on-function-call', rule, {
       <template>
         <div @click="fn"></div>
       </template>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -237,10 +237,10 @@ tester.run('v-on-function-call', rule, {
       <template>
         <div @click=fn></div>
       </template>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -254,11 +254,11 @@ tester.run('v-on-function-call', rule, {
         <div @click="beforeSpace"></div>
         <div @click='afterSpace'></div>
       </template>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses.",
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -270,10 +270,10 @@ tester.run('v-on-function-call', rule, {
       <template>
         <div @click="&#x66;oo"></div>
       </template>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -285,19 +285,19 @@ tester.run('v-on-function-call', rule, {
       <template>
         <div @click="fn"></div>
       </template>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template>\r\n<div\r\n@click="foo()" /></template>',
       output: '<template>\r\n<div\r\n@click="foo" /></template>',
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -319,10 +319,10 @@ tester.run('v-on-function-call', rule, {
         }
       }
       </script>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     },
     {
       filename: 'test.vue',
@@ -344,10 +344,10 @@ tester.run('v-on-function-call', rule, {
         }
       }
       </script>`,
+      options: ['never'],
       errors: [
         "Method calls without arguments inside of 'v-on' directives must not have parentheses."
-      ],
-      options: ['never']
+      ]
     }
   ]
 })

--- a/tests/lib/rules/v-on-handler-style.js
+++ b/tests/lib/rules/v-on-handler-style.js
@@ -78,12 +78,12 @@ tester.run('v-on-handler-style', rule, {
         <button @click="foo()" />
         <button @click="() => foo()" />
       </template>`,
-      options: [['method', 'inline-function']],
       output: `<template>
         <button @click="foo" />
         <button @click="foo" />
         <button @click="foo" />
       </template>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -155,12 +155,12 @@ tester.run('v-on-handler-style', rule, {
         <button @click="foo()" />
         <button @click="() => foo()" />
       </template>`,
-      options: ['inline-function'],
       output: `<template>
         <button @click="foo" />
         <button @click="() => foo()" />
         <button @click="() => foo()" />
       </template>`,
+      options: ['inline-function'],
       errors: [
         {
           message: 'Prefer inline function over method handler in v-on.',
@@ -193,8 +193,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="foo() /* comment */" />
       </template>`,
-      options: [['method', 'inline-function']],
       output: null,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -208,10 +208,10 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="foo() /* comment */" />
       </template>`,
-      options: [['method', 'inline-function'], { ignoreIncludesComment: true }],
       output: `<template>
         <button @click="() => foo() /* comment */" />
       </template>`,
+      options: [['method', 'inline-function'], { ignoreIncludesComment: true }],
       errors: [
         {
           message: 'Prefer inline function over inline handler in v-on.',
@@ -229,8 +229,8 @@ tester.run('v-on-handler-style', rule, {
         <button @click="foo()// comment
         "/>
       </template>`,
-      options: [['method', 'inline-function']],
       output: null,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -263,7 +263,6 @@ tester.run('v-on-handler-style', rule, {
         <button @click="{ fn(); }" />
         <button @click="{(fn());;;}" />
       </template>`,
-      options: [['method', 'inline-function']],
       output: `
       <template>
         <button @click="fn" />
@@ -271,6 +270,7 @@ tester.run('v-on-handler-style', rule, {
         <button @click="fn" />
         <button @click="fn" />
       </template>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -301,12 +301,12 @@ tester.run('v-on-handler-style', rule, {
         <div @click=" beforeSpace()" />
         <div @click='afterSpace() ' />
       </template>`,
-      options: [['method', 'inline-function']],
       output: `
       <template>
         <div @click="beforeSpace" />
         <div @click='afterSpace' />
       </template>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -326,11 +326,11 @@ tester.run('v-on-handler-style', rule, {
       <template>
         <button @click=" &#x66;oo ( ) " />
       </template>`,
-      options: [['method', 'inline-function']],
       output: `
       <template>
         <button @click="&#x66;oo" />
       </template>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -350,7 +350,6 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline-function']],
       output: `
       <template><button @click="foo" /></template>
       <script>
@@ -360,6 +359,7 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -379,7 +379,6 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline-function']],
       output: `
       <template><button @click="foo" /></template>
       <script>
@@ -389,6 +388,7 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -406,8 +406,8 @@ tester.run('v-on-handler-style', rule, {
         <button @click="foo();foo();" />
         <button @click="{}" />
       </template>`,
-      options: [['method', 'inline-function']],
       output: null,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -451,8 +451,8 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline-function']],
       output: null,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -478,8 +478,8 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline-function']],
       output: null,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -515,8 +515,8 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline-function']],
       output: null,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -542,12 +542,12 @@ tester.run('v-on-handler-style', rule, {
           <button @click="e()" />
         </template>
       </template>`,
-      options: [['method', 'inline-function']],
       output: `<template>
         <template v-for="e in list">
           <button @click="e" />
         </template>
       </template>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer method handler over inline handler in v-on.',
@@ -566,7 +566,6 @@ tester.run('v-on-handler-style', rule, {
           <button @click="e.foo()" />
         </template>
       </template>`,
-      options: [['method', 'inline-function']],
       output: `<template>
         <template v-for="e in list">
           <button @click="() => handler(e)" />
@@ -575,6 +574,7 @@ tester.run('v-on-handler-style', rule, {
           <button @click="() => e.foo()" />
         </template>
       </template>`,
+      options: [['method', 'inline-function']],
       errors: [
         {
           message: 'Prefer inline function over inline handler in v-on.',
@@ -694,8 +694,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="foo" />
       </template>`,
-      options: ['inline'],
       output: null,
+      options: ['inline'],
       errors: [
         {
           message: 'Prefer inline handler over method handler in v-on.',
@@ -712,12 +712,12 @@ tester.run('v-on-handler-style', rule, {
         <button @click="(a, b) => foo(a, b)" />
         <button @click="() => { foo() }" />
       </template>`,
-      options: [['method', 'inline']],
       output: `<template>
         <button @click="foo" />
         <button @click="foo" />
         <button @click="foo" />
       </template>`,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -741,8 +741,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="() => foo() /* comment */" />
       </template>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -756,10 +756,10 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="() => foo() /* comment */" />
       </template>`,
-      options: [['method', 'inline'], { ignoreIncludesComment: true }],
       output: `<template>
         <button @click="foo() /* comment */" />
       </template>`,
+      options: [['method', 'inline'], { ignoreIncludesComment: true }],
       errors: [
         {
           message: 'Prefer inline handler over inline function in v-on.',
@@ -780,7 +780,6 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline']],
       output: `<template>
         <button @click="foo" />
       </template>
@@ -791,6 +790,7 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -811,7 +811,6 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline']],
       output: `<template>
         <button @click="foo" />
       </template>
@@ -822,6 +821,7 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -835,8 +835,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="() => handler(foo)" />
       </template>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -850,8 +850,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="() => foo?.()" />
       </template>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message:
@@ -866,8 +866,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="() => count++" />
       </template>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message:
@@ -882,8 +882,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="() => { count++ }" />
       </template>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message:
@@ -900,8 +900,8 @@ tester.run('v-on-handler-style', rule, {
         <button @click="(a, b) => foo(...a, b)" />
         <button @click="(...a) => foo(a)" />
       </template>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -937,8 +937,8 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -974,8 +974,8 @@ tester.run('v-on-handler-style', rule, {
         }
       }
       </script>`,
-      options: [['method', 'inline']],
       output: null,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -1003,7 +1003,6 @@ tester.run('v-on-handler-style', rule, {
           <button @click="(a, b) => e(a, b)" />
         </template>
       </template>`,
-      options: [['method', 'inline']],
       output: `<template>
         <template v-for="e in list">
           <button @click="e" />
@@ -1011,6 +1010,7 @@ tester.run('v-on-handler-style', rule, {
           <button @click="e" />
         </template>
       </template>`,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer method handler over inline function in v-on.',
@@ -1039,7 +1039,6 @@ tester.run('v-on-handler-style', rule, {
           <button @click="() => e.foo()" />
         </template>
       </template>`,
-      options: [['method', 'inline']],
       output: `<template>
         <template v-for="e in list">
           <button @click="handler(e)" />
@@ -1048,6 +1047,7 @@ tester.run('v-on-handler-style', rule, {
           <button @click="e.foo()" />
         </template>
       </template>`,
+      options: [['method', 'inline']],
       errors: [
         {
           message: 'Prefer inline handler over inline function in v-on.',
@@ -1079,12 +1079,12 @@ tester.run('v-on-handler-style', rule, {
         <button @click="() => count++" />
         <button @click="() => { count++; foo(); }" />
       </template>`,
-      options: ['inline'],
       output: `<template>
         <button @click="foo(a, b)" />
         <button @click="count++" />
         <button @click=" count++; foo(); " />
       </template>`,
+      options: ['inline'],
       errors: [
         {
           message: 'Prefer inline handler over inline function in v-on.',
@@ -1108,8 +1108,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="(a) => foo(a, b)" />
       </template>`,
-      options: ['inline'],
       output: null,
+      options: ['inline'],
       errors: [
         {
           message: 'Prefer inline handler over inline function in v-on.',
@@ -1123,8 +1123,8 @@ tester.run('v-on-handler-style', rule, {
       code: `<template>
         <button @click="(a, b) => foo(a, b)" />
       </template>`,
-      options: ['inline'],
       output: null,
+      options: ['inline'],
       errors: [
         {
           message:

--- a/tests/lib/rules/v-on-style.js
+++ b/tests/lib/rules/v-on-style.js
@@ -47,16 +47,16 @@ tester.run('v-on-style', rule, {
     },
     {
       filename: 'test.vue',
-      options: ['shorthand'],
       code: '<template><div v-on:foo="foo"></div></template>',
       output: '<template><div @foo="foo"></div></template>',
+      options: ['shorthand'],
       errors: ["Expected '@' instead of 'v-on:'."]
     },
     {
       filename: 'test.vue',
-      options: ['longform'],
       code: '<template><div @foo="foo"></div></template>',
       output: '<template><div v-on:foo="foo"></div></template>',
+      options: ['longform'],
       errors: ["Expected 'v-on:' instead of '@'."]
     }
   ]

--- a/tests/lib/rules/v-slot-style.js
+++ b/tests/lib/rules/v-slot-style.js
@@ -217,13 +217,13 @@ tester.run('v-slot-style', rule, {
           <my-component #default="data"></my-component>
         </template>
       `,
+      options: [{ atComponent: 'shorthand' }],
       errors: [
         {
           messageId: 'expectedShorthand',
           data: { actual: 'v-slot:default', argument: 'default' }
         }
-      ],
-      options: [{ atComponent: 'shorthand' }]
+      ]
     },
     {
       code: `
@@ -236,13 +236,13 @@ tester.run('v-slot-style', rule, {
           <my-component #default="data"></my-component>
         </template>
       `,
+      options: [{ atComponent: 'shorthand' }],
       errors: [
         {
           messageId: 'expectedShorthand',
           data: { actual: 'v-slot', argument: 'default' }
         }
-      ],
-      options: [{ atComponent: 'shorthand' }]
+      ]
     },
     {
       code: `
@@ -255,13 +255,13 @@ tester.run('v-slot-style', rule, {
           <my-component v-slot:default="data"></my-component>
         </template>
       `,
+      options: [{ atComponent: 'longform' }],
       errors: [
         {
           messageId: 'expectedLongform',
           data: { actual: '#default', argument: 'default' }
         }
-      ],
-      options: [{ atComponent: 'longform' }]
+      ]
     },
     {
       code: `
@@ -274,13 +274,13 @@ tester.run('v-slot-style', rule, {
           <my-component v-slot:default="data"></my-component>
         </template>
       `,
+      options: [{ atComponent: 'longform' }],
       errors: [
         {
           messageId: 'expectedLongform',
           data: { actual: 'v-slot', argument: 'default' }
         }
-      ],
-      options: [{ atComponent: 'longform' }]
+      ]
     },
 
     {
@@ -342,13 +342,13 @@ tester.run('v-slot-style', rule, {
           </my-component>
         </template>
       `,
+      options: [{ default: 'longform' }],
       errors: [
         {
           messageId: 'expectedLongform',
           data: { actual: '#default', argument: 'default' }
         }
-      ],
-      options: [{ default: 'longform' }]
+      ]
     },
     {
       code: `
@@ -365,13 +365,13 @@ tester.run('v-slot-style', rule, {
           </my-component>
         </template>
       `,
+      options: [{ default: 'longform' }],
       errors: [
         {
           messageId: 'expectedLongform',
           data: { actual: 'v-slot', argument: 'default' }
         }
-      ],
-      options: [{ default: 'longform' }]
+      ]
     },
     {
       code: `
@@ -388,13 +388,13 @@ tester.run('v-slot-style', rule, {
           </my-component>
         </template>
       `,
+      options: [{ default: 'v-slot' }],
       errors: [
         {
           messageId: 'expectedVSlot',
           data: { actual: '#default', argument: 'default' }
         }
-      ],
-      options: [{ default: 'v-slot' }]
+      ]
     },
     {
       code: `
@@ -411,13 +411,13 @@ tester.run('v-slot-style', rule, {
           </my-component>
         </template>
       `,
+      options: [{ default: 'v-slot' }],
       errors: [
         {
           messageId: 'expectedVSlot',
           data: { actual: 'v-slot:default', argument: 'default' }
         }
-      ],
-      options: [{ default: 'v-slot' }]
+      ]
     },
 
     {
@@ -457,13 +457,13 @@ tester.run('v-slot-style', rule, {
           </my-component>
         </template>
       `,
+      options: [{ named: 'longform' }],
       errors: [
         {
           messageId: 'expectedLongform',
           data: { actual: '#foo', argument: 'foo' }
         }
-      ],
-      options: [{ named: 'longform' }]
+      ]
     },
 
     {
@@ -503,13 +503,13 @@ tester.run('v-slot-style', rule, {
           </my-component>
         </template>
       `,
+      options: [{ named: 'longform' }],
       errors: [
         {
           messageId: 'expectedLongform',
           data: { actual: '#[foo]', argument: '[foo]' }
         }
-      ],
-      options: [{ named: 'longform' }]
+      ]
     }
   ]
 })

--- a/tests/lib/rules/valid-define-emits.js
+++ b/tests/lib/rules/valid-define-emits.js
@@ -69,9 +69,6 @@ tester.run('valid-define-emits', rule, {
     {
       // https://github.com/vuejs/eslint-plugin-vue/issues/1656
       filename: 'test.vue',
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      },
       code: `
       <script setup lang="ts">
       import type { PropType } from 'vue';
@@ -86,13 +83,13 @@ tester.run('valid-define-emits', rule, {
         myProp: (x: X) => true,
       });
       </script>
-      `
+      `,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     },
     {
       filename: 'test.vue',
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      },
       code: `
       <script setup lang="ts">
       import type { PropType } from 'vue';
@@ -108,7 +105,10 @@ tester.run('valid-define-emits', rule, {
         myProp: (x: typeof str) => true,
       });
       </script>
-      `
+      `,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     },
     {
       filename: 'test.vue',

--- a/tests/lib/rules/valid-define-options.js
+++ b/tests/lib/rules/valid-define-options.js
@@ -35,29 +35,29 @@ tester.run('valid-define-options', rule, {
     },
     {
       filename: 'test.vue',
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      },
       code: `
       <script setup lang="ts">
       type X = string;
 
       defineOptions({ name: 'foo' as X })
       </script>
-      `
+      `,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     },
     {
       filename: 'test.vue',
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      },
       code: `
       <script setup lang="ts">
       const str = 'abc'
 
       defineOptions({ name: 'foo' as (typeof str) })
       </script>
-      `
+      `,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     },
     {
       filename: 'test.vue',

--- a/tests/lib/rules/valid-define-props.js
+++ b/tests/lib/rules/valid-define-props.js
@@ -72,9 +72,6 @@ tester.run('valid-define-props', rule, {
     {
       // https://github.com/vuejs/eslint-plugin-vue/issues/1656
       filename: 'test.vue',
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      },
       code: `
       <script setup lang="ts">
       import type { PropType } from 'vue';
@@ -89,13 +86,13 @@ tester.run('valid-define-props', rule, {
         myProp: (x: X) => true,
       });
       </script>
-      `
+      `,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     },
     {
       filename: 'test.vue',
-      parserOptions: {
-        parser: require.resolve('@typescript-eslint/parser')
-      },
       code: `
       <script setup lang="ts">
       import type { PropType } from 'vue';
@@ -111,7 +108,10 @@ tester.run('valid-define-props', rule, {
         myProp: (x: typeof str) => true,
       });
       </script>
-      `
+      `,
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      }
     },
     {
       filename: 'test.vue',

--- a/tests/lib/rules/valid-v-for.js
+++ b/tests/lib/rules/valid-v-for.js
@@ -273,9 +273,6 @@ tester.run('valid-v-for', rule, {
     },
     {
       filename: 'test.vue',
-      errors: [
-        "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
-      ],
       code: `
         <template>
           <template v-for="x in xs">
@@ -286,13 +283,13 @@ tester.run('valid-v-for', rule, {
             </template>
           </template>
         </template>
-      `
+      `,
+      errors: [
+        "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
+      ]
     },
     {
       filename: 'test.vue',
-      errors: [
-        "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
-      ],
       code: `
         <template>
           <template v-for="x in xs">
@@ -303,13 +300,13 @@ tester.run('valid-v-for', rule, {
             </template>
           </template>
         </template>
-      `
+      `,
+      errors: [
+        "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
+      ]
     },
     {
       filename: 'test.vue',
-      errors: [
-        "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
-      ],
       code: `
         <template>
           <template v-for="x in xs">
@@ -320,7 +317,10 @@ tester.run('valid-v-for', rule, {
             </template>
           </template>
         </template>
-      `
+      `,
+      errors: [
+        "Expected 'v-bind:key' directive to use the variables which are defined by the 'v-for' directive."
+      ]
     },
     // empty value
     {

--- a/tests/lib/rules/valid-v-model.js
+++ b/tests/lib/rules/valid-v-model.js
@@ -128,14 +128,13 @@ tester.run('valid-v-model', rule, {
       code: '<template><MyComponent v-model.modifier.modifierTwo="a"></MyComponent></template>'
     },
     // svg
-    {
-      code: `
+    `
       <template>
         <svg>
           <MyComponent v-model="slotProps"></MyComponent>
         </svg>
-      </template>`
-    },
+      </template>
+    `,
     // parsing error
     {
       filename: 'parsing-error.vue',

--- a/tests/lib/rules/valid-v-on.js
+++ b/tests/lib/rules/valid-v-on.js
@@ -140,14 +140,14 @@ tester.run('valid-v-on', rule, {
     {
       filename: 'test.vue',
       code: '<template><div @keydown.bar.aaa="foo"></div></template>',
-      errors: ["'v-on' directives don't support the modifier 'aaa'."],
-      options: [{ modifiers: ['bar'] }]
+      options: [{ modifiers: ['bar'] }],
+      errors: ["'v-on' directives don't support the modifier 'aaa'."]
     },
     {
       filename: 'test.vue',
       code: '<template><div @keydown.bar.aaa="foo"></div></template>',
-      errors: ["'v-on' directives don't support the modifier 'bar'."],
-      options: [{ modifiers: ['aaa'] }]
+      options: [{ modifiers: ['aaa'] }],
+      errors: ["'v-on' directives don't support the modifier 'bar'."]
     },
     {
       filename: 'test.vue',

--- a/tests/lib/rules/valid-v-slot.js
+++ b/tests/lib/rules/valid-v-slot.js
@@ -124,16 +124,15 @@ tester.run('valid-v-slot', rule, {
       options: [{ allowModifiers: true }]
     },
     // svg
-    {
-      code: `
+    `
       <template>
         <svg>
           <MyComponent v-slot="slotProps">
             <MyChildComponent :thing="slotProps.thing" />
           </MyComponent>
         </svg>
-      </template>`
-    },
+      </template>
+    `,
     // parsing error
     {
       filename: 'parsing-error.vue',

--- a/tests/lib/rules/valid-v-slot.js
+++ b/tests/lib/rules/valid-v-slot.js
@@ -407,8 +407,8 @@ tester.run('valid-v-slot', rule, {
           </MyComponent>
         </template>
       `,
-      errors: [{ messageId: 'disallowAnyModifier' }],
-      options: [{ allowModifiers: true }]
+      options: [{ allowModifiers: true }],
+      errors: [{ messageId: 'disallowAnyModifier' }]
     },
     {
       code: `
@@ -418,8 +418,8 @@ tester.run('valid-v-slot', rule, {
           </MyComponent>
         </template>
       `,
-      errors: [{ messageId: 'disallowAnyModifier' }],
-      options: [{ allowModifiers: false }]
+      options: [{ allowModifiers: false }],
+      errors: [{ messageId: 'disallowAnyModifier' }]
     },
     {
       code: `


### PR DESCRIPTION
This PR updates the [`eslint-plugin-eslint-plugin`](https://github.com/eslint-community/eslint-plugin-eslint-plugin) from v3 to v5, and also switches from the `recommended` to the `all` preset config. This enables many more rules that improve consistency in our codebase. I've also fixed all new lint issues, or disabled the rules where it makes sense.

~~I noticed some `eslint-plugin-eslint-plugin` rules that now error in our codebase and fixed them upstream:~~

* ~~https://github.com/eslint-community/eslint-plugin-eslint-plugin/pull/362~~
* ~~https://github.com/eslint-community/eslint-plugin-eslint-plugin/pull/363~~

~~While those are not merged and released, I've disabled the rules in files where they error.~~  
My fixes are already merged/cherry-picked and released, and I [updated](https://github.com/vuejs/eslint-plugin-vue/compare/27a07eb0f388b77f2ae654fe1bd2edea051db18d..a634e3538e4f384d295a25860b092e62a4916fb3) this branch accordingly.

---

Please review each commit individually, the commit descriptions should be self-explanatory.