### PR TITLE
feat(define-macros-order): add `defineExposeLast` option

### DIFF
--- a/docs/rules/define-macros-order.md
+++ b/docs/rules/define-macros-order.md
@@ -21,7 +21,7 @@ This rule reports the `defineProps` and `defineEmits` compiler macros when they 
 {
   "vue/define-macros-order": ["error", {
     "order": ["defineProps", "defineEmits"],
-    "defineExposeLast": false,
+    "defineExposeLast": false
   }]
 }
 ```

--- a/docs/rules/define-macros-order.md
+++ b/docs/rules/define-macros-order.md
@@ -20,12 +20,14 @@ This rule reports the `defineProps` and `defineEmits` compiler macros when they 
 ```json
 {
   "vue/define-macros-order": ["error", {
-    "order": ["defineProps", "defineEmits"]
+    "order": ["defineProps", "defineEmits"],
+    "defineExposeLast": false,
   }]
 }
 ```
 
 - `order` (`string[]`) ... The order of defineEmits and defineProps macros. You can also add `"defineOptions"` and `"defineSlots"`.
+- `defineExposeLast` (`boolean`) ... Force `defineExpose` at the end.
 
 ### `{ "order": ["defineProps", "defineEmits"] }` (default)
 
@@ -105,6 +107,35 @@ const bar = ref()
 defineOptions({/* ... */})
 defineProps(/* ... */)
 defineEmits(/* ... */)
+const slots = defineSlots()
+</script>
+```
+
+</eslint-code-block>
+
+### `{ "defineExposeLast": true }`
+<eslint-code-block fix :rules="{'vue/define-macros-order': ['error', {defineExposeLast: true}]}">
+
+```vue
+<!-- ✓ GOOD -->
+<script setup>
+defineProps(/* ... */)
+defineEmits(/* ... */)
+const slots = defineSlots()
+defineExpose({/* ... */})
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block fix :rules="{'vue/define-macros-order': ['error', {defineExposeLast: true}]}">
+
+```vue
+<!-- ✗ BAD -->
+<script setup>
+defineProps(/* ... */)
+defineEmits(/* ... */)
+defineExpose({/* ... */})
 const slots = defineSlots()
 </script>
 ```

--- a/docs/rules/define-macros-order.md
+++ b/docs/rules/define-macros-order.md
@@ -114,6 +114,7 @@ const slots = defineSlots()
 </eslint-code-block>
 
 ### `{ "defineExposeLast": true }`
+
 <eslint-code-block fix :rules="{'vue/define-macros-order': ['error', {defineExposeLast: true}]}">
 
 ```vue

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -196,9 +196,14 @@ function create(context) {
       node,
       loc: node.loc,
       messageId: 'defineExposeNotTheLast',
-      fix(fixer) {
-        return moveNodeToLast(fixer, node, lastNode)
-      }
+      suggest: [
+        {
+          messageId: 'putExposeAtTheLast',
+          fix(fixer) {
+            return moveNodeToLast(fixer, node, lastNode)
+          }
+        }
+      ]
     })
   }
 
@@ -228,13 +233,8 @@ function create(context) {
       node.range[0] - beforeNodeToken.range[1]
     )
 
-    // insert position:  after target and comments (if any)
-    const afterTargetComment = sourceCode.getTokenAfter(target, {
-      includeComments: true
-    })
-
     return [
-      fixer.insertTextAfter(afterTargetComment, textNode),
+      fixer.insertTextAfter(target, textNode),
       fixer.removeRange([cutStart, cutEnd])
     ]
   }
