### PR TITLE
Improve the `vue/no-setup-props-destructure` rule

### DIFF
--- a/lib/rules/no-setup-props-destructure.js
+++ b/lib/rules/no-setup-props-destructure.js
@@ -23,7 +23,10 @@ module.exports = {
         'Getting a value from the `props` in root scope of `{{scopeName}}` will cause the value to lose reactivity.'
     }
   },
-  /** @param {RuleContext} context */
+  /**
+   * @param {RuleContext} context
+   * @returns {RuleListener}
+   **/
   create(context) {
     /**
      * @typedef {object} ScopePropsReferences
@@ -59,6 +62,30 @@ module.exports = {
       }
 
       const rightNode = utils.skipChainExpression(right)
+
+      if (rightNode.type === 'CallExpression') {
+        const propRefs = [...propsReferences.refs.values()]
+        const isPropsMemberAccessed = propRefs.some((props) => {
+          const isPropsInCallExpression = utils.inRange(rightNode.range, props)
+
+          if (isPropsInCallExpression) {
+            const isPropMemberExpression =
+              props.parent.type === 'MemberExpression' &&
+              props.parent.object === props
+
+            if (isPropMemberExpression) {
+              return true
+            }
+          }
+
+          return false
+        })
+
+        if (isPropsMemberAccessed) {
+          return report(left, 'getProperty', propsReferences.scopeName)
+        }
+      }
+
       if (
         left.type !== 'ArrayPattern' &&
         left.type !== 'ObjectPattern' &&
@@ -66,6 +93,7 @@ module.exports = {
       ) {
         return
       }
+
       /** @type {Expression | Super} */
       let rightId = rightNode
       while (rightId.type === 'MemberExpression') {
@@ -114,6 +142,11 @@ module.exports = {
       }
       const propsReferenceIds = new Set()
       for (const reference of variable.references) {
+        // If reference is in another scope, we can't check it.
+        if (reference.from !== context.getScope()) {
+          continue
+        }
+
         if (!reference.isRead()) {
           continue
         }

--- a/lib/rules/no-setup-props-destructure.js
+++ b/lib/rules/no-setup-props-destructure.js
@@ -35,9 +35,8 @@ module.exports = {
      */
     /** @type {Map<FunctionDeclaration | FunctionExpression | ArrowFunctionExpression | Program, ScopePropsReferences>} */
     const setupScopePropsReferenceIds = new Map()
-    const outerExpressionTypes = new Set([
+    const wrapperExpressionTypes = new Set([
       'ArrayExpression',
-      'CallExpression',
       'ObjectExpression'
     ])
 
@@ -68,27 +67,11 @@ module.exports = {
 
       const rightNode = utils.skipChainExpression(right)
 
-      if (outerExpressionTypes.has(rightNode.type)) {
-        const propRefs = [...propsReferences.refs.values()]
-        const isPropsMemberAccessed = propRefs.some((props) => {
-          const isPropsInCallExpression = utils.inRange(rightNode.range, props)
-
-          if (isPropsInCallExpression) {
-            const isPropMemberExpression =
-              props.parent.type === 'MemberExpression' &&
-              props.parent.object === props
-
-            if (isPropMemberExpression) {
-              return true
-            }
-          }
-
-          return false
-        })
-
-        if (isPropsMemberAccessed) {
-          return report(left, 'getProperty', propsReferences.scopeName)
-        }
+      if (
+        wrapperExpressionTypes.has(rightNode.type) &&
+        isPropsMemberAccessed(rightNode, propsReferences)
+      ) {
+        return report(rightNode, 'getProperty', propsReferences.scopeName)
       }
 
       if (
@@ -108,6 +91,24 @@ module.exports = {
         report(left, 'getProperty', propsReferences.scopeName)
       }
     }
+
+    /**
+     * @param {Expression} node
+     * @param {ScopePropsReferences} propsReferences
+     */
+    function isPropsMemberAccessed(node, propsReferences) {
+      const propRefs = [...propsReferences.refs.values()]
+
+      return propRefs.some((props) => {
+        const isPropsInExpressionRange = utils.inRange(node.range, props)
+        const isPropsMemberExpression =
+          props.parent.type === 'MemberExpression' &&
+          props.parent.object === props
+
+        return isPropsInExpressionRange && isPropsMemberExpression
+      })
+    }
+
     /**
      * @typedef {object} ScopeStack
      * @property {ScopeStack | null} upper
@@ -181,6 +182,26 @@ module.exports = {
           scopeStack = scopeStack && scopeStack.upper
 
           setupScopePropsReferenceIds.delete(node)
+        },
+        /**
+         * @param {CallExpression} node
+         */
+        CallExpression(node) {
+          if (!scopeStack) {
+            return
+          }
+
+          const propsReferenceIds = setupScopePropsReferenceIds.get(
+            scopeStack.scopeNode
+          )
+
+          if (!propsReferenceIds) {
+            return
+          }
+
+          if (isPropsMemberAccessed(node, propsReferenceIds)) {
+            report(node, 'getProperty', propsReferenceIds.scopeName)
+          }
         },
         /**
          * @param {VariableDeclarator} node

--- a/lib/rules/no-setup-props-destructure.js
+++ b/lib/rules/no-setup-props-destructure.js
@@ -35,6 +35,11 @@ module.exports = {
      */
     /** @type {Map<FunctionDeclaration | FunctionExpression | ArrowFunctionExpression | Program, ScopePropsReferences>} */
     const setupScopePropsReferenceIds = new Map()
+    const outerExpressionTypes = new Set([
+      'ArrayExpression',
+      'CallExpression',
+      'ObjectExpression'
+    ])
 
     /**
      * @param {ESNode} node
@@ -63,7 +68,7 @@ module.exports = {
 
       const rightNode = utils.skipChainExpression(right)
 
-      if (rightNode.type === 'CallExpression') {
+      if (outerExpressionTypes.has(rightNode.type)) {
         const propRefs = [...propsReferences.refs.values()]
         const isPropsMemberAccessed = propRefs.some((props) => {
           const isPropsInCallExpression = utils.inRange(rightNode.range, props)

--- a/tests/lib/rules/no-setup-props-destructure.js
+++ b/tests/lib/rules/no-setup-props-destructure.js
@@ -660,6 +660,23 @@ tester.run('no-setup-props-destructure', rule, {
           line: 4
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ count: Number })
+      const buildCounter = (count) => ({ count })
+
+      buildCounter(props.count)
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 6
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-setup-props-destructure.js
+++ b/tests/lib/rules/no-setup-props-destructure.js
@@ -204,6 +204,27 @@ tester.run('no-setup-props-destructure', rule, {
           line: 4
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        setup: (props) => {
+          const count = computed(() => props.count)
+        }
+      }
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ count: Number })
+      const count = computed(() => props.count)
+      </script>
+      `
     }
   ],
   invalid: [
@@ -410,6 +431,18 @@ tester.run('no-setup-props-destructure', rule, {
         {
           messageId: 'getProperty',
           line: 7
+        },
+        {
+          messageId: 'getProperty',
+          line: 9
+        },
+        {
+          messageId: 'getProperty',
+          line: 10
+        },
+        {
+          messageId: 'getProperty',
+          line: 11
         }
       ]
     },
@@ -512,6 +545,49 @@ tester.run('no-setup-props-destructure', rule, {
       const props = defineProps({count:Number})
       const count = props.count
       count = props.count
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 4
+        },
+        {
+          messageId: 'getProperty',
+          line: 5
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      export default {
+        setup: (props) => {
+          const count = ref(props.count)
+          count = fn(props.count)
+        }
+      }
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 5
+        },
+        {
+          messageId: 'getProperty',
+          line: 6
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ count: Number })
+      const count = ref(props.count)
+      count = fn(props.count)
       </script>
       `,
       errors: [

--- a/tests/lib/rules/no-setup-props-destructure.js
+++ b/tests/lib/rules/no-setup-props-destructure.js
@@ -600,6 +600,66 @@ tester.run('no-setup-props-destructure', rule, {
           line: 5
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ count: Number })
+      const newProps = ref({ count: props.count })
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 4
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ count: Number })
+      const counts = [props.count]
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 4
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ count: Number })
+      const counter = { count: props.count }
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 4
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ count: Number })
+      const counters = [{ count: [props.count] }]
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'getProperty',
+          line: 4
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
- closes #1933
- closes #2007
- closes #2092

### Summary

Previously, the rule did not catch some reactivity-breaking uses of `props`.

#### Examples

Accessing a prop in a function call.

```vue
<script setup>
  const props = defineProps({ count: Number })
  
  const count = ref(props.count)
</script>
```

Accessing a prop in an object.

```vue
<script setup>
  const props = defineProps({ count: Number })
  
  const counter = { count: props.count }
</script>
```

Accessing a prop in an array.

```vue
<script setup>
  const props = defineProps({ count: Number })
  
  const counts = [props.count]
</script>
```

Accessing a prop in a nested object structure.

```vue
<script setup>
  const props = defineProps({ count: Number })
  
  const counters = [{ counts: [props.count] }]
</script>
```