### PR TITLE
Update rule `define-macros-order` for custom macros

### DIFF
--- a/docs/rules/define-macros-order.md
+++ b/docs/rules/define-macros-order.md
@@ -8,14 +8,14 @@ since: v8.7.0
 
 # vue/define-macros-order
 
-> enforce order of `defineEmits` and `defineProps` compiler macros
+> Enforce order of compiler macros (`defineProps`, `defineEmits`, etc.)
 
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 - :bulb: Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 ## :book: Rule Details
 
-This rule reports the `defineProps` and `defineEmits` compiler macros when they are not the first statements in `<script setup>` (after any potential import statements or type definitions) or when they are not in the correct order.
+This rule reports compiler macros (like `defineProps` or `defineEmits` but also custom ones) when they are not the first statements in `<script setup>` (after any potential import statements or type definitions) or when they are not in the correct order.
 
 ## :wrench: Options
 
@@ -28,7 +28,7 @@ This rule reports the `defineProps` and `defineEmits` compiler macros when they 
 }
 ```
 
-- `order` (`string[]`) ... The order of defineEmits and defineProps macros. You can also add `"defineOptions"`, `"defineSlots"`, and `"defineModel"`.
+- `order` (`string[]`) ... The order in which the macros should appear. The default is `["defineProps", "defineEmits"]`.
 - `defineExposeLast` (`boolean`) ... Force `defineExpose` at the end.
 
 ### `{ "order": ["defineProps", "defineEmits"] }` (default)
@@ -113,6 +113,39 @@ const model = defineModel()
 defineProps(/* ... */)
 defineEmits(/* ... */)
 const slots = defineSlots()
+</script>
+```
+
+</eslint-code-block>
+
+### `{ "order": ["definePage", "defineModel", "defineCustom", "defineEmits", "defineSlots"] }`
+
+<eslint-code-block fix :rules="{'vue/define-macros-order': ['error', {order: ['definePage', 'defineModel', 'defineCustom', 'defineEmits', 'defineSlots']}]}">
+
+```vue
+<!-- ✓ GOOD -->
+<script setup>
+definePage()
+const model = defineModel()
+defineCustom()
+defineEmits(/* ... */)
+const slots = defineSlots()
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block fix :rules="{'vue/define-macros-order': ['error', {order: ['definePage', 'defineModel', 'defineCustom', 'defineEmits', 'defineSlots']}]}">
+
+```vue
+<!-- ✗ BAD -->
+<script setup>
+defineEmits(/* ... */)
+const slots = defineSlots()
+defineProps(/* ... */)
+defineCustom({/* ... */})
+const model = defineModel()
+definePage()
 </script>
 ```
 

--- a/docs/rules/define-macros-order.md
+++ b/docs/rules/define-macros-order.md
@@ -2,13 +2,13 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/define-macros-order
-description: enforce order of `defineEmits` and `defineProps` compiler macros
+description: enforce order of compiler macros (`defineProps`, `defineEmits`, etc.)
 since: v8.7.0
 ---
 
 # vue/define-macros-order
 
-> Enforce order of compiler macros (`defineProps`, `defineEmits`, etc.)
+> enforce order of compiler macros (`defineProps`, `defineEmits`, etc.)
 
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 - :bulb: Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -213,7 +213,7 @@ For example:
 | [vue/component-options-name-casing](./component-options-name-casing.md) | enforce the casing of component name in `components` options | :wrench::bulb: | :hammer: |
 | [vue/custom-event-name-casing](./custom-event-name-casing.md) | enforce specific casing for custom event name |  | :hammer: |
 | [vue/define-emits-declaration](./define-emits-declaration.md) | enforce declaration style of `defineEmits` |  | :hammer: |
-| [vue/define-macros-order](./define-macros-order.md) | enforce order of `defineEmits` and `defineProps` compiler macros | :wrench::bulb: | :lipstick: |
+| [vue/define-macros-order](./define-macros-order.md) | enforce order of compiler macros (`defineProps`, `defineEmits`, etc.) | :wrench::bulb: | :lipstick: |
 | [vue/define-props-declaration](./define-props-declaration.md) | enforce declaration style of `defineProps` |  | :hammer: |
 | [vue/enforce-style-attribute](./enforce-style-attribute.md) | enforce or forbid the use of the `scoped` and `module` attributes in SFC top level style tags |  | :hammer: |
 | [vue/html-button-has-type](./html-button-has-type.md) | disallow usage of button without an explicit type attribute |  | :hammer: |

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -140,7 +140,10 @@ function create(context) {
         defineExposeNode = getDefineMacrosStatement(node)
       },
 
-      'CallExpression:exit'(node) {
+      /** @param {CallExpression} node */
+      'Program > ExpressionStatement > CallExpression, Program > VariableDeclaration > VariableDeclarator > CallExpression'(
+        node
+      ) {
         if (
           node.callee &&
           node.callee.type === 'Identifier' &&

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -113,7 +113,7 @@ function create(context) {
 
   if (order.includes(MACROS_EXPOSE) && defineExposeLast) {
     throw new Error(
-      'defineExposeLast cannot be used if defineExpose macro is in order array.'
+      "`defineExpose` macro can't be in the `order` array if `defineExposeLast` is true."
     )
   }
 

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -11,12 +11,14 @@ const MACROS_PROPS = 'defineProps'
 const MACROS_OPTIONS = 'defineOptions'
 const MACROS_SLOTS = 'defineSlots'
 const MACROS_MODEL = 'defineModel'
-const ORDER_SCHEMA = new Set([
+const MACROS_EXPOSE = 'defineExpose'
+const KNOWN_MACROS = new Set([
   MACROS_EMITS,
   MACROS_PROPS,
   MACROS_OPTIONS,
   MACROS_SLOTS,
-  MACROS_MODEL
+  MACROS_MODEL,
+  MACROS_EXPOSE
 ])
 const DEFAULT_ORDER = [MACROS_PROPS, MACROS_EMITS]
 
@@ -133,12 +135,11 @@ function create(context) {
       },
 
       'CallExpression:exit'(node) {
-        // check if the node is a macro in the order
         if (
           node.callee &&
           node.callee.type === 'Identifier' &&
           order.includes(node.callee.name) &&
-          !ORDER_SCHEMA.has(node.callee.name)
+          !KNOWN_MACROS.has(node.callee.name)
         ) {
           macrosNodes.set(node.callee.name, [getDefineMacrosStatement(node)])
         }
@@ -344,8 +345,7 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description:
-        'enforce order of `defineEmits` and `defineProps` compiler macros',
+      description: 'enforce order of specified compiler macros.',
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/define-macros-order.html'
     },
@@ -358,8 +358,8 @@ module.exports = {
           order: {
             type: 'array',
             items: {
-               type: string,
-               minLength: 1
+              type: 'string',
+              minLength: 1
             },
             uniqueItems: true,
             additionalItems: false

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -11,13 +11,13 @@ const MACROS_PROPS = 'defineProps'
 const MACROS_OPTIONS = 'defineOptions'
 const MACROS_SLOTS = 'defineSlots'
 const MACROS_MODEL = 'defineModel'
-const ORDER_SCHEMA = [
+const ORDER_SCHEMA = new Set([
   MACROS_EMITS,
   MACROS_PROPS,
   MACROS_OPTIONS,
   MACROS_SLOTS,
   MACROS_MODEL
-]
+])
 const DEFAULT_ORDER = [MACROS_PROPS, MACROS_EMITS]
 
 /**
@@ -130,6 +130,18 @@ function create(context) {
       },
       onDefineExposeExit(node) {
         defineExposeNode = getDefineMacrosStatement(node)
+      },
+
+      'CallExpression:exit'(node) {
+        // check if the node is a macro in the order
+        if (
+          node.callee &&
+          node.callee.type === 'Identifier' &&
+          order.includes(node.callee.name) &&
+          !ORDER_SCHEMA.has(node.callee.name)
+        ) {
+          macrosNodes.set(node.callee.name, [getDefineMacrosStatement(node)])
+        }
       }
     }),
     {
@@ -345,9 +357,9 @@ module.exports = {
         properties: {
           order: {
             type: 'array',
-            items: {
-              enum: ORDER_SCHEMA
-            },
+            // items: {
+            //   enum: ORDER_SCHEMA
+            // },
             uniqueItems: true,
             additionalItems: false
           },

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -345,7 +345,8 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {
-      description: 'enforce order of specified compiler macros.',
+      description:
+        'enforce order of compiler macros (`defineProps`, `defineEmits`, etc.)',
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/define-macros-order.html'
     },

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -111,6 +111,12 @@ function create(context) {
   /** @type {ASTNode} */
   let defineExposeNode
 
+  if (order.includes(MACROS_EXPOSE) && defineExposeLast) {
+    throw new Error(
+      'defineExposeLast cannot be used if defineExpose macro is in order array.'
+    )
+  }
+
   return utils.compositingVisitors(
     utils.defineScriptSetupVisitor(context, {
       onDefinePropsExit(node) {

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -357,9 +357,10 @@ module.exports = {
         properties: {
           order: {
             type: 'array',
-            // items: {
-            //   enum: ORDER_SCHEMA
-            // },
+            items: {
+               type: string,
+               minLength: 1
+            },
             uniqueItems: true,
             additionalItems: false
           },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "npm run test:base -- --watch --growl",
     "test:base": "mocha \"tests/lib/**/*.js\" --reporter dot",
     "test": "nyc npm run test:base -- \"tests/integrations/*.js\" --timeout 60000",
+    "test:define-macros-order": "mocha \"tests/lib/rules/define-macros-order.js\" --timeout 60000",
     "test:integrations": "mocha \"tests/integrations/*.js\" --timeout 60000",
     "debug": "mocha --inspect \"tests/lib/**/*.js\" --reporter dot --timeout 60000",
     "cover": "npm run cover:test && npm run cover:report",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "npm run test:base -- --watch --growl",
     "test:base": "mocha \"tests/lib/**/*.js\" --reporter dot",
     "test": "nyc npm run test:base -- \"tests/integrations/*.js\" --timeout 60000",
-    "test:define-macros-order": "mocha \"tests/lib/rules/define-macros-order.js\" --timeout 60000",
     "test:integrations": "mocha \"tests/integrations/*.js\" --timeout 60000",
     "debug": "mocha --inspect \"tests/lib/**/*.js\" --reporter dot --timeout 60000",
     "cover": "npm run cover:test && npm run cover:report",

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -200,6 +200,25 @@ tester.run('define-macros-order', rule, {
       code: `
         <script setup>
           import Foo from 'foo'