@@ -322,6 +322,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/define-macros-order.html'
     },
     fixable: 'code',
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',
@@ -345,7 +346,9 @@ module.exports = {
       macrosNotOnTop:
         '{{macro}} should be the first statement in `<script setup>` (after any potential import statements or type definitions).',
       defineExposeNotTheLast:
-        '`defineExpose` should be the last statement in `<script setup>`.'
+        '`defineExpose` should be the last statement in `<script setup>`.',
+      putExposeAtTheLast:
+        'Put `defineExpose` as the last statement in `<script setup>`.'
     }
   },
   create

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -95,8 +95,12 @@ function create(context) {
   const options = context.options
   /** @type {[string, string]} */
   const order = (options[0] && options[0].order) || DEFAULT_ORDER
+  /** @type {boolean} */
+  const defineExposeLast = (options[0] && options[0].defineExposeLast) || false
   /** @type {Map<string, ASTNode>} */
   const macrosNodes = new Map()
+  /** @type {ASTNode} */
+  let defineExposeNode
 
   return utils.compositingVisitors(
     utils.defineScriptSetupVisitor(context, {
@@ -111,6 +115,9 @@ function create(context) {
       },
       onDefineSlotsExit(node) {
         macrosNodes.set(MACROS_SLOTS, getDefineMacrosStatement(node))
+      },
+      onDefineExposeExit(node) {
+        defineExposeNode = getDefineMacrosStatement(node)
       }
     }),
     {
@@ -130,6 +137,14 @@ function create(context) {
             /** @returns {data is OrderedData} */
             (data) => utils.isDef(data.node)
           )
+
+        // check last node
+        if (defineExposeLast) {
+          const lastNode = program.body[program.body.length - 1]
+          if (defineExposeNode && lastNode !== defineExposeNode) {
+            reportExposeNotOnBottom(defineExposeNode, lastNode)
+          }
+        }
 
         for (const [index, should] of orderedList.entries()) {
           const targetStatement = program.body[firstStatementIndex + index]
@@ -170,6 +185,58 @@ function create(context) {
         }
       }
     })
+  }
+
+  /**
+   * @param {ASTNode} node
+   * @param {ASTNode} lastNode
+   */
+  function reportExposeNotOnBottom(node, lastNode) {
+    context.report({
+      node,
+      loc: node.loc,
+      messageId: 'defineExposeNotTheLast',
+      fix(fixer) {
+        return moveNodeToLast(fixer, node, lastNode)
+      }
+    })
+  }
+
+  /**
+   * Move all lines of "node" with its comments to after the "target"
+   * @param {RuleFixer} fixer
+   * @param {ASTNode} node
+   * @param {ASTNode} target
+   */
+  function moveNodeToLast(fixer, node, target) {
+    // get comments under tokens(if any)
+    const beforeNodeToken = sourceCode.getTokenBefore(node)
+    const nodeComment = sourceCode.getTokenAfter(beforeNodeToken, {
+      includeComments: true
+    })
+    const nextNodeComment = sourceCode.getTokenAfter(node, {
+      includeComments: true
+    })
+
+    // remove position: node (and comments) to next node (and comments)
+    const cutStart = getLineStartIndex(nodeComment, beforeNodeToken)
+    const cutEnd = getLineStartIndex(nextNodeComment, node)
+
+    // insert text: comment + node
+    const textNode = sourceCode.getText(
+      node,
+      node.range[0] - beforeNodeToken.range[1]
+    )
+
+    // insert position:  after target and comments (if any)
+    const afterTargetComment = sourceCode.getTokenAfter(target, {
+      includeComments: true
+    })
+
+    return [
+      fixer.insertTextAfter(afterTargetComment, textNode),
+      fixer.removeRange([cutStart, cutEnd])
+    ]
   }
 
   /**
@@ -266,6 +333,9 @@ module.exports = {
             },
             uniqueItems: true,
             additionalItems: false
+          },
+          defineExposeLast: {
+            type: 'boolean'
           }
         },
         additionalProperties: false
@@ -273,7 +343,9 @@ module.exports = {
     ],
     messages: {
       macrosNotOnTop:
-        '{{macro}} should be the first statement in `<script setup>` (after any potential import statements or type definitions).'
+        '{{macro}} should be the first statement in `<script setup>` (after any potential import statements or type definitions).',
+      defineExposeNotTheLast:
+        '`defineExpose` should be the last statement in `<script setup>`.'
     }
   },
   create

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1314,6 +1314,8 @@ module.exports = {
    * - `onDefineOptionsExit` ... Event when defineOptions visit ends.
    * - `onDefineSlotsEnter` ... Event when defineSlots is found.
    * - `onDefineSlotsExit` ... Event when defineSlots visit ends.
+   * - `onDefineExposeEnter` ... Event when defineExpose is found.
+   * - `onDefineExposeExit` ... Event when defineExpose visit ends.
    *
    * @param {RuleContext} context The ESLint rule context object.
    * @param {ScriptSetupVisitor} visitor The visitor to traverse the AST nodes.
@@ -1399,6 +1401,13 @@ module.exports = {
         'defineSlots',
         'onDefineSlotsEnter',
         'onDefineSlotsExit',
+        (candidateMacro, node) => candidateMacro === node,
+        () => undefined
+      ),
+      new MacroListener(
+        'defineExpose',
+        'onDefineExposeEnter',
+        'onDefineExposeExit',
         (candidateMacro, node) => candidateMacro === node,
         () => undefined
       )

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -27,9 +27,18 @@ const optionsPropsFirst = [
   }
 ]
 
+const optionsExposeLast = [
+  {
+    defineExposeLast: true
+  }
+]
+
 function message(macro) {
   return `${macro} should be the first statement in \`<script setup>\` (after any potential import statements or type definitions).`
 }
+
+const defineExposeNotTheLast =
+  '`defineExpose` should be the last statement in `<script setup>`.'
 
 tester.run('define-macros-order', rule, {
   valid: [
@@ -170,6 +179,21 @@ tester.run('define-macros-order', rule, {
           order: ['defineOptions', 'defineEmits', 'defineProps', 'defineSlots']
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          defineProps({
+            test: Boolean
+          })
+          console.log('test')
+          defineExpose({
+            a: 1
+          })
+        </script>
+      `,
+      options: optionsExposeLast
     }
   ],
   invalid: [
@@ -620,6 +644,48 @@ tester.run('define-macros-order', rule, {
         {
           message: message('defineOptions'),
           line: 6
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+        defineProps({
+          test: Boolean
+        })
+
+        // expose
+        defineExpose({
+          a: 1
+        })
+
+        // console start
+        console.log('test')
+        // console end
+        </script>
+      `,
+      output: `
+        <script setup>
+        defineProps({
+          test: Boolean
+        })
+
+        // console start
+        console.log('test')
+        // console end
+
+        // expose
+        defineExpose({
+          a: 1
+        })
+        </script>
+      `,
+      options: optionsExposeLast,
+      errors: [
+        {
+          message: defineExposeNotTheLast,
+          line: 8
         }
       ]
     }

--- a/typings/eslint-plugin-vue/util-types/utils.ts
+++ b/typings/eslint-plugin-vue/util-types/utils.ts
@@ -44,6 +44,8 @@ export interface ScriptSetupVisitor extends ScriptSetupVisitorBase {
   onDefineOptionsExit?(node: CallExpression): void
   onDefineSlotsEnter?(node: CallExpression): void
   onDefineSlotsExit?(node: CallExpression): void
+  onDefineExposeEnter?(node: CallExpression): void
+  onDefineExposeExit?(node: CallExpression): void
   [query: string]:
     | ((node: VAST.ParamNode) => void)
     | ((node: CallExpression, props: ComponentProp[]) => void)


### PR DESCRIPTION
will close https://github.com/vuejs/eslint-plugin-vue/issues/2235

I'll be thankful for any suggestions on these TODOs.

- open to suggestions for a better option name…
- should we include `defineExpose` within the `order` schema? There is a potential conflict in the options, like:
`{ order: ['defineExpose', 'defineProps'], defineExposeLast: true }`.
- any other test cases should we add to verify the fixer?
- update the docs.