### PR TITLE
Allow ESLint v9 as peer dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,12 +28,8 @@ jobs:
       matrix:
         node: [18, 20]
         os: [ubuntu-latest]
-        eslint: [8]
+        eslint: [8, 9]
         include:
-          # On next ESLint version
-          - eslint: ^9.0.0-0
-            node: 20
-            os: ubuntu-latest
           # On old Node version
           - eslint: 8
             node: 17

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node": "^14.17.0 || >=16.0.0"
   },
   "peerDependencies": {
-    "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0"
+    "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.4.0",

--- a/tests/lib/rules/custom-event-name-casing.js
+++ b/tests/lib/rules/custom-event-name-casing.js
@@ -578,37 +578,6 @@ tester.run('custom-event-name-casing', rule, {
     {
       filename: 'test.vue',
       code: `
-      <template>
-        <input
-          @click="$emit('fooBar')">
-      </template>
-      <script>
-      export default {
-        setup(props, context) {
-          return {
-            onInput(value) {
-              context.emit('barBaz')
-            }
-          }
-        },
-        methods: {
-          onClick() {
-            this.$emit('bazQux')
-          }
-        }
-      }
-      </script>
-      `,
-      options: ['kebab-case'],
-      errors: [
-        "Custom event name 'fooBar' must be kebab-case.",
-        "Custom event name 'barBaz' must be kebab-case.",
-        "Custom event name 'bazQux' must be kebab-case."
-      ]
-    },
-    {
-      filename: 'test.vue',
-      code: `
       <script setup>
       const emit = defineEmits({})
       emit('fooBar')


### PR DESCRIPTION
Fixes #2443.

ESLint v9 stable has been released now: https://eslint.org/blog/2024/04/eslint-v9.0.0-released/