### PR TITLE
fix(v-for-delimiter-style): ignore Punctuator token

### DIFF
--- a/lib/rules/v-for-delimiter-style.js
+++ b/lib/rules/v-for-delimiter-style.js
@@ -42,7 +42,7 @@ module.exports = {
             node.left.length > 0
               ? node.left[node.left.length - 1]
               : tokenStore.getFirstToken(node),
-            (token) => token.type !== 'Punctuator' || token.value !== ')'
+            (token) => token.type !== 'Punctuator'
           )
         )
 

--- a/tests/lib/rules/v-for-delimiter-style.js
+++ b/tests/lib/rules/v-for-delimiter-style.js
@@ -37,6 +37,10 @@ tester.run('v-for-delimiter-style', rule, {
     },
     {
       filename: 'test.vue',
+      code: '<template><div v-for="(x,) in xs"></div></template>'
+    },
+    {
+      filename: 'test.vue',
       code: '<template><div v-for="x in xs"></div></template>',
       options: ['in']
     },

--- a/tests/lib/rules/v-for-delimiter-style.js
+++ b/tests/lib/rules/v-for-delimiter-style.js
@@ -36,8 +36,17 @@ tester.run('v-for-delimiter-style', rule, {
       code: '<template><div v-for="x    in    xs"></div></template>'
     },
     {
+      // https://github.com/vuejs/vue-eslint-parser/issues/226
       filename: 'test.vue',
       code: '<template><div v-for="(x,) in xs"></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div v-for="(value, key, index) in xs"></div></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div v-for="{ x, y } in xs"></div></template>'
     },
     {
       filename: 'test.vue',
@@ -55,6 +64,17 @@ tester.run('v-for-delimiter-style', rule, {
       filename: 'test.vue',
       code: '<template><div v-for="x of xs"></div></template>',
       output: '<template><div v-for="x in xs"></div></template>',
+      errors: [
+        {
+          message: "Expected 'in' instead of 'of' in 'v-for'.",
+          column: 23
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div v-for="(x, index) of xs"></div></template>',
+      output: '<template><div v-for="(x, index) in xs"></div></template>',
       errors: [
         {
           message: "Expected 'in' instead of 'of' in 'v-for'.",


### PR DESCRIPTION
fixes https://github.com/vuejs/vue-eslint-parser/issues/226 (`vue-eslint-parser` issue!)

Maybe we can simply ignore all 'Punctuator' type token, without the need to specifically declare `token.type !== 'Punctuator' || (token.value !== ')' && token.value !== ',')`?