### PR TITLE
Add new option to specify tags to ignore `vue/no-deprecated-slot-attribute`

### DIFF
--- a/docs/rules/no-deprecated-slot-attribute.md
+++ b/docs/rules/no-deprecated-slot-attribute.md
@@ -37,6 +37,49 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
 
 </eslint-code-block>
 
+## :wrench: Options
+
+```json
+{
+  "vue/no-deprecated-slot-attribute": ["error", {
+    "ignore": ["my-component"]
+  }]
+}
+```
+
+- `"ignore"` (`string[]`) An array of tags that ignore this rules. This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
+
+### `"ignore": ["my-component"]`
+
+<eslint-code-block :rules="{'vue/no-dupe-keys': ['error', {ignore: ['my-component']}]}">
+
+```vue
+<template>
+  <ListComponent>
+    <!-- ✓ GOOD -->
+    <template v-slot:name>
+      {{ props.title }}
+    </template>
+  </ListComponent>
+
+  <ListComponent>
+    <!-- ✗ GOOD -->
+    <my-component slot="name">
+      {{ props.title }}
+    </my-component>
+  </ListComponent>
+
+    <ListComponent>
+    <!-- ✗ BAD -->
+    <other-component slot="name">
+      {{ props.title }}
+    </other-component>
+  </ListComponent>
+</template>
+```
+
+</eslint-code-block>
+
 ## :books: Further Reading
 
 - [API - slot](https://v2.vuejs.org/v2/api/#slot-deprecated)

--- a/docs/rules/no-deprecated-slot-attribute.md
+++ b/docs/rules/no-deprecated-slot-attribute.md
@@ -63,7 +63,7 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
   </ListComponent>
 
   <ListComponent>
-    <!-- ✗ GOOD -->
+    <!-- ✓ GOOD -->
     <my-component slot="name">
       {{ props.title }}
     </my-component>

--- a/lib/rules/no-deprecated-slot-attribute.js
+++ b/lib/rules/no-deprecated-slot-attribute.js
@@ -16,7 +16,17 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html'
     },
     fixable: 'code',
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignore: {
+            type: 'array'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
     messages: {
       forbiddenSlotAttribute: '`slot` attributes are deprecated.'
     }

--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -11,6 +11,12 @@ module.exports = {
   supported: '<3.0.0',
   /** @param {RuleContext} context @returns {TemplateListener} */
   createTemplateBodyVisitor(context) {
+    const options = context.options[0] || {}
+    /** @type {string[]} */
+    const ignore = Array.isArray(options.ignore)
+      ? options.ignore
+      : [options.ignore]
+
     const sourceCode = context.getSourceCode()
     const tokenStore =
       context.parserServices.getTemplateBodyTokenStore &&
@@ -95,6 +101,9 @@ module.exports = {
      * @returns {void}
      */
     function reportSlot(slotAttr) {
+      if (ignore.includes(slotAttr.parent.parent.name)) {
+        return
+      }
       context.report({
         node: slotAttr.key,
         messageId: 'forbiddenSlotAttribute',

--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const canConvertToVSlot = require('./utils/can-convert-to-v-slot')
+const casing = require('../../utils/casing')
 
 module.exports = {
   deprecated: '2.6.0',
@@ -12,10 +13,8 @@ module.exports = {
   /** @param {RuleContext} context @returns {TemplateListener} */
   createTemplateBodyVisitor(context) {
     const options = context.options[0] || {}
-    /** @type {string[]} */
-    const ignore = Array.isArray(options.ignore)
-      ? options.ignore
-      : [options.ignore]
+    /** @type {Set<string>} */
+    const ignore = new Set(options.ignore)
 
     const sourceCode = context.getSourceCode()
     const tokenStore =
@@ -101,9 +100,15 @@ module.exports = {
      * @returns {void}
      */
     function reportSlot(slotAttr) {
-      if (ignore.includes(slotAttr.parent.parent.name)) {
+      const componentName = slotAttr.parent.parent.rawName
+      if (
+        ignore.has(componentName) ||
+        ignore.has(casing.pascalCase(componentName)) ||
+        ignore.has(casing.kebabCase(componentName))
+      ) {
         return
       }
+
       context.report({
         node: slotAttr.key,
         messageId: 'forbiddenSlotAttribute',

--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -53,6 +53,8 @@ tester.run('no-deprecated-slot-attribute', rule, {
         <one slot="one" />
         <two slot="two" />
         <my-component slot="my-component-slot" />
+        <myComponent slot="myComponent-slot" />
+        <MyComponent slot="MyComponent-slot" />
       </LinkList>
     </template>`,
       options: [{ ignore: ['one', 'two', 'my-component'] }]

--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -46,7 +46,17 @@ tester.run('no-deprecated-slot-attribute', rule, {
       <LinkList>
         <a />
       </LinkList>
-    </template>`
+    </template>`,
+    {
+      code: `<template>
+      <LinkList>
+        <one slot="one" />
+        <two slot="two" />
+        <my-component slot="my-component-slot" />
+      </LinkList>
+    </template>`,
+      options: [{ ignore: ['one', 'two', 'my-component'] }]
+    }
   ],
   invalid: [
     {
@@ -594,6 +604,26 @@ tester.run('no-deprecated-slot-attribute', rule, {
         '`slot` attributes are deprecated.',
         '`slot` attributes are deprecated.'
       ]
+    },
+    {
+      code: `
+      <template>
+        <my-component>
+          <one slot="one">
+            A
+          </one>
+          <two slot="two">
+            B
+          </two>
+        </my-component>
+      </template>`,
+      output: null,
+      options: [
+        {
+          ignore: ['one']
+        }
+      ],
+      errors: ['`slot` attributes are deprecated.']
     }
   ]
 })


### PR DESCRIPTION
closes: https://github.com/vuejs/eslint-plugin-vue/issues/2313


I have not yet updated the documentation for this rule. If the content of this PR and issue is accepted, I will start working on those.