### PR TITLE
docs: add an example on how to use custom parser with flat config

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -186,6 +186,8 @@ export default ts.config(
 )
 ```
 
+:::
+
 The `parserOptions.parser` option can also specify an object to specify multiple parsers. See [vue-eslint-parser README](https://github.com/vuejs/vue-eslint-parser#readme) for more details.
 
 ### How does ESLint detect components?

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -483,7 +483,7 @@ In [Nuxt 3](https://nuxt.com/) or with [`unplugin-auto-import`](https://github.c
 
 ::: code-group
 
-```json [.eslintrc] 
+```json [.eslintrc]
 {
   "globals": {
     "ref": "readonly",
@@ -495,7 +495,7 @@ In [Nuxt 3](https://nuxt.com/) or with [`unplugin-auto-import`](https://github.c
 }
 ```
 
-```js [eslint.config.js] 
+```js [eslint.config.js]
 export default [
   {
     languageOptions: {

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -150,8 +150,7 @@ Full example:
 
 ::: code-group
 
-```json [Legacy Config]
-// .eslintrc
+```json [.eslintrc]
 {
   "root": true,
   "plugins": ["@typescript-eslint"],
@@ -167,8 +166,7 @@ Full example:
 }
 ```
 
-```js [Flat Config]
-// eslint.config.js
+```js [eslint.config.js]
 import js from '@eslint/js'
 import eslintPluginVue from 'eslint-plugin-vue'
 import ts from 'typescript-eslint'
@@ -483,8 +481,7 @@ In [Nuxt 3](https://nuxt.com/) or with [`unplugin-auto-import`](https://github.c
 
 ::: code-group
 
-```json [Legacy Config]
-// .eslintrc
+```json [.eslintrc] 
 {
   "globals": {
     "ref": "readonly",
@@ -496,8 +493,7 @@ In [Nuxt 3](https://nuxt.com/) or with [`unplugin-auto-import`](https://github.c
 }
 ```
 
-```js [Flat Config]
-// eslint.config.js
+```js [eslint.config.js] 
 export default [
   {
     languageOptions: {

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -146,6 +146,48 @@ If you want to use custom parsers such as [@babel/eslint-parser](https://www.npm
   }
 ```
 
+Full example:
+
+::: code-group
+
+```json [Legacy Config]
+// .eslintrc
+{
+  "root": true,
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:vue/vue3-recommended"
+  ],
+  "parser": "vue-eslint-parser",
+  "parserOptions": {
+    "parser": "@typescript-eslint/parser"
+  }
+}
+```
+
+```js [Flat Config]
+// eslint.config.js
+import js from '@eslint/js'
+import eslintPluginVue from 'eslint-plugin-vue'
+import ts from 'typescript-eslint'
+
+export default ts.config(
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  ...eslintPluginVue.configs['flat/recommended'],
+  {
+    files: ['*.vue', '**/*.vue'],
+    languageOptions: {
+      parserOptions: {
+        parser: '@typescript-eslint/parser'
+      }
+    }
+  }
+)
+```
+
 The `parserOptions.parser` option can also specify an object to specify multiple parsers. See [vue-eslint-parser README](https://github.com/vuejs/vue-eslint-parser#readme) for more details.
 
 ### How does ESLint detect components?


### PR DESCRIPTION
Related to: https://github.com/vuejs/eslint-plugin-vue/issues/2448

📚 Description

This PR adds an example on how to use this plugin with TypeScript, which is a common use case.

📜 Notes

The getting started guide is getting a bit hard to follow with a lot of warnings, duplicated text for each configuration style. It might worth extracting the `.eslintrc` format to a different subpage like it is done in [the official eslint docs](https://eslint.org/docs/latest/use/configure/configuration-files).