### PR TITLE
Fix Linter type import in index.d.ts

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,5 @@
+import type { Linter } from 'eslint'
+
 declare const vue: {
   meta: any
   configs: {
@@ -19,19 +21,19 @@ declare const vue: {
   }
   rules: Record<string, any>
   processors: {
-    ".vue": any
+    '.vue': any
     vue: any
   }
   environments: {
     /**
      * @deprecated
      */
-    "setup-compiler-macros": {
+    'setup-compiler-macros': {
       globals: {
-        defineProps: "readonly"
-        defineEmits: "readonly"
-        defineExpose: "readonly"
-        withDefaults: "readonly"
+        defineProps: 'readonly'
+        defineEmits: 'readonly'
+        defineExpose: 'readonly'
+        withDefaults: 'readonly'
       }
     }
   }


### PR DESCRIPTION
Thanks for adding TypeScript declarations in the latest v9.29.0.

I found an issue when using the new declaration. In the `lib/index.d.ts`, the `Linter` namespace is pointing to `typings/eslint/index.d.ts`. However, `typings/` is not included in the [final NPM package](https://unpkg.com/browse/eslint-plugin-vue@9.29.0/), therefore the declarations in `index.d.ts` is not working.

This issue can be fixed by adding a single line `import type { Linter } from 'eslint'` as shown in this PR. 

Other code-styling changes included in this PR are made by Prettier based on `eslint-plugin-vue`'s Prettier config.

---

Just FYI, the latest eslint has already includes TypeScript declarations, which means you don't need `@types/eslint` and perhaps also `typings/eslint/index.d.ts` anymore once `eslint-plugin-vue` updated to the latest version of eslint (currently `eslint-plugin-vue` is still using eslint@8).

