### PR TITLE
Update links to GitHub repos with changed main branch name

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -318,7 +318,7 @@ If you are using JSX, you need to enable JSX in your ESLint configuration.
 See also [ESLint - Specifying Parser Options](https://eslint.org/docs/user-guide/configuring#specifying-parser-options).
 
 The same configuration is required when using JSX with TypeScript (TSX) in the `.vue` file.  
-See also [here](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/parser/README.md#parseroptionsecmafeaturesjsx).  
+See also [here](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/README.md#parseroptionsecmafeaturesjsx).  
 Note that you cannot use angle-bracket type assertion style (`var x = <foo>bar;`) when using `jsx: true`.
 
 ### Trouble with Visual Studio Code

--- a/typings/eslint-plugin-vue/util-types/ast/jsx-ast.ts
+++ b/typings/eslint-plugin-vue/util-types/ast/jsx-ast.ts
@@ -1,6 +1,6 @@
 /**
- * @see https://github.com/facebook/jsx/blob/master/AST.md
- * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/typescript-estree/src/ts-estree/ts-estree.ts
+ * @see https://github.com/facebook/jsx/blob/main/AST.md
+ * @see https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/ts-estree/ts-estree.ts
  */
 import { HasParentNode } from '../node'
 import * as ES from './es-ast'

--- a/typings/eslint-plugin-vue/util-types/ast/ts-ast.ts
+++ b/typings/eslint-plugin-vue/util-types/ast/ts-ast.ts
@@ -1,5 +1,5 @@
 /**
- * @see https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/typescript-estree/src/ts-estree/ts-estree.ts
+ * @see https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/ts-estree/ts-estree.ts
  */
 import { HasParentNode } from '../node'
 import * as ES from './es-ast'


### PR DESCRIPTION
typescript-eslint repo master was renamed to main.