### PR TITLE
Remove dead link from docs

### DIFF
--- a/docs/rules/no-v-html.md
+++ b/docs/rules/no-v-html.md
@@ -38,10 +38,6 @@ Nothing.
 
 If you are certain the content passed to `v-html` is sanitized HTML you can disable this rule.
 
-## :books: Further Reading
-
-- [XSS in Vue.js](https://blog.sqreen.io/xss-in-vue-js/)
-
 ## :rocket: Version
 
 This rule was introduced in eslint-plugin-vue v4.7.0


### PR DESCRIPTION
Removed further reading section. The link doesn't provide reader more information about the subject. It just redirects to a datadog marketing page.