### PR TITLE
fix(no-useless-mustaches): escape < in fixes

### DIFF
--- a/lib/rules/no-useless-mustaches.js
+++ b/lib/rules/no-useless-mustaches.js
@@ -142,8 +142,9 @@ module.exports = {
             // It doesn't autofix because another rule like indent or eol space might remove spaces.
             return null
           }
+          const escaped = text.replace(/\</g, '&lt;');
 
-          return fixer.replaceText(node, text.replace(/\\([\S\s])/g, '$1'))
+          return fixer.replaceText(node, escaped.replace(/\\([\S\s])/g, '$1'))
         }
       })
     }

--- a/lib/rules/no-useless-mustaches.js
+++ b/lib/rules/no-useless-mustaches.js
@@ -142,7 +142,7 @@ module.exports = {
             // It doesn't autofix because another rule like indent or eol space might remove spaces.
             return null
           }
-          const escaped = text.replace(/\</g, '&lt;')
+          const escaped = text.replace(/</g, '&lt;')
 
           return fixer.replaceText(node, escaped.replace(/\\([\S\s])/g, '$1'))
         }

--- a/lib/rules/no-useless-mustaches.js
+++ b/lib/rules/no-useless-mustaches.js
@@ -142,7 +142,7 @@ module.exports = {
             // It doesn't autofix because another rule like indent or eol space might remove spaces.
             return null
           }
-          const escaped = text.replace(/\</g, '&lt;');
+          const escaped = text.replace(/\</g, '&lt;')
 
           return fixer.replaceText(node, escaped.replace(/\\([\S\s])/g, '$1'))
         }

--- a/tests/lib/rules/no-useless-mustaches.js
+++ b/tests/lib/rules/no-useless-mustaches.js
@@ -189,6 +189,54 @@ tester.run('no-useless-mustaches', rule, {
     {
       code: `
       <template>
+        {{ '&lt;' }}
+        {{ '&gt;' }}
+        {{ '&amp;' }}
+        {{ '&#8212;' }}
+      </template>
+      `,
+      output: `
+      <template>
+        &lt;
+        &gt;
+        &amp;
+        &#8212;
+      </template>
+      `,
+      errors: [
+        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.',
+      ]
+    },
+    {
+      code: `
+      <template>
+        {{ '<' }}
+        {{ '<<' }}
+        {{ 'can be < anywhere' }}
+        {{ '<tag>' }}
+      </template>
+      `,
+      output: `
+      <template>
+        &lt;
+        &lt;&lt;
+        can be &lt; anywhere
+        &lt;tag>
+      </template>
+      `,
+      errors: [
+        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.',
+      ]
+    },
+    {
+      code: `
+      <template>
         {{ \`foo
 bar\` }}
       </template>

--- a/tests/lib/rules/no-useless-mustaches.js
+++ b/tests/lib/rules/no-useless-mustaches.js
@@ -207,7 +207,7 @@ tester.run('no-useless-mustaches', rule, {
         'Unexpected mustache interpolation with a string literal value.',
         'Unexpected mustache interpolation with a string literal value.',
         'Unexpected mustache interpolation with a string literal value.',
-        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.'
       ]
     },
     {
@@ -231,7 +231,7 @@ tester.run('no-useless-mustaches', rule, {
         'Unexpected mustache interpolation with a string literal value.',
         'Unexpected mustache interpolation with a string literal value.',
         'Unexpected mustache interpolation with a string literal value.',
-        'Unexpected mustache interpolation with a string literal value.',
+        'Unexpected mustache interpolation with a string literal value.'
       ]
     },
     {


### PR DESCRIPTION
Fixes #2384
I looked up the parser specification for the [inside tag case](https://html.spec.whatwg.org/multipage/parsing.html#data-state) for potential additional cases which would differ:
- `<`: already covered in the issue
- `EOF`: would already be an error
- `\0`: I guess/hope no one would do this but there is a [difference](https://play.vuejs.org/#eNp9kE1rAjEQhv9KmIsX2Ra8iRTa4qE9tKXtcS7LOq6r2UlIJrqw5L+bRPw4iLfJ+zwJ72SEV2urfSCYw0Kot7oWekFWahzVBPF5omLMxzQiL55uFJiC+MbwumurrTecXhiLCY3pbafJfVvpDHuEuSoks1prc/gsmbhA03PebKjZ3cm3fsgZwo8jT25PCBcmtWtJTnj590VDmi+wN6ugk/0A/pI3OuSOJ+0t8CrVvvFK24/eGicdt/9+OQixPy+Vi2YzFh8hfeP7g9WvdWfVrNxDjhCPljJ9KQ==)
- `&`: there are cases when combining the text with either before or [after the mustache](https://play.vuejs.org/#eNp9kLtuAjEQRX/FmiI0aFPQERQpiSiSIomSlG5Wy2RZ8HoszxhWWvnfsY14FIjOuude6YxHeHGu2gWEOSwEe2dqwWdtlRpHNXmoHfFExfik7eLxCsMUhBuy/11bbZhsWo95pKGh3nUG/ZeTjixrmKtCMquNof1HycQHnJ7yZo3N9ka+4SFnGr49MvodajgzqX2LcsTL308c0vsMe1oFk9p34A8ymZAdj7XXYFdJ+6pXbN97R1462/7xchC0fDoqi+ZmLH0N6Qvf7px+0Z1Vs7LTNkI8AFgmfGM=) but is also highly unlikely

So this PR only adds escaping `<` with `&lt;` in the fixer.