### PR TITLE
fix(require-explicit-emits): Add support for kebab-cased custom events

### DIFF
--- a/docs/rules/require-explicit-emits.md
+++ b/docs/rules/require-explicit-emits.md
@@ -94,11 +94,12 @@ export default {
 ```vue
 <script>
 export default {
-  props: ['onGood', 'bad'],
+  props: ['onGood', 'onCustomEvent', 'bad'],
   methods: {
     foo () {
       // ✓ GOOD
       this.$emit('good')
+      this.$emit('custom-event')
       // ✗ BAD
       this.$emit('bad')
     }

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -17,7 +17,7 @@ const {
   isOpeningBracketToken
 } = require('@eslint-community/eslint-utils')
 const utils = require('../utils')
-const { capitalize } = require('../utils/casing')
+const { pascalCase } = require('../utils/casing')
 
 const FIX_EMITS_AFTER_OPTIONS = new Set([
   'setup',
@@ -136,7 +136,7 @@ module.exports = {
         return
       }
       if (allowProps) {
-        const key = `on${capitalize(name)}`
+        const key = `on${pascalCase(name)}`
         if (props.some((e) => e.propName === key || e.propName == null)) {
           return
         }

--- a/tests/lib/rules/require-explicit-emits.js
+++ b/tests/lib/rules/require-explicit-emits.js
@@ -398,6 +398,26 @@ tester.run('require-explicit-emits', rule, {
       `,
       options: [{ allowProps: true }]
     },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <button @click="$emit('foo-bar')"/>
+      </template>
+      <script>
+      export default {
+        props: ['onFooBar'],
+        methods: {
+          fn() { this.$emit('foo-bar') }
+        },
+        setup(p, ctx) {
+          ctx.emit('foo-bar')
+        }
+      }
+      </script>
+      `,
+      options: [{ allowProps: true }]
+    },
 
     // <script setup>
     {


### PR DESCRIPTION
The existing [`vue/require-explicit-emits`](https://eslint.vuejs.org/rules/require-explicit-emits.html) rule does not support the scenario where a custom event is emitted in kebab-case. This usage was recommended as a workaround by core Vue members here: https://github.com/vuejs/core/issues/5220#issuecomment-1007488240 .

Before this PR with `allowProps: true`, this works but is ugly and violates [`vue/prop-name-casing`](https://eslint.vuejs.org/rules/prop-name-casing.html):
```js
props: ['onCustom-event'],
// ...
this.$emit('custom-event')
```

After this PR you will be able to do:
```js
props: ['onCustomEvent'],
// ...
this.$emit('custom-event')
```