### PR TITLE
fix: change flat config name separator to `/`

### DIFF
--- a/lib/configs/flat/base.js
+++ b/lib/configs/flat/base.js
@@ -6,7 +6,7 @@
 const globals = require('globals')
 module.exports = [
   {
-    name: 'vue:base:setup',
+    name: 'vue/base/setup',
     plugins: {
       get vue() {
         return require('../../index')
@@ -18,7 +18,7 @@ module.exports = [
     }
   },
   {
-    name: 'vue:base:setup-for-vue',
+    name: 'vue/base/setup-for-vue',
     files: ['*.vue', '**/*.vue'],
     plugins: {
       get vue() {

--- a/lib/configs/flat/vue2-essential.js
+++ b/lib/configs/flat/vue2-essential.js
@@ -9,7 +9,7 @@ const config = require('./base.js')
 module.exports = [
   ...config,
   {
-    name: 'vue:vue2-essential:rules',
+    name: 'vue/vue2-essential/rules',
     rules: {
       'vue/multi-word-component-names': 'error',
       'vue/no-arrow-functions-in-watch': 'error',

--- a/lib/configs/flat/vue2-recommended.js
+++ b/lib/configs/flat/vue2-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue2-strongly-recommended.js')
 module.exports = [
   ...config,
   {
-    name: 'vue:vue2-recommended:rules',
+    name: 'vue/vue2-recommended/rules',
     rules: {
       'vue/attributes-order': 'warn',
       'vue/component-tags-order': 'warn',

--- a/lib/configs/flat/vue2-strongly-recommended.js
+++ b/lib/configs/flat/vue2-strongly-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue2-essential.js')
 module.exports = [
   ...config,
   {
-    name: 'vue:vue2-strongly-recommended:rules',
+    name: 'vue/vue2-strongly-recommended/rules',
     rules: {
       'vue/attribute-hyphenation': 'warn',
       'vue/component-definition-name-casing': 'warn',

--- a/lib/configs/flat/vue3-essential.js
+++ b/lib/configs/flat/vue3-essential.js
@@ -9,7 +9,7 @@ const config = require('./base.js')
 module.exports = [
   ...config,
   {
-    name: 'vue:essential:rules',
+    name: 'vue/essential/rules',
     rules: {
       'vue/multi-word-component-names': 'error',
       'vue/no-arrow-functions-in-watch': 'error',

--- a/lib/configs/flat/vue3-recommended.js
+++ b/lib/configs/flat/vue3-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue3-strongly-recommended.js')
 module.exports = [
   ...config,
   {
-    name: 'vue:recommended:rules',
+    name: 'vue/recommended/rules',
     rules: {
       'vue/attributes-order': 'warn',
       'vue/component-tags-order': 'warn',

--- a/lib/configs/flat/vue3-strongly-recommended.js
+++ b/lib/configs/flat/vue3-strongly-recommended.js
@@ -9,7 +9,7 @@ const config = require('./vue3-essential.js')
 module.exports = [
   ...config,
   {
-    name: 'vue:strongly-recommended:rules',
+    name: 'vue/strongly-recommended/rules',
     rules: {
       'vue/attribute-hyphenation': 'warn',
       'vue/component-definition-name-casing': 'warn',

--- a/tools/update-lib-flat-configs.js
+++ b/tools/update-lib-flat-configs.js
@@ -58,7 +58,7 @@ function formatCategory(category) {
 const globals = require('globals')
 module.exports = [
   {
-    name: 'vue:base:setup',
+    name: 'vue/base/setup',
     plugins: {
       get vue() {
         return require('../../index')
@@ -70,7 +70,7 @@ module.exports = [
     }
   },
   {
-    name: 'vue:base:setup-for-vue',
+    name: 'vue/base/setup-for-vue',
     files: ['*.vue', '**/*.vue'],
     plugins: {
       get vue() {
@@ -99,7 +99,7 @@ const config = require('./${extendsCategoryId}.js')
 module.exports = [
   ...config,
   {
-    name: 'vue:${category.categoryId.replace(/^vue3-/u, '')}:rules',
+    name: 'vue/${category.categoryId.replace(/^vue3-/u, '')}/rules',
     rules: ${formatRules(category.rules, category.categoryId)},
   }
 ]


### PR DESCRIPTION
This PR changes the all flat configs' name separator from `:` to `/`.

As ESLint recommended use `/` as the separator.

Refs:

- [Configuration Naming Conventions](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions)