### PR TITLE
Remove v-bind shorthand syntax from list of examples rule will catch.

### DIFF
--- a/docs/rules/valid-v-bind.md
+++ b/docs/rules/valid-v-bind.md
@@ -34,7 +34,6 @@ This rule does not report `v-bind` directives which do not have their argument (
 
   <!-- ✗ BAD -->
   <div v-bind/>
-  <div :aaa/>
   <div v-bind:aaa.bbb="foo"/>
 </template>
 ```


### PR DESCRIPTION
This syntax gets removed at the parser level and so will never be enforced, even in Vue 2.

See https://github.com/vuejs/eslint-plugin-vue/pull/2357.