### PR TITLE
Chore: fix errors in tests using ESLint v9.0.0-alpha.2

### DIFF
--- a/tests/lib/rules/no-reserved-component-names.js
+++ b/tests/lib/rules/no-reserved-component-names.js
@@ -245,7 +245,6 @@ const invalidElements = [
   'menu',
   'Menu',
   'menuitem',
-  'menuitem',
   'summary',
   'Summary',
   'content',

--- a/tests/lib/rules/this-in-template.js
+++ b/tests/lib/rules/this-in-template.js
@@ -44,10 +44,6 @@ function createValidTests(prefix, options) {
       options
     },
     {
-      code: `<template><div :parent="this"></div></template><!-- ${comment} -->`,
-      options
-    },
-    {
       code: `<template><div v-for="x of ${prefix}xs">{{this.x}}</div></template><!-- ${comment} -->`,
       options
     },
@@ -68,26 +64,6 @@ function createValidTests(prefix, options) {
       options
     },
     {
-      code: `<template><div>{{ this.class }}</div></template><!-- ${comment} -->`,
-      options
-    },
-    {
-      code: `<template><div>{{ this['0'] }}</div></template><!-- ${comment} -->`,
-      options
-    },
-    {
-      code: `<template><div>{{ this['this'] }}</div></template><!-- ${comment} -->`,
-      options
-    },
-    {
-      code: `<template><div>{{ this['foo bar'] }}</div></template><!-- ${comment} -->`,
-      options
-    },
-    {
-      code: `<template><div>{{ }}</div></template><!-- ${comment} -->`,
-      options
-    },
-    {
       code: `<template>
         <div>
           <div v-for="bar in ${prefix}foo" v-if="bar">{{ bar }}</div>
@@ -96,12 +72,6 @@ function createValidTests(prefix, options) {
           </div>
         </div>
       </template><!-- ${comment} -->`,
-      options
-    },
-
-    // We cannot use `.` in dynamic arguments because the right of the `.` becomes a modifier.
-    {
-      code: `<template><div v-on:[x]="1"></div></template><!-- ${comment} -->`,
       options
     }
   ]
@@ -181,7 +151,7 @@ function createInvalidTests(prefix, options, message, type) {
       )}bar"></div></template><!-- ${comment} -->`,
       errors: [{ message, type }],
       options
-    },
+    }
 
     // We cannot use `.` in dynamic arguments because the right of the `.` becomes a modifier.
     // {
@@ -189,22 +159,6 @@ function createInvalidTests(prefix, options, message, type) {
     //   errors: [{ message, type }],
     //   options
     // }
-    ...(options[0] === 'always'
-      ? []
-      : [
-          {
-            code: `<template><div>{{ this['xs'] }}</div></template><!-- ${comment} -->`,
-            output: `<template><div>{{ xs }}</div></template><!-- ${comment} -->`,
-            errors: [{ message, type }],
-            options
-          },
-          {
-            code: `<template><div>{{ this['xs0AZ_foo'] }}</div></template><!-- ${comment} -->`,
-            output: `<template><div>{{ xs0AZ_foo }}</div></template><!-- ${comment} -->`,
-            errors: [{ message, type }],
-            options
-          }
-        ])
   ]
 }
 
@@ -216,7 +170,41 @@ ruleTester.run('this-in-template', rule, {
     ...createValidTests('', []),
     ...createValidTests('', ['never']),
     ...createValidTests('this.', ['always']),
-    ...createValidTests('this?.', ['always'])
+    ...createValidTests('this?.', ['always']),
+    ...[[], ['never'], ['always']].flatMap((options) => {
+      const comment = options.join('')
+      return [
+        {
+          code: `<template><div :parent="this"></div></template><!-- ${comment} -->`,
+          options
+        },
+        {
+          code: `<template><div>{{ this.class }}</div></template><!-- ${comment} -->`,
+          options
+        },
+        {
+          code: `<template><div>{{ this['0'] }}</div></template><!-- ${comment} -->`,
+          options
+        },
+        {
+          code: `<template><div>{{ this['this'] }}</div></template><!-- ${comment} -->`,
+          options
+        },
+        {
+          code: `<template><div>{{ this['foo bar'] }}</div></template><!-- ${comment} -->`,
+          options
+        },
+        {
+          code: `<template><div>{{ }}</div></template><!-- ${comment} -->`,
+          options
+        },
+        // We cannot use `.` in dynamic arguments because the right of the `.` becomes a modifier.
+        {
+          code: `<template><div v-on:[x]="1"></div></template><!-- ${comment} -->`,
+          options
+        }
+      ]
+    })
   ],
   invalid: [
     ...createInvalidTests(
@@ -244,6 +232,25 @@ ruleTester.run('this-in-template', rule, {
       'ThisExpression'
     ),
     ...createInvalidTests('', ['always'], "Expected 'this'.", 'Identifier'),
+    ...[[], ['never']].flatMap((options) => {
+      const comment = options.join('')
+      const message = "Unexpected usage of 'this'."
+      const type = 'ThisExpression'
+      return [
+        {
+          code: `<template><div>{{ this['xs'] }}</div></template><!-- ${comment} -->`,
+          output: `<template><div>{{ xs }}</div></template><!-- ${comment} -->`,
+          errors: [{ message, type }],
+          options
+        },
+        {
+          code: `<template><div>{{ this['xs0AZ_foo'] }}</div></template><!-- ${comment} -->`,
+          output: `<template><div>{{ xs0AZ_foo }}</div></template><!-- ${comment} -->`,
+          errors: [{ message, type }],
+          options
+        }
+      ]
+    }),
     {
       code: `<template><div v-if="fn(this.$foo)"></div></template><!-- never -->`,
       output: `<template><div v-if="fn($foo)"></div></template><!-- never -->`,


### PR DESCRIPTION
This PR removes duplicate test cases and fixes errors in testing with ESLint v9.
Found in #2381.

