### PR TITLE
Improve docs

### DIFF
--- a/docs/.vitepress/build-system/src/eslint.mjs
+++ b/docs/.vitepress/build-system/src/eslint.mjs
@@ -1,5 +1,8 @@
 // @ts-nocheck
-import * as all from '../../../../node_modules/eslint/lib/linter/linter.js'
-const Linter = all.Linter
-export { Linter }
-export default { Linter }
+/* eslint-disable unicorn/prefer-export-from -- exporting as named and default is less duplication without `export…from` */
+
+import { Linter } from '../../../../node_modules/eslint/lib/linter/linter.js'
+import SourceCode from '../../../../node_modules/eslint/lib/source-code/source-code.js'
+
+export { Linter, SourceCode }
+export default { Linter, SourceCode }

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,7 +1,3 @@
----
-outline: deep
----
-
 # User Guide
 
 ## :cd: Installation

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-eslint-plugin": "~6.1.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jsonc": "^2.13.0",
+    "eslint-plugin-jsonc": "^2.16.0",
     "eslint-plugin-node-dependencies": "^0.12.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^54.0.0",


### PR DESCRIPTION
### 1. Remove `outline: deep` frontmatter which is now unnecessary

* Follows #2481.

### 2. Bump eslint-plugin-jsonc to latest version

* I somehow missed this in #2478, that's probably causing errors like [this](https://togithub.com/vuejs/eslint-plugin-vue/pull/2481#issuecomment-2182473055).

### 3. Also expose `SourceCode` in `eslint` shim

Fixes this issue in https://eslint.vuejs.org/rules/max-lines-per-block.html:

> ![Screenshot_20240703_145453](https://github.com/vuejs/eslint-plugin-vue/assets/202916/ac93e903-00b2-41f1-8de7-1b345f44eced)

because `SourceCode` is needed in

https://github.com/vuejs/eslint-plugin-vue/blob/c64bf9448099bd7ca3512dca705c81730afec4ab/lib/rules/max-lines-per-block.js#L7