### PR TITLE
feat(valid-v-model): add support for type assertions and non-null expressions

### DIFF
--- a/lib/rules/valid-v-model.js
+++ b/lib/rules/valid-v-model.js
@@ -49,7 +49,12 @@ function isOptionalChainingMemberExpression(node) {
  * @returns {boolean} `true` if the node can be LHS.
  */
 function isLhs(node) {
-  return node.type === 'Identifier' || node.type === 'MemberExpression'
+  return (
+    node.type === 'Identifier' ||
+    node.type === 'MemberExpression' ||
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSNonNullExpression'
+  )
 }
 
 /**

--- a/tests/lib/rules/valid-v-model.js
+++ b/tests/lib/rules/valid-v-model.js
@@ -143,6 +143,24 @@ tester.run('valid-v-model', rule, {
     {
       filename: 'comment-value.vue',
       code: '<template><MyComponent v-model="/**/" /></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent v-model="a as string"></MyComponent></template>',
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent v-model="a!"></MyComponent></template>',
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
     }
   ],
   invalid: [

--- a/typings/eslint-plugin-vue/util-types/ast/ts-ast.ts
+++ b/typings/eslint-plugin-vue/util-types/ast/ts-ast.ts
@@ -6,6 +6,7 @@ import * as ES from './es-ast'
 import { TSESTree } from '@typescript-eslint/types'
 export type TSNode =
   | TSAsExpression
+  | TSNonNullExpression
   | TSTypeParameterInstantiation
   | TSPropertySignature
   | TSMethodSignatureBase
@@ -18,6 +19,11 @@ export interface TSAsExpression extends HasParentNode {
   type: 'TSAsExpression'
   expression: ES.Expression
   typeAnnotation: any
+}
+
+export interface TSNonNullExpression extends HasParentNode {
+  type: 'TSNonNullExpression'
+  expression: ES.Expression
 }
 
 export interface TSTypeParameterInstantiation extends HasParentNode {


### PR DESCRIPTION
Fixes https://github.com/vuejs/eslint-plugin-vue/issues/2262

Both `TSAsExpression` and `TSNonNullExpression` are valid `v-model` args: [vue playground](https://play.vuejs.org/#eNqFUk1PwzAM/Ssmlw1ptEK7TV0lQJPgwIcAiUsuVeuWTmkS5WNMKv3vOFk3dmDs1NrPjp/fc89utE42HtmCZbY0rXZg0XkNopDNkjNnOcu5bDutjIMeDNYwQG1UBxNqmxygO9XpMZ+kIQivEsxlqaR10NkGlqE9s860soFvkF6IfDq5RyEUfCgjqovJJZdZuiNCYylw2GlROKQIIPu8zvs+vjUMWUpRzMbZm6tOVSiIc4ALC7s5nEF6qupiBLP0aAqb0dLEuW6bZG2VJGX60M9ZSQ+0As2zdi3txNkCIhKwMKx0IeWMx9k+vbbbkOPsxaBFs0HODpgrTIOxhbPV2xNu6f8AEksvqPof8BWtEj5Q2ZXdelkRu6O6goT9eoj+kBLvdrV1KO2eeyAaKodYzxn5FSQ6teEv3Xkyj31cDiTW3uszFwQw3kGQny6hwrqV+Bii8SLy6RnzW6m9O3YwfP+0cPgBZS7zuw==)

[`TSNonNullExpression` spec](https://github.com/typescript-eslint/typescript-eslint/blob/9883ee275e79006f048813da851f00ba34f09b92/packages/ast-spec/src/expression/TSNonNullExpression/spec.ts#L5)