### PR TITLE
fix: avoid calling typeParameters getter

### DIFF
--- a/lib/rules/define-emits-declaration.js
+++ b/lib/rules/define-emits-declaration.js
@@ -47,7 +47,8 @@ module.exports = {
           }
 
           case 'runtime': {
-            const typeArguments = node.typeArguments || node.typeParameters
+            const typeArguments =
+              'typeArguments' in node ? node.typeArguments : node.typeParameters
             if (typeArguments && typeArguments.params.length > 0) {
               context.report({
                 node,

--- a/lib/rules/define-props-declaration.js
+++ b/lib/rules/define-props-declaration.js
@@ -47,7 +47,8 @@ module.exports = {
           }
 
           case 'runtime': {
-            const typeArguments = node.typeArguments || node.typeParameters
+            const typeArguments =
+              'typeArguments' in node ? node.typeArguments : node.typeParameters
             if (typeArguments && typeArguments.params.length > 0) {
               context.report({
                 node,

--- a/lib/rules/require-typed-ref.js
+++ b/lib/rules/require-typed-ref.js
@@ -84,7 +84,9 @@ module.exports = {
           }
 
           const typeArguments =
-            ref.node.typeArguments || ref.node.typeParameters
+            'typeArguments' in ref.node
+              ? ref.node.typeArguments
+              : ref.node.typeParameters
           if (typeArguments == null) {
             if (
               ref.node.parent.type === 'VariableDeclarator' &&

--- a/lib/rules/valid-define-emits.js
+++ b/lib/rules/valid-define-emits.js
@@ -47,7 +47,8 @@ module.exports = {
         onDefineEmitsEnter(node) {
           defineEmitsNodes.push(node)
 
-          const typeArguments = node.typeArguments || node.typeParameters
+          const typeArguments =
+            'typeArguments' in node ? node.typeArguments : node.typeParameters
           if (node.arguments.length > 0) {
             if (typeArguments && typeArguments.params.length > 0) {
               // `defineEmits` has both a literal type and an argument.

--- a/lib/rules/valid-define-options.js
+++ b/lib/rules/valid-define-options.js
@@ -74,7 +74,8 @@ module.exports = {
             })
           }
 
-          const typeArguments = node.typeArguments || node.typeParameters
+          const typeArguments =
+            'typeArguments' in node ? node.typeArguments : node.typeParameters
           if (typeArguments) {
             context.report({
               node: typeArguments,

--- a/lib/rules/valid-define-props.js
+++ b/lib/rules/valid-define-props.js
@@ -48,7 +48,8 @@ module.exports = {
         onDefinePropsEnter(node) {
           definePropsNodes.push(node)
 
-          const typeArguments = node.typeArguments || node.typeParameters
+          const typeArguments =
+            'typeArguments' in node ? node.typeArguments : node.typeParameters
           if (node.arguments.length > 0) {
             if (typeArguments && typeArguments.params.length > 0) {
               // `defineProps` has both a literal type and an argument.

--- a/lib/utils/indent-common.js
+++ b/lib/utils/indent-common.js
@@ -1168,7 +1168,8 @@ module.exports.defineVisitor = function create(
     },
     /** @param {CallExpression} node */
     CallExpression(node) {
-      const typeArguments = node.typeArguments || node.typeParameters
+      const typeArguments =
+        'typeArguments' in node ? node.typeArguments : node.typeParameters
       const firstToken = tokenStore.getFirstToken(node)
       const rightToken = tokenStore.getLastToken(node)
       const leftToken = /** @type {Token} */ (
@@ -1695,7 +1696,8 @@ module.exports.defineVisitor = function create(
     },
     /** @param {NewExpression} node */
     NewExpression(node) {
-      const typeArguments = node.typeArguments || node.typeParameters
+      const typeArguments =
+        'typeArguments' in node ? node.typeArguments : node.typeParameters
       const newToken = tokenStore.getFirstToken(node)
       const calleeToken = tokenStore.getTokenAfter(newToken)
       const rightToken = tokenStore.getLastToken(node)

--- a/lib/utils/indent-ts.js
+++ b/lib/utils/indent-ts.js
@@ -332,7 +332,10 @@ function defineVisitor({
      * @param {TSTypeReference | TSInstantiationExpression} node
      */
     'TSTypeReference, TSInstantiationExpression'(node) {
-      const typeArguments = node.typeArguments || node.typeParameters
+      const typeArguments =
+        'typeArguments' in node
+          ? node.typeArguments
+          : /** @type {any} typescript-eslint v5 */ (node).typeParameters
       if (typeArguments) {
         const firstToken = tokenStore.getFirstToken(node)
         setOffset(tokenStore.getFirstToken(typeArguments), 1, firstToken)
@@ -1183,8 +1186,9 @@ function defineVisitor({
         setOffset([dotToken, propertyToken], 1, firstToken)
       }
       const typeArguments =
-        node.typeArguments ||
-        /** @type {any} typescript-eslint v5 */ (node).typeParameters
+        'typeArguments' in node
+          ? node.typeArguments
+          : /** @type {any} typescript-eslint v5 */ (node).typeParameters
       if (typeArguments) {
         setOffset(tokenStore.getFirstToken(typeArguments), 1, firstToken)
       }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -3000,7 +3000,8 @@ function getComponentPropsFromDefineProps(context, node) {
       }
     ]
   }
-  const typeArguments = node.typeArguments || node.typeParameters
+  const typeArguments =
+    'typeArguments' in node ? node.typeArguments : node.typeParameters
   if (typeArguments && typeArguments.params.length > 0) {
     return getComponentPropsFromTypeDefine(context, typeArguments.params[0])
   }
@@ -3033,7 +3034,8 @@ function getComponentEmitsFromDefineEmits(context, node) {
       }
     ]
   }
-  const typeArguments = node.typeArguments || node.typeParameters
+  const typeArguments =
+    'typeArguments' in node ? node.typeArguments : node.typeParameters
   if (typeArguments && typeArguments.params.length > 0) {
     return getComponentEmitsFromTypeDefine(context, typeArguments.params[0])
   }

--- a/lib/utils/ts-utils/ts-ast.js
+++ b/lib/utils/ts-utils/ts-ast.js
@@ -430,7 +430,10 @@ function inferRuntimeType(context, node, checked = new Set()) {
             return ['Array']
           }
           case 'NonNullable': {
-            const typeArguments = node.typeArguments || node.typeParameters
+            const typeArguments =
+              'typeArguments' in node
+                ? node.typeArguments
+                : /** @type {any} typescript-eslint v5 */ (node).typeParameters
             if (typeArguments && typeArguments.params[0]) {
               return inferRuntimeType(
                 context,
@@ -441,7 +444,10 @@ function inferRuntimeType(context, node, checked = new Set()) {
             break
           }
           case 'Extract': {
-            const typeArguments = node.typeArguments || node.typeParameters
+            const typeArguments =
+              'typeArguments' in node
+                ? node.typeArguments
+                : /** @type {any} typescript-eslint v5 */ (node).typeParameters
             if (typeArguments && typeArguments.params[1]) {
               return inferRuntimeType(context, typeArguments.params[1], checked)
             }
@@ -449,7 +455,10 @@ function inferRuntimeType(context, node, checked = new Set()) {
           }
           case 'Exclude':
           case 'OmitThisParameter': {
-            const typeArguments = node.typeArguments || node.typeParameters
+            const typeArguments =
+              'typeArguments' in node
+                ? node.typeArguments
+                : /** @type {any} typescript-eslint v5 */ (node).typeParameters
             if (typeArguments && typeArguments.params[0]) {
               return inferRuntimeType(context, typeArguments.params[0], checked)
             }


### PR DESCRIPTION
#2292

typeParameters was still being accessed when typeArguments is undefined