### PR TITLE
docs: fix build on windows

### DIFF
--- a/docs/.vitepress/build-system/build.mts
+++ b/docs/.vitepress/build-system/build.mts
@@ -2,7 +2,7 @@
  * Pre-build cjs packages that cannot be bundled well.
  */
 import esbuild from 'esbuild'
-import path from 'path'
+import path from 'pathe'
 import fs from 'fs'
 import { fileURLToPath } from 'url'
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,6 +1,6 @@
 import type { DefaultTheme } from 'vitepress'
 import { defineConfig } from 'vitepress'
-import path from 'path'
+import path from 'pathe'
 import { fileURLToPath } from 'url'
 import { viteCommonjs, vitePluginRequireResolve } from './vite-plugin.mjs'
 

--- a/docs/.vitepress/vite-plugin.mts
+++ b/docs/.vitepress/vite-plugin.mts
@@ -1,5 +1,5 @@
 import type { UserConfig } from 'vitepress'
-import path from 'path'
+import path from 'pathe'
 import { fileURLToPath } from 'url'
 import esbuild from 'esbuild'
 type Plugin = Extract<

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -259,6 +259,7 @@ module.exports = {
     }
 
     /**
+     * @param {RuleFixer} fixer
      * @param {Property} propertyNode
      * @param {Property} unorderedPropertyNode
      */

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "markdownlint-cli": "^0.41.0",
     "mocha": "^10.3.0",
     "nyc": "^17.0.0",
+    "pathe": "^1.1.2",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3",
     "vitepress": "^1.0.0-rc.42"


### PR DESCRIPTION
Resolves #2492 

This PR uses [pathe](https://www.npmjs.com/package/pathe) instead of the built-in path module from Node.js to handle the different file separators between Windows and other operating systems.

I tested it, and works, it's only a draft because I'm not sure you want to add another dependency to the project, even if it is only a dev dependency.