### PR TITLE
fix: Prevent spread operator from disabling the rule

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -3121,7 +3121,7 @@ function getWithDefaultsProps(node) {
 
   for (const prop of param.properties) {
     if (prop.type !== 'Property') {
-      return {}
+      continue
     }
     const name = getStaticPropertyName(prop)
     if (name != null) {

--- a/tests/lib/rules/require-default-prop.js
+++ b/tests/lib/rules/require-default-prop.js
@@ -329,6 +329,28 @@ ruleTester.run('require-default-prop', rule, {
         ...languageOptions,
         parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
       }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const defaultProps = {
+        foo: 'foo',
+      }
+      withDefaults(defineProps<{
+        foo: string;
+        bar?: number;
+      }>(), {
+        ...defaultProps,
+        bar: 42,
+      })
+      </script>
+      `,
+      languageOptions: {
+        parser: require('vue-eslint-parser'),
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
     }
   ],
 
@@ -542,6 +564,33 @@ ruleTester.run('require-default-prop', rule, {
       languageOptions: {
         parser: require('vue-eslint-parser'),
         ...languageOptions
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const defaultProps = {
+        foo: 'foo',
+      }
+      withDefaults(defineProps<{
+        foo: string;
+        bar?: number;
+      }>(), {
+        ...defaultProps,
+      })
+      </script>
+      `,
+      errors: [
+        {
+          message: "Prop 'bar' requires default value to be set.",
+          line: 8
+        }
+      ],
+      languageOptions: {
+        parser: require('vue-eslint-parser'),
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
       }
     },
     ...(semver.lt(


### PR DESCRIPTION
The rule `vue/require-default-prop` return an error for all optional props when using `withDefaults` and a spread operator as second argument

<img width="848" alt="image" src="https://github.com/vuejs/eslint-plugin-vue/assets/146925467/b16d3f4b-2074-481b-a276-27b7900b2733">

The rule seems to return an empty object if something different from `Property` is found. Ignoring it instead will allow the check for at least props defined in the file