### PR TITLE
feat: allow v-bind shorthand

### DIFF
--- a/lib/rules/valid-v-bind.js
+++ b/lib/rules/valid-v-bind.js
@@ -21,8 +21,7 @@ module.exports = {
     schema: [],
     messages: {
       unsupportedModifier:
-        "'v-bind' directives don't support the modifier '{{name}}'.",
-      expectedValue: "'v-bind' directives require an attribute value."
+        "'v-bind' directives don't support the modifier '{{name}}'."
     }
   },
   /** @param {RuleContext} context */
@@ -38,13 +37,6 @@ module.exports = {
               data: { name: modifier.name }
             })
           }
-        }
-
-        if (!node.value || utils.isEmptyValueDirective(node, context)) {
-          context.report({
-            node,
-            messageId: 'expectedValue'
-          })
         }
       }
     })


### PR DESCRIPTION
v-bind shorthand is supported in Vue 3.4

see https://blog.vuejs.org/posts/vue-3-4#v-bind-same-name-shorthand