### PR TITLE
feat: update default configs from `component-tags-order` to `block-order`

### DIFF
--- a/docs/rules/block-order.md
+++ b/docs/rules/block-order.md
@@ -10,6 +10,7 @@ since: v9.16.0
 
 > enforce order of component top-level elements
 
+- :gear: This rule is included in all of `"plugin:vue/vue3-recommended"`, `*.configs["flat/recommended"]`, `"plugin:vue/recommended"` and `*.configs["flat/vue2-recommended"]`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/docs/rules/component-tags-order.md
+++ b/docs/rules/component-tags-order.md
@@ -11,7 +11,6 @@ since: v6.1.0
 > enforce order of component top-level elements
 
 - :no_entry_sign: This rule was **deprecated** and replaced by [vue/block-order](block-order.md) rule.
-- :gear: This rule is included in all of `"plugin:vue/vue3-recommended"`, `*.configs["flat/recommended"]`, `"plugin:vue/recommended"` and `*.configs["flat/vue2-recommended"]`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/lib/configs/flat/vue2-recommended.js
+++ b/lib/configs/flat/vue2-recommended.js
@@ -11,7 +11,7 @@ module.exports = [
   {
     rules: {
       'vue/attributes-order': 'warn',
-      'vue/component-tags-order': 'warn',
+      'vue/block-order': 'warn',
       'vue/no-lone-template': 'warn',
       'vue/no-multiple-slot-args': 'warn',
       'vue/no-v-html': 'warn',

--- a/lib/configs/flat/vue3-recommended.js
+++ b/lib/configs/flat/vue3-recommended.js
@@ -11,7 +11,7 @@ module.exports = [
   {
     rules: {
       'vue/attributes-order': 'warn',
-      'vue/component-tags-order': 'warn',
+      'vue/block-order': 'warn',
       'vue/no-lone-template': 'warn',
       'vue/no-multiple-slot-args': 'warn',
       'vue/no-v-html': 'warn',

--- a/lib/configs/vue2-recommended.js
+++ b/lib/configs/vue2-recommended.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: require.resolve('./vue2-strongly-recommended'),
   rules: {
     'vue/attributes-order': 'warn',
-    'vue/component-tags-order': 'warn',
+    'vue/block-order': 'warn',
     'vue/no-lone-template': 'warn',
     'vue/no-multiple-slot-args': 'warn',
     'vue/no-v-html': 'warn',

--- a/lib/configs/vue3-recommended.js
+++ b/lib/configs/vue3-recommended.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: require.resolve('./vue3-strongly-recommended'),
   rules: {
     'vue/attributes-order': 'warn',
-    'vue/component-tags-order': 'warn',
+    'vue/block-order': 'warn',
     'vue/no-lone-template': 'warn',
     'vue/no-multiple-slot-args': 'warn',
     'vue/no-v-html': 'warn',


### PR DESCRIPTION
### Description

This pr updated recommend rule sets from `component-tags-order` to `block-order` as `component-tags-order` is replaced by `block-order`. 