### PR TITLE
Fix crash for TSFunctionType with `type-literal` option in `vue/define-emits-declaration` rule

### DIFF
--- a/lib/rules/define-emits-declaration.js
+++ b/lib/rules/define-emits-declaration.js
@@ -7,7 +7,7 @@
 const utils = require('../utils')
 
 /**
- * @typedef {import('@typescript-eslint/types').TSESTree.TSTypeLiteral} TSTypeLiteral
+ * @typedef {import('@typescript-eslint/types').TSESTree.TypeNode} TypeNode
  *
  */
 
@@ -54,24 +54,7 @@ module.exports = {
           }
 
           case 'type-literal': {
-            if (node.arguments.length > 0) {
-              context.report({
-                node,
-                messageId: 'hasArg'
-              })
-              return
-            }
-
-            const typeArguments = node.typeArguments || node.typeParameters
-            const param = /** @type {TSTypeLiteral} */ (typeArguments.params[0])
-            for (const memberNode of param.members) {
-              if (memberNode.type !== 'TSPropertySignature') {
-                context.report({
-                  node: memberNode,
-                  messageId: 'hasTypeCallArg'
-                })
-              }
-            }
+            verifyTypeLiteral(node)
             break
           }
 
@@ -89,5 +72,35 @@ module.exports = {
         }
       }
     })
+
+    /** @param {CallExpression} node */
+    function verifyTypeLiteral(node) {
+      if (node.arguments.length > 0) {
+        context.report({
+          node,
+          messageId: 'hasArg'
+        })
+        return
+      }
+
+      const typeArguments = node.typeArguments || node.typeParameters
+      const param = /** @type {TypeNode|undefined} */ (typeArguments?.params[0])
+      if (!param) return
+      if (param.type === 'TSTypeLiteral') {
+        for (const memberNode of param.members) {
+          if (memberNode.type !== 'TSPropertySignature') {
+            context.report({
+              node: memberNode,
+              messageId: 'hasTypeCallArg'
+            })
+          }
+        }
+      } else if (param.type === 'TSFunctionType') {
+        context.report({
+          node: param,
+          messageId: 'hasTypeCallArg'
+        })
+      }
+    }
   }
 }

--- a/tests/lib/rules/define-emits-declaration.js
+++ b/tests/lib/rules/define-emits-declaration.js
@@ -243,6 +243,25 @@ tester.run('define-emits-declaration', rule, {
           line: 5
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+        const emit = defineEmits<(e: 'change', id: number) => void>()
+        </script>
+        `,
+      options: ['type-literal'],
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser')
+      },
+      errors: [
+        {
+          message:
+            'Use new type literal declaration instead of the old call signature declaration.',
+          line: 3
+        }
+      ]
     }
   ]
 })

--- a/typings/eslint-plugin-vue/util-types/ast/es-ast.ts
+++ b/typings/eslint-plugin-vue/util-types/ast/es-ast.ts
@@ -522,7 +522,7 @@ export interface CallExpression extends HasParentNode {
   typeArguments?: TS.TSTypeParameterInstantiation
 
   /* @deprecated */
-  typeParameters: never
+  typeParameters?: never
 }
 export interface Super extends HasParentNode {
   type: 'Super'
@@ -534,7 +534,7 @@ export interface NewExpression extends HasParentNode {
   typeArguments?: TSTypeParameterInstantiation
 
   /* @deprecated */
-  typeParameters: never
+  typeParameters?: never
 }
 interface BaseMemberExpression extends HasParentNode {
   type: 'MemberExpression'


### PR DESCRIPTION

fixes #2335