### PR TITLE
fix(utils): also recognize .tsx files as Vue files

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2681,7 +2681,7 @@ function markVariableAsUsed(context, name, node) {
  * @param {string} path
  */
 function isVueFile(path) {
-  return path.endsWith('.vue') || path.endsWith('.jsx')
+  return path.endsWith('.vue') || path.endsWith('.jsx') || path.endsWith('.tsx')
 }
 
 /**

--- a/tests/lib/utils/vue-component.js
+++ b/tests/lib/utils/vue-component.js
@@ -339,6 +339,7 @@ ruleTester.run('vue-component', rule, {
     },
     ...validTests('js'),
     ...validTests('jsx'),
+    ...validTests('tsx'),
     ...validTests('vue')
   ],
   invalid: [
@@ -356,6 +357,7 @@ ruleTester.run('vue-component', rule, {
     },
     ...invalidTests('js'),
     ...invalidTests('jsx'),
+    ...invalidTests('tsx'),
     ...invalidTests('vue')
   ]
 })


### PR DESCRIPTION
I was testing `eslint-config-vue` integration with TypeScript projects.
I was surprised to find out that the rule `vue/multi-word-component-names` does not error on `.tsx` files, such as `Foo.tsx`, while it correctly showed errors for `Foo.jsx` and `Foo.vue`.

Digging into the rule source code I found that it's because `isVueFile('Foo.tsx')` always returns false:
https://github.com/vuejs/eslint-plugin-vue/blob/2dc606ca589ff5cdcd197c3c64ace7e575a6347d/lib/rules/multi-word-component-names.js#L120