### PR TITLE
Fix require-toggle-inside-transition should respect "<slot>", "v-bind:key", attribute "appear"

### DIFF
--- a/lib/rules/require-toggle-inside-transition.js
+++ b/lib/rules/require-toggle-inside-transition.js
@@ -32,6 +32,13 @@ module.exports = {
       if (utils.isCustomComponent(element)) {
         return
       }
+
+      /** @type VElement */ // @ts-expect-error
+      const parent = element.parent
+      if (utils.hasAttribute(parent, 'appear')) {
+        return
+      }
+
       if (
         element.name !== 'slot' &&
         !utils.hasDirective(element, 'if') &&
@@ -50,7 +57,7 @@ module.exports = {
       /** @param {VElement} node */
       "VElement[name='transition'] > VElement"(node) {
         verifyInsideElement(node)
-      },
+      }
     })
   }
 }

--- a/lib/rules/require-toggle-inside-transition.js
+++ b/lib/rules/require-toggle-inside-transition.js
@@ -56,6 +56,11 @@ module.exports = {
     return utils.defineTemplateBodyVisitor(context, {
       /** @param {VElement} node */
       "VElement[name='transition'] > VElement"(node) {
+        const child = node.parent.children.find(utils.isVElement)
+        if (child !== node) {
+          return
+        }
+
         verifyInsideElement(node)
       }
     })

--- a/lib/rules/require-toggle-inside-transition.js
+++ b/lib/rules/require-toggle-inside-transition.js
@@ -33,8 +33,10 @@ module.exports = {
         return
       }
       if (
+        element.name !== 'slot' &&
         !utils.hasDirective(element, 'if') &&
-        !utils.hasDirective(element, 'show')
+        !utils.hasDirective(element, 'show') &&
+        !utils.hasDirective(element, 'bind', 'key')
       ) {
         context.report({
           node: element.startTag,
@@ -47,12 +49,8 @@ module.exports = {
     return utils.defineTemplateBodyVisitor(context, {
       /** @param {VElement} node */
       "VElement[name='transition'] > VElement"(node) {
-        const child = node.parent.children.find(utils.isVElement)
-        if (child !== node) {
-          return
-        }
         verifyInsideElement(node)
-      }
+      },
     })
   }
 }

--- a/tests/lib/rules/require-toggle-inside-transition.js
+++ b/tests/lib/rules/require-toggle-inside-transition.js
@@ -66,6 +66,10 @@ tester.run('require-toggle-inside-transition', rule, {
       filename: 'test.vue',
       code: '<template><transition><div :key="k" /></transition></template>'
     },
+    {
+      filename: 'test.vue',
+      code: '<template><transition appear><div /></transition></template>'
+    }
   ],
   invalid: [
     {

--- a/tests/lib/rules/require-toggle-inside-transition.js
+++ b/tests/lib/rules/require-toggle-inside-transition.js
@@ -57,7 +57,15 @@ tester.run('require-toggle-inside-transition', rule, {
     {
       filename: 'test.vue',
       code: '<template><transition><template v-if="show"><div /></template></transition></template>'
-    }
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><transition><slot /></transition></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><transition><div :key="k" /></transition></template>'
+    },
   ],
   invalid: [
     {
@@ -81,7 +89,7 @@ tester.run('require-toggle-inside-transition', rule, {
     {
       filename: 'test.vue',
       code: '<template><transition><div /><div /></transition></template>',
-      errors: [{ messageId: 'expected' }]
+      errors: [{ messageId: 'expected' }, { messageId: 'expected' }]
     },
     {
       filename: 'test.vue',

--- a/tests/lib/rules/require-toggle-inside-transition.js
+++ b/tests/lib/rules/require-toggle-inside-transition.js
@@ -93,7 +93,7 @@ tester.run('require-toggle-inside-transition', rule, {
     {
       filename: 'test.vue',
       code: '<template><transition><div /><div /></transition></template>',
-      errors: [{ messageId: 'expected' }, { messageId: 'expected' }]
+      errors: [{ messageId: 'expected' }]
     },
     {
       filename: 'test.vue',


### PR DESCRIPTION
fix: #2302 

Also, the following case that tansition with attribute `appear` should be valid.
```
<template>
  <Transition appear>
    <div />
  </Transition>
</template>
```