### PR TITLE
Fix no-ref-as-operand and allow lint when ref as right operator

### DIFF
--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -104,9 +104,6 @@ module.exports = {
       // refValue || other, refValue && other. ignore: other || refValue
       /** @param {Identifier & {parent: LogicalExpression}} node */
       'LogicalExpression>Identifier'(node) {
-        if (node.parent.left !== node) {
-          return
-        }
         // Report only constants.
         const data = refReferences.get(node)
         if (

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -68,6 +68,8 @@ tester.run('no-ref-as-operand', rule, {
     1 - count.value
     count.value || other
     count.value && other
+    other && count.value
+    other || count.value
     var foo = count.value ? x : y
     `,
     `
@@ -78,8 +80,6 @@ tester.run('no-ref-as-operand', rule, {
     `
     import { ref } from 'vue'
     const foo = ref(true)
-    var a = other || foo // ignore
-    var b = other && foo // ignore
 
     let bar = ref(true)
     var a = bar || other
@@ -451,12 +451,16 @@ tester.run('no-ref-as-operand', rule, {
       const foo = ref(true)
       var a = foo || other
       var b = foo && other
+      var c = other || foo
+      var d = other && foo
       `,
       output: `
       import { ref } from 'vue'
       const foo = ref(true)
       var a = foo.value || other
       var b = foo.value && other
+      var c = other || foo.value
+      var d = other && foo.value
       `,
       errors: [
         {
@@ -466,6 +470,14 @@ tester.run('no-ref-as-operand', rule, {
         {
           messageId: 'requireDotValue',
           line: 5
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 6
+        },
+        {
+          messageId: 'requireDotValue',
+          line: 7
         }
       ]
     },


### PR DESCRIPTION
fix #2271