### PR TITLE
fix(attribute-hyphenation): skip auto-fix when suffixed with `.sync`

### DIFF
--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -104,8 +104,8 @@ module.exports = {
           if (/^[A-Z]/.test(name)) {
             return null
           }
-          
-          if(text.endsWith('.sync')) {
+
+          if (text.endsWith('.sync')) {
             return null
           }
 

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -104,6 +104,10 @@ module.exports = {
           if (/^[A-Z]/.test(name)) {
             return null
           }
+          
+          if(text.endsWith('.sync')) {
+            return null
+          }
 
           return fixer.replaceText(
             node.key,

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -101,11 +101,11 @@ module.exports = {
             return null
           }
 
-          if (/^[A-Z]/.test(name)) {
+          if (text.endsWith('.sync')) {
             return null
           }
 
-          if (text.endsWith('.sync')) {
+          if (/^[A-Z]/.test(name)) {
             return null
           }
 

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -70,6 +70,16 @@ ruleTester.run('attribute-hyphenation', rule, {
       filename: 'test.vue',
       code: '<template><div><custom :attr_ff="prop"></custom></div></template>',
       options: ['never']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><custom :my-name.sync="prop"></custom></div></template>',
+      options: ['always']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><custom :myName.sync="prop"></custom></div></template>',
+      options: ['never']
     }
   ],
 
@@ -363,6 +373,32 @@ ruleTester.run('attribute-hyphenation', rule, {
       errors: [
         {
           message: "Attribute ':my-custom_prop' can't be hyphenated.",
+          type: 'VDirectiveKey',
+          line: 1
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><custom :myAge.sync="prop"></custom></div></template>',
+      output: null,
+      options: ['always'],
+      errors: [
+        {
+          message: "Attribute ':myAge.sync' must be hyphenated.",
+          type: 'VDirectiveKey',
+          line: 1
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div><custom :my-age.sync="prop"></custom></div></template>',
+      output: null,
+      options: ['never'],
+      errors: [
+        {
+          message: "Attribute ':my-age.sync' can't be hyphenated.",
           type: 'VDirectiveKey',
           line: 1
         }


### PR DESCRIPTION
Close https://github.com/vuejs/eslint-plugin-vue/issues/2521

I'll just submit a pr first, so if there are any changes that need to be made please just point them out ❤️