### PR TITLE
fix(require-explicit-slots): recognize slot names enclosed in quotes

### DIFF
--- a/docs/rules/require-explicit-slots.md
+++ b/docs/rules/require-explicit-slots.md
@@ -11,7 +11,7 @@ since: v9.21.0
 
 ## :book: Rule Details
 
-This rule enforces all slots used in the template to be defined once either in the `script setup` block with the [`defineSlots`](https://vuejs.org/api/sfc-script-setup.html) macro, or with the [`slots property`](https://vuejs.org/api/options-rendering.html#slots) in the Options API.
+This rule enforces all slots used in the template to be defined once either in the `script setup` block with the [`defineSlots`](https://vuejs.org/api/sfc-script-setup.html#defineslots) macro, or with the [`slots property`](https://vuejs.org/api/options-rendering.html#slots) in the Options API.
 
 <eslint-code-block :rules="{'vue/require-explicit-slots': ['error']}">
 

--- a/lib/rules/require-explicit-slots.js
+++ b/lib/rules/require-explicit-slots.js
@@ -8,7 +8,30 @@ const utils = require('../utils')
 
 /**
  * @typedef {import('@typescript-eslint/types').TSESTree.TypeNode} TypeNode
+ * @typedef {import('@typescript-eslint/types').TSESTree.TypeElement} TypeElement
  */
+
+/**
+ *
+ * @param {TypeElement} node
+ */
+function getSlotsName(node) {
+  if (
+    node.type === 'TSMethodSignature' ||
+    node.type === 'TSPropertySignature'
+  ) {
+    const key = node.key
+    if (key.type === 'Literal') {
+      return typeof key.value === 'string' ? key.value : null
+    }
+
+    if (key.type === 'Identifier') {
+      return key.name
+    }
+  }
+
+  return null
+}
 
 module.exports = {
   meta: {
@@ -34,9 +57,9 @@ module.exports = {
     if (!documentFragment) {
       return {}
     }
-    const scripts = documentFragment.children.filter(
-      (element) => utils.isVElement(element) && element.name === 'script'
-    )
+    const scripts = documentFragment.children
+      .filter(utils.isVElement)
+      .filter((element) => element.name === 'script')
     if (scripts.every((script) => !utils.hasAttribute(script, 'lang', 'ts'))) {
       return {}
     }
@@ -54,7 +77,9 @@ module.exports = {
 
           if (param.type === 'TSTypeLiteral') {
             for (const memberNode of param.members) {
-              const slotName = memberNode.key.name
+              const slotName = getSlotsName(memberNode)
+              if (!slotName) continue
+
               if (slotsDefined.has(slotName)) {
                 context.report({
                   node: memberNode,
@@ -75,6 +100,7 @@ module.exports = {
         if (!slotsProperty) return
 
         const slotsTypeHelper =
+          slotsProperty.value.type === 'TSAsExpression' &&
           slotsProperty.value.typeAnnotation?.typeName.name === 'SlotsType' &&
           slotsProperty.value.typeAnnotation
         if (!slotsTypeHelper) return
@@ -90,7 +116,9 @@ module.exports = {
 
         if (param.type === 'TSTypeLiteral') {
           for (const memberNode of param.members) {
-            const slotName = memberNode.key.name
+            const slotName = getSlotsName(memberNode)
+            if (!slotName) continue
+
             if (slotsDefined.has(slotName)) {
               context.report({
                 node: memberNode,
@@ -111,7 +139,7 @@ module.exports = {
 
           const slotNameAttr = utils.getAttribute(node, 'name')
 
-          if (slotNameAttr) {
+          if (slotNameAttr?.value) {
             slotName = slotNameAttr.value.value
           }
 

--- a/lib/rules/require-explicit-slots.js
+++ b/lib/rules/require-explicit-slots.js
@@ -12,8 +12,8 @@ const utils = require('../utils')
  */
 
 /**
- *
  * @param {TypeElement} node
+ * @return {string | null}
  */
 function getSlotsName(node) {
   if (

--- a/lib/rules/require-explicit-slots.js
+++ b/lib/rules/require-explicit-slots.js
@@ -17,17 +17,19 @@ const utils = require('../utils')
  */
 function getSlotsName(node) {
   if (
-    node.type === 'TSMethodSignature' ||
-    node.type === 'TSPropertySignature'
+    node.type !== 'TSMethodSignature' &&
+    node.type !== 'TSPropertySignature'
   ) {
-    const key = node.key
-    if (key.type === 'Literal') {
-      return typeof key.value === 'string' ? key.value : null
-    }
+    return null
+  }
 
-    if (key.type === 'Identifier') {
-      return key.name
-    }
+  const key = node.key
+  if (key.type === 'Literal') {
+    return typeof key.value === 'string' ? key.value : null
+  }
+
+  if (key.type === 'Identifier') {
+    return key.name
   }
 
   return null

--- a/tests/lib/rules/require-explicit-slots.js
+++ b/tests/lib/rules/require-explicit-slots.js
@@ -238,6 +238,44 @@ tester.run('require-explicit-slots', rule, {
           <slot name="foo" />
         </div>
       </template>
+      <script setup lang="ts">
+      defineSlots<{
+        default: (props: { msg: string }) => any
+      }>()
+      </script>`,
+      errors: [
+        {
+          message: 'Slots must be explicitly defined.'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>
+          <slot name />
+        </div>
+      </template>
+      <script setup lang="ts">
+      defineSlots<{
+        'foo-bar'(props: { msg: string }): any
+      }>()
+      </script>`,
+      errors: [
+        {
+          message: 'Slots must be explicitly defined.'
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>
+          <slot name="foo" />
+        </div>
+      </template>
       <script lang="ts">
       import { SlotsType } from 'vue'
 

--- a/tests/lib/rules/require-explicit-slots.js
+++ b/tests/lib/rules/require-explicit-slots.js
@@ -62,7 +62,34 @@ tester.run('require-explicit-slots', rule, {
       }>()
       </script>`
     },
-
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>
+          <slot name="foo"></slot>
+        </div>
+      </template>
+      <script setup lang="ts">
+      defineSlots<{
+        foo: (props: { msg: string }) => any
+      }>()
+      </script>`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>
+          <slot name="foo-bar"></slot>
+        </div>
+      </template>
+      <script setup lang="ts">
+      defineSlots<{
+        'foo-bar'(props: { msg: string }): any
+      }>()
+      </script>`
+    },
     {
       filename: 'test.vue',
       code: `


### PR DESCRIPTION
solves https://github.com/vuejs/eslint-plugin-vue/issues/2391

1. The update now allows `node.key` to be a string, supporting both `Identifier` and `Literal` types. It also skips over dynamic slot names since `slotNameAttr` only detects nodes with `directive: false`.

2. The `memberNode` type has been narrowed down to only include `TSMethodSignature` and `TSPropertySignature`.
- `foo(): any`
- `foo: () => any`

