### PR TITLE
fix(types): importing Linter namespace from eslint

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,5 @@
+import type {Linter} from 'eslint'
+
 declare const vue: {
   meta: any
   configs: {


### PR DESCRIPTION
The types for `Linter.LegacyConfig` and `Linter.FlatConfig[]` weren't being imported or defined by the declaration file, so they were being interpretted as `any` and `any[]` respectively by consumers.

Fixes: #2574