### PR TITLE
fix(define-macros-order): skip TSModuleDeclaration statements

### DIFF
--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -53,6 +53,7 @@ function isUseStrictStatement(node) {
 function getTargetStatementPosition(scriptSetup, program) {
   const skipStatements = new Set([
     'ImportDeclaration',
+    'TSModuleDeclaration',
     'TSInterfaceDeclaration',
     'TSTypeAliasDeclaration',
     'DebuggerStatement',

--- a/tests/lib/rules/define-macros-order.js
+++ b/tests/lib/rules/define-macros-order.js
@@ -126,6 +126,8 @@ tester.run('define-macros-order', rule, {
       code: `
         <script setup lang="ts">
           import { bar } from 'foo'
+          declare global {}
+          declare namespace Namespace {}
           export interface Props {
             msg?: string
             labels?: string[]


### PR DESCRIPTION
fix #2590