### PR TITLE
Improve error range for `vue/max-props`

### DIFF
--- a/lib/rules/max-props.js
+++ b/lib/rules/max-props.js
@@ -43,7 +43,7 @@ module.exports = {
     function checkMaxNumberOfProps(props) {
       if (props.length > option.maxProps && props[0].node) {
         context.report({
-          node: props[0].node,
+          node: props[0].node.parent,
           messageId: 'tooManyProps',
           data: {
             propCount: props.length,

--- a/tests/lib/rules/max-props.js
+++ b/tests/lib/rules/max-props.js
@@ -113,7 +113,8 @@ tester.run('max-props', rule, {
       errors: [
         {
           message: 'Component has too many props (2). Maximum allowed is 1.',
-          line: 3
+          line: 3,
+          endLine: 3
         }
       ]
     },
@@ -133,7 +134,8 @@ tester.run('max-props', rule, {
       errors: [
         {
           message: 'Component has too many props (2). Maximum allowed is 1.',
-          line: 5
+          line: 4,
+          endLine: 7
         }
       ]
     },
@@ -154,7 +156,8 @@ tester.run('max-props', rule, {
       errors: [
         {
           message: 'Component has too many props (3). Maximum allowed is 2.',
-          line: 3
+          line: 3,
+          endLine: 3
         }
       ]
     }


### PR DESCRIPTION
While trying out the new unreleased props rule, I noticed that the rule only highlights the very first prop if violated, instead of the entire props block. I think this is slightly confusing. 

Therefore I changed it to report the parent node and therefore the entire props block.