### PR TITLE
fix(no-deprecated-slot-attribute): no fix for dynamic components

### DIFF
--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -56,10 +56,8 @@ module.exports = {
         // parse error or empty expression
         return false
       }
-      const slotName = sourceCode.getText(slotAttr.value.expression).trim()
-      // If non-Latin characters are included it can not be converted.
-      // It does not check the space only because `a>b?c:d` should be rejected.
-      return !/[^a-z]/i.test(slotName)
+
+      return slotAttr.value.expression.type === 'Identifier'
     }
 
     /**
@@ -102,7 +100,18 @@ module.exports = {
           yield fixer.remove(scopeAttr)
         }
 
-        yield fixer.insertTextBefore(element, `<template ${replaceText}>\n`)
+        const vFor = startTag.attributes.find(
+          (attr) => attr.directive && attr.key.name.name === 'for'
+        )
+        const vForText = vFor ? `${sourceCode.getText(vFor)} ` : ''
+        if (vFor) {
+          yield fixer.remove(vFor)
+        }
+
+        yield fixer.insertTextBefore(
+          element,
+          `<template ${vForText}${replaceText}>\n`
+        )
         yield fixer.insertTextAfter(element, `\n</template>`)
       }
     }

--- a/lib/rules/syntaxes/utils/can-convert-to-v-slot.js
+++ b/lib/rules/syntaxes/utils/can-convert-to-v-slot.js
@@ -28,7 +28,8 @@ module.exports = function canConvertToVSlot(element, sourceCode, tokenStore) {
   const ownerElement = element.parent
   if (
     ownerElement.type === 'VDocumentFragment' ||
-    !utils.isCustomComponent(ownerElement)
+    !utils.isCustomComponent(ownerElement) ||
+    ownerElement.name === 'component'
   ) {
     return false
   }

--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -668,6 +668,19 @@ tester.run('no-deprecated-slot-attribute', rule, {
         </my-component>
       </template>`,
       errors: ['`slot` attributes are deprecated.']
+    },
+    {
+      code: `
+      <template>
+        <component :is="toggle ? 'my-component' : 'div'">
+          <div slot="named">
+            Passing in a named slot to a div worked with old syntax
+            But not with new syntax
+          </div>
+        </component>
+      </template>`,
+      output: null,
+      errors: ['`slot` attributes are deprecated.']
     }
   ]
 })

--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -643,6 +643,31 @@ tester.run('no-deprecated-slot-attribute', rule, {
         }
       ],
       errors: ['`slot` attributes are deprecated.']
+    },
+    {
+      code: `
+      <template>
+        <my-component>
+          <slot
+            v-for="slot in Object.keys($slots)"
+            :slot="slot"
+            :name="slot"
+          ></slot>
+        </my-component>
+      </template>`,
+      output: `
+      <template>
+        <my-component>
+          <template v-for="slot in Object.keys($slots)" v-slot:[slot]>
+<slot
+            
+            
+            :name="slot"
+          ></slot>
+</template>
+        </my-component>
+      </template>`,
+      errors: ['`slot` attributes are deprecated.']
     }
   ]
 })


### PR DESCRIPTION
> Warning: I made this PR on top of https://github.com/vuejs/eslint-plugin-vue/pull/2529 but I needed to open a PR against the `master` branch for it to show up in this repo

The `#slot` syntax doesn't work when passed into a native HTML `<div>` element for obvious reasons.

However, the old `slot="name"` syntax works... [Demo](https://vue2-sfc-playground.vercel.app/#eNqVUDsOwjAMvYplBhZoJMaqILgDY5YCAQI0sWoXBtS747QVVAxIbO8Xv9hP3BBl98ZhjgXva08C7KShlQ2F6QWFSsRVdCvFKQMoDv7eAYX7WFEMLgjknpcWp+pNLQ52nwW+RVGv5MNxZAFsz57hEesrv+NmNHvA/zRNUsd3w6525e+KDyrMaFWcodfSWuZVSdmFY9BDPVPcDgZbzKFTkqaXTNziWYQ4N6YJdD1l+nOj1nqhHSwJZo4rnWcxvWxtaLF9AdGye9Q=)

This can happen (and has happened in my work project) when a dynamic component renders a `div` to fallback when certain conditions aren't met:
