### PR TITLE
Update order-in-components.md

### DIFF
--- a/docs/rules/order-in-components.md
+++ b/docs/rules/order-in-components.md
@@ -10,7 +10,6 @@ since: v3.2.0
 > enforce order of properties in components
 
 - :gear: This rule is included in `"plugin:vue/vue3-recommended"` and `"plugin:vue/recommended"`.
-- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details
 


### PR DESCRIPTION
Hi team, I have added modifications to the document.

Even though this rule does not support auto-fix, the documentation explained that it does. So I have removed it.
Honestly, I'm not sure why it cannot be fixed automatically, but it was mentioned in this comment (https://github.com/vuejs/eslint-plugin-vue/issues/1841#issuecomment-1091610974).

related:
- https://github.com/vuejs/eslint-plugin-vue/issues/1841
- https://github.com/vuejs/eslint-plugin-vue/issues/724
