### PR TITLE
Make `vue/v-on-event-hyphenation` autofixable by default in Vue 3

### DIFF
--- a/lib/configs/vue3-strongly-recommended.js
+++ b/lib/configs/vue3-strongly-recommended.js
@@ -28,7 +28,12 @@ module.exports = {
     'vue/require-prop-types': 'warn',
     'vue/singleline-html-element-content-newline': 'warn',
     'vue/v-bind-style': 'warn',
-    'vue/v-on-event-hyphenation': 'warn',
+    'vue/v-on-event-hyphenation': [
+      'warn',
+      {
+        autofix: true
+      }
+    ],
     'vue/v-on-style': 'warn',
     'vue/v-slot-style': 'warn'
   }

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -10,7 +10,10 @@ module.exports = {
       description:
         'enforce v-on event naming style on custom components in template',
       categories: ['vue3-strongly-recommended'],
-      url: 'https://eslint.vuejs.org/rules/v-on-event-hyphenation.html'
+      url: 'https://eslint.vuejs.org/rules/v-on-event-hyphenation.html',
+      defaultOptions: {
+        vue3: [{ autofix: true }]
+      }
     },
     fixable: 'code',
     schema: [


### PR DESCRIPTION
Fixes #2065.