### PR TITLE
Document non-fixable rules correctly

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -62,7 +62,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/no-deprecated-slot-attribute](./no-deprecated-slot-attribute.md) | disallow deprecated `slot` attribute (in Vue.js 2.6.0+) | :wrench: | :three::hammer: |
 | [vue/no-deprecated-slot-scope-attribute](./no-deprecated-slot-scope-attribute.md) | disallow deprecated `slot-scope` attribute (in Vue.js 2.6.0+) | :wrench: | :three::hammer: |
 | [vue/no-deprecated-v-bind-sync](./no-deprecated-v-bind-sync.md) | disallow use of deprecated `.sync` modifier on `v-bind` directive (in Vue.js 3.0.0+) | :wrench: | :three::warning: |
-| [vue/no-deprecated-v-is](./no-deprecated-v-is.md) | disallow deprecated `v-is` directive (in Vue.js 3.1.0+) | :wrench: | :three::hammer: |
+| [vue/no-deprecated-v-is](./no-deprecated-v-is.md) | disallow deprecated `v-is` directive (in Vue.js 3.1.0+) |  | :three::hammer: |
 | [vue/no-deprecated-v-on-native-modifier](./no-deprecated-v-on-native-modifier.md) | disallow using deprecated `.native` modifiers (in Vue.js 3.0.0+) |  | :three::warning: |
 | [vue/no-deprecated-v-on-number-modifiers](./no-deprecated-v-on-number-modifiers.md) | disallow using deprecated number (keycode) modifiers (in Vue.js 3.0.0+) | :wrench: | :three::warning: |
 | [vue/no-deprecated-vue-config-keycodes](./no-deprecated-vue-config-keycodes.md) | disallow using deprecated `Vue.config.keyCodes` (in Vue.js 3.0.0+) |  | :three::warning: |
@@ -225,7 +225,7 @@ For example:
 | [vue/new-line-between-multi-line-property](./new-line-between-multi-line-property.md) | enforce new lines between multi-line properties in Vue components | :wrench: | :lipstick: |
 | [vue/next-tick-style](./next-tick-style.md) | enforce Promise or callback style in `nextTick` | :wrench: | :hammer: |
 | [vue/no-bare-strings-in-template](./no-bare-strings-in-template.md) | disallow the use of bare strings in `<template>` |  | :hammer: |
-| [vue/no-boolean-default](./no-boolean-default.md) | disallow boolean defaults | :wrench: | :hammer: |
+| [vue/no-boolean-default](./no-boolean-default.md) | disallow boolean defaults |  | :hammer: |
 | [vue/no-deprecated-model-definition](./no-deprecated-model-definition.md) | disallow deprecated `model` definition (in Vue.js 3.0.0+) | :bulb: | :warning: |
 | [vue/no-duplicate-attr-inheritance](./no-duplicate-attr-inheritance.md) | enforce `inheritAttrs` to be set to `false` when using `v-bind="$attrs"` |  | :hammer: |
 | [vue/no-empty-component-block](./no-empty-component-block.md) | disallow the `<template>` `<script>` `<style>` block to be empty |  | :hammer: |

--- a/docs/rules/no-boolean-default.md
+++ b/docs/rules/no-boolean-default.md
@@ -9,15 +9,13 @@ since: v7.0.0
 
 > disallow boolean defaults
 
-- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
-
 The rule prevents Boolean props from having a default value.
 
 ## :book: Rule Details
 
 The rule is to enforce the HTML standard of always defaulting boolean attributes to false.
 
-<eslint-code-block fix :rules="{'vue/no-boolean-default': ['error']}">
+<eslint-code-block :rules="{'vue/no-boolean-default': ['error']}">
 
 ```vue
 <script>

--- a/docs/rules/no-deprecated-v-is.md
+++ b/docs/rules/no-deprecated-v-is.md
@@ -10,7 +10,6 @@ since: v7.11.0
 > disallow deprecated `v-is` directive (in Vue.js 3.1.0+)
 
 - :gear: This rule is included in all of `"plugin:vue/vue3-essential"`, `"plugin:vue/vue3-strongly-recommended"` and `"plugin:vue/vue3-recommended"`.
-- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details
 
@@ -18,7 +17,7 @@ This rule reports deprecated `v-is` directive in Vue.js v3.1.0+.
 
 Use [`is` attribute with `vue:` prefix](https://vuejs.org/api/built-in-special-attributes.html#is) instead.
 
-<eslint-code-block fix :rules="{'vue/no-deprecated-v-is': ['error']}">
+<eslint-code-block :rules="{'vue/no-deprecated-v-is': ['error']}">
 
 ```vue
 <template>

