### PR TITLE
fix(require-explicit-emits): detect template emits

### DIFF
--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -271,7 +271,7 @@ module.exports = {
             return
           }
 
-          // e.g. $emit() / emits() in template
+          // e.g. $emit() / emit() in template
           if (
             callee.type === 'Identifier' &&
             (callee.name === '$emit' ||

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -71,6 +71,25 @@ function getNameParamNode(node) {
   return null
 }
 
+/**
+ * Check if the given name matches defineEmitsNode variable name
+ * @param {string} name
+ * @param {CallExpression | undefined} defineEmitsNode
+ * @returns {boolean}
+ */
+function verifyEmitVariableName(name, defineEmitsNode) {
+  const node = defineEmitsNode?.parent
+  if (!node) return false
+
+  /** @type {string | undefined} */
+  let defineEmitVariable
+  if (node.type === 'VariableDeclarator' && node.id.type === 'Identifier') {
+    defineEmitVariable = node.id?.name
+  }
+
+  return name === defineEmitVariable
+}
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -251,7 +270,16 @@ module.exports = {
           if (!vueTemplateDefineData) {
             return
           }
-          if (callee.type === 'Identifier' && callee.name === '$emit') {
+
+          // e.g. $emit() / emits() in template
+          if (
+            callee.type === 'Identifier' &&
+            (callee.name === '$emit' ||
+              verifyEmitVariableName(
+                callee.name,
+                vueTemplateDefineData.defineEmits
+              ))
+          ) {
             verifyEmit(
               vueTemplateDefineData.emits,
               vueTemplateDefineData.props,

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -79,15 +79,15 @@ function getNameParamNode(node) {
  */
 function verifyEmitVariableName(name, defineEmitsNode) {
   const node = defineEmitsNode?.parent
-  if (!node) return false
 
-  /** @type {string | undefined} */
-  let defineEmitVariable
-  if (node.type === 'VariableDeclarator' && node.id.type === 'Identifier') {
-    defineEmitVariable = node.id?.name
+  if (
+    node?.type === 'VariableDeclarator' &&
+    node.id.type === 'Identifier'
+  ) {
+    return name === node.id.name
   }
 
-  return name === defineEmitVariable
+  return false
 }
 
 module.exports = {

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -77,13 +77,10 @@ function getNameParamNode(node) {
  * @param {CallExpression | undefined} defineEmitsNode
  * @returns {boolean}
  */
-function verifyEmitVariableName(name, defineEmitsNode) {
+function isEmitVariableName(name, defineEmitsNode) {
   const node = defineEmitsNode?.parent
 
-  if (
-    node?.type === 'VariableDeclarator' &&
-    node.id.type === 'Identifier'
-  ) {
+  if (node?.type === 'VariableDeclarator' && node.id.type === 'Identifier') {
     return name === node.id.name
   }
 
@@ -275,7 +272,7 @@ module.exports = {
           if (
             callee.type === 'Identifier' &&
             (callee.name === '$emit' ||
-              verifyEmitVariableName(
+              isEmitVariableName(
                 callee.name,
                 vueTemplateDefineData.defineEmits
               ))

--- a/tests/lib/rules/require-explicit-emits.js
+++ b/tests/lib/rules/require-explicit-emits.js
@@ -461,6 +461,19 @@ tester.run('require-explicit-emits', rule, {
       `,
       parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
     },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div @click="emit('foo')"/>
+        <div @click="emit('bar')"/>
+      </template>
+      <script setup lang="ts">
+      const emit = defineEmits<(e: 'foo' | 'bar') => void>()
+      </script>
+      `,
+      parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+    },
 
     // unknown emits definition
     {

--- a/tests/lib/rules/require-explicit-emits.js
+++ b/tests/lib/rules/require-explicit-emits.js
@@ -1983,6 +1983,25 @@ emits: {'foo': null}
         }
       ],
       ...getTypeScriptFixtureTestOptions()
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div @click="emits('bar')"/>
+      </template>
+      <script setup lang="ts">
+      const emits = defineEmits<(e: 'foo') => void>()
+      </script>
+      `,
+      parserOptions: { parser: require.resolve('@typescript-eslint/parser') },
+      errors: [
+        {
+          message:
+            'The "bar" event has been triggered but not declared on `defineEmits`.',
+          line: 3
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/require-explicit-emits.js
+++ b/tests/lib/rules/require-explicit-emits.js
@@ -1988,10 +1988,10 @@ emits: {'foo': null}
       filename: 'test.vue',
       code: `
       <template>
-        <div @click="emits('bar')"/>
+        <div @click="emit('bar')"/>
       </template>
       <script setup lang="ts">
-      const emits = defineEmits<(e: 'foo') => void>()
+      const emit = defineEmits<(e: 'foo') => void>()
       </script>
       `,
       parserOptions: { parser: require.resolve('@typescript-eslint/parser') },


### PR DESCRIPTION
This rule has a similar issue to https://github.com/vuejs/eslint-plugin-vue/issues/2337.
The unused emits in the template were not detected, so this PR fixes that.