### PR TITLE
Docs: fix options for use-v-on-exact

### DIFF
--- a/docs/rules/use-v-on-exact.md
+++ b/docs/rules/use-v-on-exact.md
@@ -32,11 +32,7 @@ This rule enforce usage of `exact` modifier on `v-on` when there is another `v-o
 
 ## :wrench: Options
 
-```json
-{
-  "vue/use-v-on-exact": ["error"]
-}
-```
+Nothing.
 
 ## :couple: Related Rules
 


### PR DESCRIPTION
`use-v-on-exact` rule documentation shows a useless code block in the "options" section, it should instead show "Nothing." for coherence and consistency with other rules documentation.