+          /** Page */
+          definePage()
+          /** model */
+          const model = defineModel()
+          /** emits */
+          defineEmits(['update:foo'])
+        </script>
+      `,
+      options: [
+        {
+          order: ['definePage', 'defineModel', 'defineEmits']
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          import Foo from 'foo'
           /** props */
           defineProps(['foo'])
           /** options */
@@ -252,6 +271,22 @@ tester.run('define-macros-order', rule, {
       options: [
         {
           order: ['defineModel', 'defineSlots']
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+        const page = definePage()
+
+        const first = defineModel('first')
+          const second = defineModel('second')
+        </script>
+      `,
+      options: [
+        {
+          order: ['definePage', 'defineModel']
         }
       ]
     }
@@ -385,6 +420,40 @@ tester.run('define-macros-order', rule, {
     {
       filename: 'test.vue',
       code: `
+        <script setup>
+          console.log('test1')
+          const props = defineProps({
+            test: Boolean
+          })
+          console.log('test2')
+          const page = definePage({
+            name: 'hello'
+          })
+        </script>
+      `,
+      output: `
+        <script setup>
+          const page = definePage({
+            name: 'hello'
+          })
+          const props = defineProps({
+            test: Boolean
+          })
+          console.log('test1')
+          console.log('test2')
+        </script>
+      `,
+      options: [{ order: ['definePage', 'defineProps'] }],
+      errors: [
+        {
+          message: message('definePage'),
+          line: 8
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
         <script lang="ts" setup>
           interface Props {
             msg?: string
@@ -422,6 +491,61 @@ tester.run('define-macros-order', rule, {
         {
           message: message('defineEmits'),
           line: 12
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script lang="ts" setup>
+          interface Props {
+            msg?: string
+            labels?: string[]
+          }
+
+          const props = defineProps<{
+            msg?: string
+            labels?: string[]
+          }>()
+          defineCustom()
+          const emit = defineEmits<{(e: 'update:test'): void}>()
+
+          const page = definePage({
+            name: 'hello'
+          })
+        </script>
+      `,
+      output: `
+        <script lang="ts" setup>
+          interface Props {
+            msg?: string
+            labels?: string[]
+          }
+
+          const page = definePage({
+            name: 'hello'
+          })
+          defineCustom()
+          const props = defineProps<{
+            msg?: string
+            labels?: string[]
+          }>()
+          const emit = defineEmits<{(e: 'update:test'): void}>()
+
+        </script>
+      `,
+      options: [
+        { order: ['definePage', 'defineCustom', 'defineProps', 'defineEmits'] }
+      ],
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: message('definePage'),
+          line: 15
         }
       ]
     },
@@ -540,6 +664,25 @@ tester.run('define-macros-order', rule, {
     {
       filename: 'test.vue',
       code: `
+        <script setup>
+          const props = defineProps({ test: Boolean });definePage({name: 'hello'})
+        </script>
+      `,
+      output: `
+        <script setup>
+          definePage({name: 'hello'});const props = defineProps({ test: Boolean });        </script>
+      `,
+      options: [{ order: ['definePage', 'defineProps'] }],
+      errors: [
+        {
+          message: message('definePage'),
+          line: 3
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
         <script>
           import 'test2'
           export default { inheritAttrs: false };
@@ -629,6 +772,30 @@ tester.run('define-macros-order', rule, {
       errors: [
         {
           message: message('defineProps'),
+          line: 5
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          definePage({name: 'hello'})
+          console.log('test1')
+          defineCustom({ test: Boolean })
+        </script>
+      `,
+      output: `
+        <script setup>
+          defineCustom({ test: Boolean })
+          definePage({name: 'hello'})
+          console.log('test1')
+        </script>
+      `,
+      options: [{ order: ['defineCustom', 'definePage'] }],
+      errors: [
+        {
+          message: message('defineCustom'),
           line: 5
         }
       ]
@@ -891,6 +1058,44 @@ tester.run('define-macros-order', rule, {
       errors: [
         {
           message: message('defineModel'),
+          line: 5
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          defineOptions({})
+          defineCustom('second')
+          const something = defineSomething('first')
+          definePage()
+          const model = defineModel('second')
+        </script>
+      `,
+      output: `
+        <script setup>
+          const something = defineSomething('first')
+          defineCustom('second')
+          const model = defineModel('second')
+          defineOptions({})
+          definePage()
+        </script>
+      `,
+      options: [
+        {
+          order: [
+            'defineSomething',
+            'defineCustom',
+            'defineModel',
+            'defineOptions',
+            'definePage'
+          ]
+        }
+      ],
+      errors: [
+        {
+          message: message('defineSomething'),
           line: 5
         }
       ]

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -219,6 +219,46 @@ tester.run('define-macros-order', rule, {
       code: `
         <script setup>
           import Foo from 'foo'
+          /** model */
+          const model = defineModel()
+          /** emits */
+          defineEmits(['update:foo'])
+
+          function fn() {
+            definePage()
+          }
+        </script>
+      `,
+      options: [
+        {
+          order: ['definePage', 'defineModel', 'defineEmits']
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          import Foo from 'foo'
+          /** model */
+          const model = defineModel()
+          /** emits */
+          defineEmits(['update:foo'])
+
+          const val = () => definePage()
+        </script>
+      `,
+      options: [
+        {
+          order: ['definePage', 'defineModel', 'defineEmits']
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          import Foo from 'foo'
           /** props */
           defineProps(['foo'])
           /** options */
@@ -788,6 +828,30 @@ tester.run('define-macros-order', rule, {
       output: `
         <script setup>
           defineCustom({ test: Boolean })
+          definePage({name: 'hello'})
+          console.log('test1')
+        </script>
+      `,
+      options: [{ order: ['defineCustom', 'definePage'] }],
+      errors: [
+        {
+          message: message('defineCustom'),
+          line: 5
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup>
+          definePage({name: 'hello'})
+          console.log('test1')
+          const custom = defineCustom({ test: Boolean })
+        </script>
+      `,
+      output: `
+        <script setup>
+          const custom = defineCustom({ test: Boolean })
           definePage({name: 'hello'})
           console.log('test1')
         </script>

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -281,7 +281,7 @@ tester.run('define-macros-order', rule, {
         const page = definePage()
 
         const first = defineModel('first')
-          const second = defineModel('second')
+        const second = defineModel('second')
         </script>
       `,
       options: [


### PR DESCRIPTION
**⚠️ Newbie alert ⚠️**
_This is my very first contribution to this project so I hope I did the things well; but don't hesitate to tell me what is not right._ 😄

This PR adds the ability to use the [define macro order rule](https://eslint.vuejs.org/rules/define-macros-order.html#defineexposelast-true) for any macro specified in the `order` array. This allows users to specify `definePage` for example or any macro wanted.

Basically, I added a `CallExpression` that checks whether the Identifier is included into the `order` array but **not** in the `ORDER_SCHEMA` as this is already checked with earlier events (`onDefineExposeExit` etc.)
I removed the `enum` from the `properties` of the rule as it's no longer limited to `ORDER_SCHEMA`. And finally, I've added new tests.

I also have some questions:
- If `defineExpose` is declared inside the `order`, I guess it should be ignored? Otherwise it would conflict with `defineExposeLast` I guess.
- Maybe the check could be more performant if there was no check against `ORDER_SCHEMA` in the condition? (removing the callbacks and the call to `has()`).

See #2499