--- a/eslint-internal-rules/no-invalid-meta-docs-categories.js
+++ b/eslint-internal-rules/no-invalid-meta-docs-categories.js
@@ -112,6 +112,7 @@ module.exports = {
       description: 'enforce correct use of `meta` property in core rules',
       categories: ['Internal']
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'code',
     schema: [],
     messages: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -142,6 +142,10 @@ module.exports = [
       'prefer-const': 2,
 
       'prettier/prettier': 'error',
+      'eslint-plugin/require-meta-fixable': [
+        'error',
+        { catchNoFixerButFixableProperty: true }
+      ],
       'eslint-plugin/report-message-format': ['error', "^[A-Z`'{].*\\.$"],
 
       'no-debugger': 'error',

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -29,6 +29,7 @@ module.exports = {
       categories: ['vue3-strongly-recommended', 'strongly-recommended'],
       url: 'https://eslint.vuejs.org/rules/html-indent.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'whitespace',
     schema: [
       {

--- a/lib/rules/no-boolean-default.js
+++ b/lib/rules/no-boolean-default.js
@@ -38,7 +38,7 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-boolean-default.html'
     },
-    fixable: 'code',
+    fixable: null,
     schema: [
       {
         enum: ['default-false', 'no-default']

--- a/lib/rules/no-deprecated-scope-attribute.js
+++ b/lib/rules/no-deprecated-scope-attribute.js
@@ -15,6 +15,7 @@ module.exports = {
       categories: ['vue3-essential'],
       url: 'https://eslint.vuejs.org/rules/no-deprecated-scope-attribute.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'code',
     schema: [],
     messages: {

--- a/lib/rules/no-deprecated-slot-attribute.js
+++ b/lib/rules/no-deprecated-slot-attribute.js
@@ -15,6 +15,7 @@ module.exports = {
       categories: ['vue3-essential'],
       url: 'https://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'code',
     schema: [
       {

--- a/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -16,6 +16,7 @@ module.exports = {
       categories: ['vue3-essential'],
       url: 'https://eslint.vuejs.org/rules/no-deprecated-slot-scope-attribute.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'code',
     schema: [],
     messages: {

--- a/lib/rules/no-deprecated-v-is.js
+++ b/lib/rules/no-deprecated-v-is.js
@@ -15,7 +15,7 @@ module.exports = {
       categories: ['vue3-essential'],
       url: 'https://eslint.vuejs.org/rules/no-deprecated-v-is.html'
     },
-    fixable: 'code',
+    fixable: null,
     schema: [],
     messages: {
       forbiddenVIs: '`v-is` directive is deprecated.'

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -72,6 +72,7 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-unsupported-features.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'code',
     schema: [
       {

--- a/lib/rules/padding-line-between-blocks.js
+++ b/lib/rules/padding-line-between-blocks.js
@@ -119,6 +119,7 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/padding-line-between-blocks.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'whitespace',
     schema: [
       {

--- a/lib/rules/padding-line-between-tags.js
+++ b/lib/rules/padding-line-between-tags.js
@@ -173,6 +173,7 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/padding-line-between-tags.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'whitespace',
     schema: [
       {

--- a/lib/rules/script-indent.js
+++ b/lib/rules/script-indent.js
@@ -15,6 +15,7 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/script-indent.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'whitespace',
     schema: [
       {

--- a/lib/rules/v-if-else-key.js
+++ b/lib/rules/v-if-else-key.js
@@ -103,6 +103,7 @@ module.exports = {
       recommended: false,
       url: 'https://eslint.vuejs.org/rules/v-if-else-key.html'
     },
+    // eslint-disable-next-line eslint-plugin/require-meta-fixable -- fixer is not recognized
     fixable: 'code',
     schema: [],
     messages: {


### PR DESCRIPTION
This PR enables the `catchNoFixerButFixableProperty` rule option of the [`eslint-plugin/require-meta-fixable` rule](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-fixable.md), which increases the number of false-positives, but also catches two non-fixable rules that were incorrectly described.