### PR TITLE
feat(no-deprecated-slot-attribute): improve autofix to wrap `<template v-slot>`

### DIFF
--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -71,8 +71,8 @@ module.exports = {
      * @returns {IterableIterator<Fix>} fix data
      */
     function* fixSlotToVSlot(fixer, slotAttr, slotName, vBind) {
-      const element = slotAttr.parent
-      const scopeAttr = element.attributes.find(
+      const startTag = slotAttr.parent
+      const scopeAttr = startTag.attributes.find(
         (attr) =>
           attr.directive === true &&
           attr.key.name &&
@@ -89,9 +89,21 @@ module.exports = {
           : ''
 
       const replaceText = `v-slot${nameArgument}${scopeValue}`
-      yield fixer.replaceText(slotAttr || scopeAttr, replaceText)
-      if (slotAttr && scopeAttr) {
-        yield fixer.remove(scopeAttr)
+
+      const element = startTag.parent;
+      if (element.name === 'template') {
+        yield fixer.replaceText(slotAttr || scopeAttr, replaceText)
+        if (slotAttr && scopeAttr) {
+          yield fixer.remove(scopeAttr)
+        }
+      } else {
+        yield fixer.remove(slotAttr || scopeAttr);
+        if (slotAttr && scopeAttr) {
+          yield fixer.remove(scopeAttr)
+        }
+
+        yield fixer.insertTextBefore(element, `<template ${replaceText}>\n`)
+        yield fixer.insertTextAfter(element, `\n</template>`)
       }
     }
     /**

--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -90,14 +90,14 @@ module.exports = {
 
       const replaceText = `v-slot${nameArgument}${scopeValue}`
 
-      const element = startTag.parent;
+      const element = startTag.parent
       if (element.name === 'template') {
         yield fixer.replaceText(slotAttr || scopeAttr, replaceText)
         if (slotAttr && scopeAttr) {
           yield fixer.remove(scopeAttr)
         }
       } else {
-        yield fixer.remove(slotAttr || scopeAttr);
+        yield fixer.remove(slotAttr || scopeAttr)
         if (slotAttr && scopeAttr) {
           yield fixer.remove(scopeAttr)
         }

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -65,22 +65,20 @@ module.exports = {
      * @returns {Fix[]} fix data
      */
     function fixSlotScopeToVSlot(fixer, scopeAttr) {
-      const element = scopeAttr.parent.parent;
+      const element = scopeAttr.parent.parent
       const scopeValue =
         scopeAttr && scopeAttr.value
           ? `=${sourceCode.getText(scopeAttr.value)}`
           : ''
 
       const replaceText = `v-slot${scopeValue}`
-      if (element.name === 'template') {
-        return [fixer.replaceText(scopeAttr, replaceText)]
-      } else {
-        return [
-          fixer.remove(scopeAttr),
-          fixer.insertTextBefore(element, `<template ${replaceText}>\n`),
-          fixer.insertTextAfter(element, `\n</template>`),
-        ];
-      }
+      return element.name === 'template'
+        ? [fixer.replaceText(scopeAttr, replaceText)]
+        : [
+            fixer.remove(scopeAttr),
+            fixer.insertTextBefore(element, `<template ${replaceText}>\n`),
+            fixer.insertTextAfter(element, `\n</template>`)
+          ]
     }
     /**
      * Reports `slot-scope` node

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -62,16 +62,25 @@ module.exports = {
      * Convert to `v-slot`.
      * @param {RuleFixer} fixer fixer
      * @param {VDirective} scopeAttr node of `slot-scope`
-     * @returns {Fix} fix data
+     * @returns {Fix[]} fix data
      */
     function fixSlotScopeToVSlot(fixer, scopeAttr) {
+      const element = scopeAttr.parent.parent;
       const scopeValue =
         scopeAttr && scopeAttr.value
           ? `=${sourceCode.getText(scopeAttr.value)}`
           : ''
 
       const replaceText = `v-slot${scopeValue}`
-      return fixer.replaceText(scopeAttr, replaceText)
+      if (element.name === 'template') {
+        return [fixer.replaceText(scopeAttr, replaceText)]
+      } else {
+        return [
+          fixer.remove(scopeAttr),
+          fixer.insertTextBefore(element, `<template ${replaceText}>\n`),
+          fixer.insertTextAfter(element, `\n</template>`),
+        ];
+      }
     }
     /**
      * Reports `slot-scope` node

--- a/lib/rules/syntaxes/slot-scope-attribute.js
+++ b/lib/rules/syntaxes/slot-scope-attribute.js
@@ -72,13 +72,16 @@ module.exports = {
           : ''
 
       const replaceText = `v-slot${scopeValue}`
-      return element.name === 'template'
-        ? [fixer.replaceText(scopeAttr, replaceText)]
-        : [
-            fixer.remove(scopeAttr),
-            fixer.insertTextBefore(element, `<template ${replaceText}>\n`),
-            fixer.insertTextAfter(element, `\n</template>`)
-          ]
+      if (element.name === 'template') {
+        return [fixer.replaceText(scopeAttr, replaceText)]
+      } else {
+        const tokenBefore = tokenStore.getTokenBefore(scopeAttr)
+        return [
+          fixer.removeRange([tokenBefore.range[1], scopeAttr.range[1]]),
+          fixer.insertTextBefore(element, `<template ${replaceText}>\n`),
+          fixer.insertTextAfter(element, `\n</template>`)
+        ]
+      }
     }
     /**
      * Reports `slot-scope` node

--- a/lib/rules/syntaxes/utils/can-convert-to-v-slot.js
+++ b/lib/rules/syntaxes/utils/can-convert-to-v-slot.js
@@ -25,9 +25,6 @@ const utils = require('../../../utils')
  * @param {ParserServices.TokenStore} tokenStore
  */
 module.exports = function canConvertToVSlot(element, sourceCode, tokenStore) {
-  if (element.name !== 'template') {
-    return false
-  }
   const ownerElement = element.parent
   if (
     ownerElement.type === 'VDocumentFragment' ||

--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -335,7 +335,12 @@ tester.run('no-deprecated-slot-attribute', rule, {
           <a slot="name" />
         </LinkList>
       </template>`,
-      output: null,
+      output: `
+      <template>
+        <LinkList>
+          <template v-slot:name>\n<a  />\n</template>
+        </LinkList>
+      </template>`,
       errors: [
         {
           message: '`slot` attributes are deprecated.',
@@ -350,7 +355,12 @@ tester.run('no-deprecated-slot-attribute', rule, {
           <a :slot="name" />
         </LinkList>
       </template>`,
-      output: null,
+      output: `
+      <template>
+        <LinkList>
+          <template v-slot:[name]>\n<a  />\n</template>
+        </LinkList>
+      </template>`,
       errors: [
         {
           message: '`slot` attributes are deprecated.',
@@ -616,7 +626,17 @@ tester.run('no-deprecated-slot-attribute', rule, {
           </two>
         </my-component>
       </template>`,
-      output: null,
+      output: `
+      <template>
+        <my-component>
+          <one slot="one">
+            A
+          </one>
+          <template v-slot:two>\n<two >
+            B
+          </two>\n</template>
+        </my-component>
+      </template>`,
       options: [
         {
           ignore: ['one']

--- a/tests/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -98,7 +98,12 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
           <a slot-scope="{a}" />
         </LinkList>
       </template>`,
-      output: null,
+      output: `
+      <template>
+        <LinkList>
+          <template v-slot="{a}">\n<a  />\n</template>
+        </LinkList>
+      </template>`,
       errors: [
         {
           message: '`slot-scope` are deprecated.',

--- a/tests/lib/rules/no-deprecated-slot-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-scope-attribute.js
@@ -90,7 +90,6 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
         }
       ]
     },
-    // cannot fix
     {
       code: `
       <template>
@@ -101,7 +100,7 @@ tester.run('no-deprecated-slot-scope-attribute', rule, {
       output: `
       <template>
         <LinkList>
-          <template v-slot="{a}">\n<a  />\n</template>
+          <template v-slot="{a}">\n<a />\n</template>
         </LinkList>
       </template>`,
       errors: [


### PR DESCRIPTION
Currently doing a Vue 2.7 migration in an old codebase...

I was thinking it should be possible to autofix cases of the deprecated `slot` attribute where the element is not `<template>`, by wrapping it in a `<template v-slot>`.

This PR demonstrates it, and the auto-fixes worked fine in my codebase. Want to get feedback to see if I'm missing any edge-cases.