### PR TITLE
refactor: store the defineEmits variable name

### DIFF
--- a/lib/rules/no-unused-emit-declarations.js
+++ b/lib/rules/no-unused-emit-declarations.js
@@ -56,18 +56,6 @@ function hasReferenceId(value, setupContext) {
   )
 }
 
-/**
- * Check if the given name matches emitReferenceIds variable name
- * @param {string} name
- * @param {Set<Identifier>} emitReferenceIds
- * @returns {boolean}
- */
-function isEmitVariableName(name, emitReferenceIds) {
-  if (emitReferenceIds.size === 0) return false
-  const emitVariable = emitReferenceIds.values().next().value.name
-  return emitVariable === name
-}
-
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -91,6 +79,7 @@ module.exports = {
     /** @type {Map<ObjectExpression | Program, SetupContext>} */
     const setupContexts = new Map()
     const programNode = context.getSourceCode().ast
+    let emitParamName = ''
 
     /**
      * @param {CallExpression} node
@@ -204,14 +193,6 @@ module.exports = {
 
           const { contextReferenceIds, emitReferenceIds } = setupContext
 
-          // verify defineEmits variable in template
-          if (
-            callee.type === 'Identifier' &&
-            isEmitVariableName(callee.name, emitReferenceIds)
-          ) {
-            addEmitCall(node)
-          }
-
           // verify setup(props,{emit}) {emit()}
           addEmitCallByReference(callee, emitReferenceIds, node)
           if (emit && emit.name === 'emit') {
@@ -229,8 +210,11 @@ module.exports = {
           }
         }
 
-        // verify $emit() in template
-        if (callee.type === 'Identifier' && callee.name === '$emit') {
+        // verify $emit() and defineEmits variable in template
+        if (
+          callee.type === 'Identifier' &&
+          (callee.name === '$emit' || callee.name === emitParamName)
+        ) {
           addEmitCall(node)
         }
       }
@@ -316,10 +300,15 @@ module.exports = {
           }
 
           const emitParam = node.parent.id
-          const variable =
-            emitParam.type === 'Identifier'
-              ? findVariable(utils.getScope(context, emitParam), emitParam)
-              : null
+          if (emitParam.type !== 'Identifier') {
+            return
+          }
+
+          emitParamName = emitParam.name
+          const variable = findVariable(
+            utils.getScope(context, emitParam),
+            emitParam
+          )
           if (!variable) {
             return
           }

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -71,22 +71,6 @@ function getNameParamNode(node) {
   return null
 }
 
-/**
- * Check if the given name matches defineEmitsNode variable name
- * @param {string} name
- * @param {CallExpression | undefined} defineEmitsNode
- * @returns {boolean}
- */
-function isEmitVariableName(name, defineEmitsNode) {
-  const node = defineEmitsNode?.parent
-
-  if (node?.type === 'VariableDeclarator' && node.id.type === 'Identifier') {
-    return name === node.id.name
-  }
-
-  return false
-}
-
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -128,6 +112,7 @@ module.exports = {
     const vueEmitsDeclarations = new Map()
     /** @type {Map<ObjectExpression | Program, ComponentProp[]>} */
     const vuePropsDeclarations = new Map()
+    let emitParamName = ''
 
     /**
      * @typedef {object} VueTemplateDefineData
@@ -271,11 +256,7 @@ module.exports = {
           // e.g. $emit() / emit() in template
           if (
             callee.type === 'Identifier' &&
-            (callee.name === '$emit' ||
-              isEmitVariableName(
-                callee.name,
-                vueTemplateDefineData.defineEmits
-              ))
+            (callee.name === '$emit' || callee.name === emitParamName)
           ) {
             verifyEmit(
               vueTemplateDefineData.emits,
@@ -308,10 +289,15 @@ module.exports = {
             }
 
             const emitParam = node.parent.id
-            const variable =
-              emitParam.type === 'Identifier'
-                ? findVariable(utils.getScope(context, emitParam), emitParam)
-                : null
+            if (emitParam.type !== 'Identifier') {
+              return
+            }
+
+            emitParamName = emitParam.name
+            const variable = findVariable(
+              utils.getScope(context, emitParam),
+              emitParam
+            )
             if (!variable) {
               return
             }


### PR DESCRIPTION
related to #2585

Refactored to store the `defineEmits` variable name for checking `defineEmits` variable name usage in the template.