### PR TITLE
fix(configs): remove deprecated component-tags-order rule

### DIFF
--- a/lib/configs/vue3-recommended.js
+++ b/lib/configs/vue3-recommended.js
@@ -7,7 +7,6 @@ module.exports = {
   extends: require.resolve('./vue3-strongly-recommended'),
   rules: {
     'vue/attributes-order': 'warn',
-    'vue/component-tags-order': 'warn',
     'vue/no-lone-template': 'warn',
     'vue/no-multiple-slot-args': 'warn',
     'vue/no-v-html': 'warn',


### PR DESCRIPTION
This rules is deprecated according to the documentation, so it should be removed from the config.