### PR TITLE
feat(no-reserved-component-names): add case sensitive option

### DIFF
--- a/docs/rules/no-reserved-component-names.md
+++ b/docs/rules/no-reserved-component-names.md
@@ -35,13 +35,15 @@ export default {
 {
   "vue/no-reserved-component-names": ["error", {
     "disallowVueBuiltInComponents": false,
-    "disallowVue3BuiltInComponents": false
+    "disallowVue3BuiltInComponents": false,
+    "caseSensitive": false,
   }]
 }
 ```
 
 - `disallowVueBuiltInComponents` (`boolean`) ... If `true`, disallow Vue.js 2.x built-in component names. Default is `false`.
 - `disallowVue3BuiltInComponents` (`boolean`) ... If `true`, disallow Vue.js 3.x built-in component names. Default is `false`.
+- `htmlElementCaseSensitive` (`boolean`) ... If `true`, become case-sensitive when comparing component names with HTML reserved elements. Default is `false`. This means that a component name must exactly match the case of an HTML element to be considered conflicting.
 
 ### `"disallowVueBuiltInComponents": true`
 
@@ -67,6 +69,34 @@ export default {
 /* ✗ BAD */
 export default {
   name: 'teleport'
+}
+</script>
+```
+
+</eslint-code-block>
+
+### `"htmlElementCaseSensitive": true`
+
+<eslint-code-block :rules="{'vue/no-reserved-component-names': ['error', {htmlElementCaseSensitive: true}]}">
+
+```vue
+<script>
+/* ✗ GOOD */
+export default {
+  name: 'Button'
+}
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-reserved-component-names': ['error', {htmlElementCaseSensitive: true}]}">
+
+```vue
+<script>
+/* ✗ BAD */
+export default {
+  name: 'button'
 }
 </script>
 ```

--- a/docs/rules/no-reserved-component-names.md
+++ b/docs/rules/no-reserved-component-names.md
@@ -81,7 +81,7 @@ export default {
 
 ```vue
 <script>
-/* ✗ GOOD */
+/* ✓ GOOD */
 export default {
   name: 'Button'
 }

--- a/docs/rules/no-reserved-component-names.md
+++ b/docs/rules/no-reserved-component-names.md
@@ -36,7 +36,7 @@ export default {
   "vue/no-reserved-component-names": ["error", {
     "disallowVueBuiltInComponents": false,
     "disallowVue3BuiltInComponents": false,
-    "caseSensitive": false,
+    "htmlElementCaseSensitive": false,
   }]
 }
 ```

--- a/docs/rules/no-reserved-component-names.md
+++ b/docs/rules/no-reserved-component-names.md
@@ -43,7 +43,7 @@ export default {
 
 - `disallowVueBuiltInComponents` (`boolean`) ... If `true`, disallow Vue.js 2.x built-in component names. Default is `false`.
 - `disallowVue3BuiltInComponents` (`boolean`) ... If `true`, disallow Vue.js 3.x built-in component names. Default is `false`.
-- `htmlElementCaseSensitive` (`boolean`) ... If `true`, become case-sensitive when comparing component names with HTML reserved elements. Default is `false`. This means that a component name must exactly match the case of an HTML element to be considered conflicting.
+- `htmlElementCaseSensitive` (`boolean`) ... If `true`, component names must exactly match the case of an HTML element to be considered conflicting. Default is `false` (i.e. case-insensitve comparison).
 
 ### `"disallowVueBuiltInComponents": true`
 

--- a/lib/rules/no-reserved-component-names.js
+++ b/lib/rules/no-reserved-component-names.js
@@ -34,19 +34,6 @@ function isLowercase(word) {
   return /^[a-z]*$/.test(word)
 }
 
-const RESERVED_NAMES_IN_HTML = new Set([
-  ...htmlElements,
-  ...htmlElements.map(casing.capitalize)
-])
-const RESERVED_NAMES_IN_OTHERS = new Set([
-  ...deprecatedHtmlElements,
-  ...deprecatedHtmlElements.map(casing.capitalize),
-  ...kebabCaseElements,
-  ...kebabCaseElements.map(casing.pascalCase),
-  ...svgElements,
-  ...svgElements.filter(isLowercase).map(casing.capitalize)
-])
-
 /**
  * @param {Expression | SpreadElement} node
  * @returns {node is (Literal | TemplateLiteral)}
@@ -114,6 +101,13 @@ module.exports = {
       options.disallowVue3BuiltInComponents === true
     const htmlElementCaseSensitive = options.htmlElementCaseSensitive === true
 
+    const RESERVED_NAMES_IN_HTML = new Set(htmlElements)
+    const RESERVED_NAMES_IN_OTHERS = new Set([
+      ...deprecatedHtmlElements,
+      ...kebabCaseElements,
+      ...svgElements
+    ])
+
     if (!htmlElementCaseSensitive) {
       addAll(RESERVED_NAMES_IN_HTML, htmlElements.map(casing.capitalize))
       addAll(RESERVED_NAMES_IN_OTHERS, [
@@ -131,6 +125,17 @@ module.exports = {
     ])
 
     /**
+     * @param {string} name
+     * @returns {string}
+     */
+    function getMessageId(name) {
+      if (RESERVED_NAMES_IN_HTML.has(name)) return 'reservedInHtml'
+      if (RESERVED_NAMES_IN_VUE.has(name)) return 'reservedInVue'
+      if (RESERVED_NAMES_IN_VUE3.has(name)) return 'reservedInVue3'
+      return 'reserved'
+    }
+
+    /**
      * @param {Literal | TemplateLiteral} node
      */
     function reportIfInvalid(node) {
@@ -144,17 +149,6 @@ module.exports = {
       if (reservedNames.has(name)) {
         report(node, name)
       }
-    }
-
-    /**
-     * @param {string} name
-     * @returns {string}
-     */
-    function getMessageId(name) {
-      if (RESERVED_NAMES_IN_HTML.has(name)) return 'reservedInHtml'
-      if (RESERVED_NAMES_IN_VUE.has(name)) return 'reservedInVue'
-      if (RESERVED_NAMES_IN_VUE3.has(name)) return 'reservedInVue3'
-      return 'reserved'
     }
 
     /**

--- a/lib/rules/no-reserved-component-names.js
+++ b/lib/rules/no-reserved-component-names.js
@@ -34,6 +34,19 @@ function isLowercase(word) {
   return /^[a-z]*$/.test(word)
 }
 
+const RESERVED_NAMES_IN_HTML = new Set([
+  ...htmlElements,
+  ...htmlElements.map(casing.capitalize)
+])
+const RESERVED_NAMES_IN_OTHERS = new Set([
+  ...deprecatedHtmlElements,
+  ...deprecatedHtmlElements.map(casing.capitalize),
+  ...kebabCaseElements,
+  ...kebabCaseElements.map(casing.pascalCase),
+  ...svgElements,
+  ...svgElements.filter(isLowercase).map(casing.capitalize)
+])
+
 /**
  * @param {Expression | SpreadElement} node
  * @returns {node is (Literal | TemplateLiteral)}
@@ -45,6 +58,17 @@ function canVerify(node) {
       node.expressions.length === 0 &&
       node.quasis.length === 1)
   )
+}
+
+/**
+ * @template T
+ * @param {Set<T>} set
+ * @param {Iterable<T>} iterable
+ */
+function addAll(set, iterable) {
+  for (const element of iterable) {
+    set.add(element)
+  }
 }
 
 module.exports = {
@@ -90,24 +114,14 @@ module.exports = {
       options.disallowVue3BuiltInComponents === true
     const htmlElementCaseSensitive = options.htmlElementCaseSensitive === true
 
-    const RESERVED_NAMES_IN_HTML = new Set([
-      ...htmlElements,
-      ...(htmlElementCaseSensitive ? [] : htmlElements.map(casing.capitalize))
-    ])
-    const RESERVED_NAMES_IN_OTHERS = new Set([
-      ...deprecatedHtmlElements,
-      ...(htmlElementCaseSensitive
-        ? []
-        : deprecatedHtmlElements.map(casing.capitalize)),
-      ...kebabCaseElements,
-      ...(htmlElementCaseSensitive
-        ? []
-        : kebabCaseElements.map(casing.pascalCase)),
-      ...svgElements,
-      ...(htmlElementCaseSensitive
-        ? []
-        : svgElements.filter(isLowercase).map(casing.capitalize))
-    ])
+    if (!htmlElementCaseSensitive) {
+      addAll(RESERVED_NAMES_IN_HTML, htmlElements.map(casing.capitalize))
+      addAll(RESERVED_NAMES_IN_OTHERS, [
+        ...deprecatedHtmlElements.map(casing.capitalize),
+        ...kebabCaseElements.map(casing.pascalCase),
+        ...svgElements.filter(isLowercase).map(casing.capitalize)
+      ])
+    }
 
     const reservedNames = new Set([
       ...RESERVED_NAMES_IN_HTML,

--- a/lib/rules/no-reserved-component-names.js
+++ b/lib/rules/no-reserved-component-names.js
@@ -34,19 +34,6 @@ function isLowercase(word) {
   return /^[a-z]*$/.test(word)
 }
 
-const RESERVED_NAMES_IN_HTML = new Set([
-  ...htmlElements,
-  ...htmlElements.map(casing.capitalize)
-])
-const RESERVED_NAMES_IN_OTHERS = new Set([
-  ...deprecatedHtmlElements,
-  ...deprecatedHtmlElements.map(casing.capitalize),
-  ...kebabCaseElements,
-  ...kebabCaseElements.map(casing.pascalCase),
-  ...svgElements,
-  ...svgElements.filter(isLowercase).map(casing.capitalize)
-])
-
 /**
  * @param {Expression | SpreadElement} node
  * @returns {node is (Literal | TemplateLiteral)}
@@ -58,17 +45,6 @@ function canVerify(node) {
       node.expressions.length === 0 &&
       node.quasis.length === 1)
   )
-}
-
-/**
- * @param {string} name
- * @returns {string}
- */
-function getMessageId(name) {
-  if (RESERVED_NAMES_IN_HTML.has(name)) return 'reservedInHtml'
-  if (RESERVED_NAMES_IN_VUE.has(name)) return 'reservedInVue'
-  if (RESERVED_NAMES_IN_VUE3.has(name)) return 'reservedInVue3'
-  return 'reserved'
 }
 
 module.exports = {
@@ -90,6 +66,9 @@ module.exports = {
           },
           disallowVue3BuiltInComponents: {
             type: 'boolean'
+          },
+          htmlElementCaseSensitive: {
+            type: 'boolean'
           }
         },
         additionalProperties: false
@@ -109,6 +88,26 @@ module.exports = {
       options.disallowVueBuiltInComponents === true
     const disallowVue3BuiltInComponents =
       options.disallowVue3BuiltInComponents === true
+    const htmlElementCaseSensitive = options.htmlElementCaseSensitive === true
+
+    const RESERVED_NAMES_IN_HTML = new Set([
+      ...htmlElements,
+      ...(htmlElementCaseSensitive ? [] : htmlElements.map(casing.capitalize))
+    ])
+    const RESERVED_NAMES_IN_OTHERS = new Set([
+      ...deprecatedHtmlElements,
+      ...(htmlElementCaseSensitive
+        ? []
+        : deprecatedHtmlElements.map(casing.capitalize)),
+      ...kebabCaseElements,
+      ...(htmlElementCaseSensitive
+        ? []
+        : kebabCaseElements.map(casing.pascalCase)),
+      ...svgElements,
+      ...(htmlElementCaseSensitive
+        ? []
+        : svgElements.filter(isLowercase).map(casing.capitalize))
+    ])
 
     const reservedNames = new Set([
       ...RESERVED_NAMES_IN_HTML,
@@ -131,6 +130,17 @@ module.exports = {
       if (reservedNames.has(name)) {
         report(node, name)
       }
+    }
+
+    /**
+     * @param {string} name
+     * @returns {string}
+     */
+    function getMessageId(name) {
+      if (RESERVED_NAMES_IN_HTML.has(name)) return 'reservedInHtml'
+      if (RESERVED_NAMES_IN_VUE.has(name)) return 'reservedInVue'
+      if (RESERVED_NAMES_IN_VUE3.has(name)) return 'reservedInVue3'
+      return 'reserved'
     }
 
     /**

--- a/tests/lib/rules/no-reserved-component-names.js
+++ b/tests/lib/rules/no-reserved-component-names.js
@@ -410,12 +410,16 @@ const invalidElements = [
   'xmp',
   'Xmp'
 ]
-const invalidLowerCaseElements = invalidElements.filter(
-  (element) => element === element.toLowerCase()
-)
-const invalidUpperCaseElements = invalidElements.filter(
-  (element) => element === element.toUpperCase()
-)
+const invalidLowerCaseElements = []
+const invalidUpperCaseElements = []
+
+for (const element of invalidElements) {
+  if (element[0] === element[0].toLowerCase()) {
+    invalidLowerCaseElements.push(element)
+  } else {
+    invalidUpperCaseElements.push(element)
+  }
+}
 
 const vue2BuiltInComponents = [
   'component',

--- a/tests/lib/rules/no-reserved-component-names.js
+++ b/tests/lib/rules/no-reserved-component-names.js
@@ -410,6 +410,12 @@ const invalidElements = [
   'xmp',
   'Xmp'
 ]
+const invalidLowerCaseElements = invalidElements.filter(
+  (element) => element === element.toLowerCase()
+)
+const invalidUpperCaseElements = invalidElements.filter(
+  (element) => element === element.toUpperCase()
+)
 
 const vue2BuiltInComponents = [
   'component',
@@ -559,6 +565,16 @@ ruleTester.run('no-reserved-component-names', rule, {
       languageOptions,
       options: [{ disallowVueBuiltInComponents: true }]
     })),
+    ...invalidUpperCaseElements.map((name) => ({
+      filename: `${name}.vue`,
+      code: `
+          export default {
+            name: '${name}'
+          }
+        `,
+      languageOptions,
+      options: [{ htmlElementCaseSensitive: true }]
+    })),
     {
       filename: 'test.vue',
       code: `<script setup> defineOptions({}) </script>`,
@@ -691,6 +707,24 @@ ruleTester.run('no-reserved-component-names', rule, {
         parser: require('vue-eslint-parser'),
         ...languageOptions
       },
+      errors: [
+        {
+          messageId: RESERVED_NAMES_IN_HTML.has(name)
+            ? 'reservedInHtml'
+            : 'reserved',
+          data: { name },
+          line: 1
+        }
+      ]
+    })),
+    ...invalidLowerCaseElements.map((name) => ({
+      filename: `${name}.vue`,
+      code: `<script setup> defineOptions({name: '${name}'}) </script>`,
+      languageOptions: {
+        parser: require('vue-eslint-parser'),
+        ...languageOptions
+      },
+      options: [{ htmlElementCaseSensitive: true }],
       errors: [
         {
           messageId: RESERVED_NAMES_IN_HTML.has(name)


### PR DESCRIPTION
resolve #2556

Add an option to control case-sensitive matching for HTML element names to be considered conflicting. For instance, `Button` would be allowed, but `button` would still be disallowed.