### PR TITLE
fix(require-explicit-slots): ignore attribute binding

### DIFF
--- a/lib/rules/require-explicit-slots.js
+++ b/lib/rules/require-explicit-slots.js
@@ -149,7 +149,7 @@ module.exports = {
           )
 
           /** @type {string | undefined} */
-          let slotName = ''
+          let slotName
           if (!nameNode) {
             // If no slot name is declared, default to 'default'
             slotName = 'default'

--- a/lib/rules/require-explicit-slots.js
+++ b/lib/rules/require-explicit-slots.js
@@ -137,13 +137,27 @@ module.exports = {
         }
       }),
       utils.defineTemplateBodyVisitor(context, {
+        /** @param {VElement} node */
         "VElement[name='slot']"(node) {
-          let slotName = 'default'
+          const nameNode = node.startTag.attributes.find(
+            (node) =>
+              (!node.directive && node.key.name === 'name') ||
+              (node.directive &&
+                node.key.name.name === 'bind' &&
+                node.key.argument?.type === 'VIdentifier' &&
+                node.key.argument?.name === 'name')
+          )
 
-          const slotNameAttr = utils.getAttribute(node, 'name')
-
-          if (slotNameAttr?.value) {
-            slotName = slotNameAttr.value.value
+          /** @type {string | undefined} */
+          let slotName = ''
+          if (!nameNode) {
+            // If no slot name is declared, default to 'default'
+            slotName = 'default'
+          } else if (nameNode.directive) {
+            // ignore attribute binding
+            return
+          } else {
+            slotName = nameNode.value?.value
           }
 
           if (!slotsDefined.has(slotName)) {

--- a/tests/lib/rules/require-explicit-slots.js
+++ b/tests/lib/rules/require-explicit-slots.js
@@ -160,6 +160,19 @@ tester.run('require-explicit-slots', rule, {
           parser: null
         }
       }
+    },
+    // ignore attribute binding
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>
+          <slot :name="'foo'"></slot>
+        </div>
+      </template>
+      <script setup lang="ts">
+      defineSlots<{}>()
+      </script>`
     }
   ],
   invalid: [

--- a/tests/lib/rules/require-explicit-slots.js
+++ b/tests/lib/rules/require-explicit-slots.js
@@ -171,7 +171,9 @@ tester.run('require-explicit-slots', rule, {
         </div>
       </template>
       <script setup lang="ts">
-      defineSlots<{}>()
+      defineSlots<{
+        default(props: { msg: string }): any
+      }>()
       </script>`
     }
   ],


### PR DESCRIPTION
fixes #2589.

Previously: When `node.directive` was true, `slotName` was incorrectly set to 'default', and it would check if it was explicitly defined.
Now: If `node.directive` is true, the report is simply skipped.