### PR TITLE
feat(no-empty-component-block): support auto fix

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -232,7 +232,7 @@ For example:
 | [vue/no-deprecated-delete-set](./no-deprecated-delete-set.md) | disallow using deprecated `$delete` and `$set` (in Vue.js 3.0.0+) |  | :warning: |
 | [vue/no-deprecated-model-definition](./no-deprecated-model-definition.md) | disallow deprecated `model` definition (in Vue.js 3.0.0+) | :bulb: | :warning: |
 | [vue/no-duplicate-attr-inheritance](./no-duplicate-attr-inheritance.md) | enforce `inheritAttrs` to be set to `false` when using `v-bind="$attrs"` |  | :hammer: |
-| [vue/no-empty-component-block](./no-empty-component-block.md) | disallow the `<template>` `<script>` `<style>` block to be empty |  | :hammer: |
+| [vue/no-empty-component-block](./no-empty-component-block.md) | disallow the `<template>` `<script>` `<style>` block to be empty | :wrench: | :hammer: |
 | [vue/no-multiple-objects-in-class](./no-multiple-objects-in-class.md) | disallow to pass multiple objects into array to class |  | :hammer: |
 | [vue/no-potential-component-option-typo](./no-potential-component-option-typo.md) | disallow a potential typo in your component property | :bulb: | :hammer: |
 | [vue/no-ref-object-reactivity-loss](./no-ref-object-reactivity-loss.md) | disallow usages of ref objects that can lead to loss of reactivity |  | :warning: |

--- a/docs/rules/no-empty-component-block.md
+++ b/docs/rules/no-empty-component-block.md
@@ -10,6 +10,8 @@ since: v7.0.0
 
 > disallow the `<template>` `<script>` `<style>` block to be empty
 
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
 ## :book: Rule Details
 
 This rule disallows the `<template>` `<script>` `<style>` block to be empty.
@@ -17,7 +19,7 @@ This rule disallows the `<template>` `<script>` `<style>` block to be empty.
 This rule also checks block what has attribute `src`.
 See [Vue Single-File Component (SFC) Spec](https://vue-loader.vuejs.org/spec.html#src-imports).
 
-<eslint-code-block :rules="{'vue/no-empty-component-block': ['error']}">
+<eslint-code-block fix :rules="{'vue/no-empty-component-block': ['error']}">
 
 ```vue
 <!-- ✓ GOOD -->

--- a/docs/rules/no-empty-component-block.md
+++ b/docs/rules/no-empty-component-block.md
@@ -19,7 +19,7 @@ This rule disallows the `<template>` `<script>` `<style>` block to be empty.
 This rule also checks block what has attribute `src`.
 See [Vue Single-File Component (SFC) Spec](https://vue-loader.vuejs.org/spec.html#src-imports).
 
-<eslint-code-block fix :rules="{'vue/no-empty-component-block': ['error']}">
+<eslint-code-block fix :rules="{'vue/no-empty-component-block': ['error', { autofix: true }]}">
 
 ```vue
 <!-- ✓ GOOD -->
@@ -64,7 +64,15 @@ p {
 
 ## :wrench: Options
 
-Nothing.
+```json
+{
+  "vue/no-duplicate-attributes": ["error", {
+    "autofix": false,
+  }]
+}
+```
+
+- `"autofix"` ... If `true`, enable autofix. (Default: `false`)
 
 ## :rocket: Version
 

--- a/docs/rules/no-empty-component-block.md
+++ b/docs/rules/no-empty-component-block.md
@@ -66,7 +66,7 @@ p {
 
 ```json
 {
-  "vue/no-duplicate-attributes": ["error", {
+  "vue/no-empty-component-block": ["error", {
     "autofix": false,
   }]
 }

--- a/docs/rules/no-empty-component-block.md
+++ b/docs/rules/no-empty-component-block.md
@@ -19,7 +19,7 @@ This rule disallows the `<template>` `<script>` `<style>` block to be empty.
 This rule also checks block what has attribute `src`.
 See [Vue Single-File Component (SFC) Spec](https://vue-loader.vuejs.org/spec.html#src-imports).
 
-<eslint-code-block fix :rules="{'vue/no-empty-component-block': ['error', { autofix: true }]}">
+<eslint-code-block fix :rules="{'vue/no-empty-component-block': ['error']}">
 
 ```vue
 <!-- ✓ GOOD -->
@@ -64,15 +64,7 @@ p {
 
 ## :wrench: Options
 
-```json
-{
-  "vue/no-empty-component-block": ["error", {
-    "autofix": false,
-  }]
-}
-```
-
-- `"autofix"` ... If `true`, enable autofix. (Default: `false`)
+Nothing.
 
 ## :rocket: Version
 

--- a/lib/rules/no-empty-component-block.js
+++ b/lib/rules/no-empty-component-block.js
@@ -70,9 +70,6 @@ module.exports = {
 
     return {
       Program() {
-        /** @type {VElement[]} */
-        const emptyBlocks = []
-
         for (const componentBlock of componentBlocks) {
           if (
             componentBlock.name !== 'template' &&
@@ -88,24 +85,18 @@ module.exports = {
             isValueOnlyWhiteSpacesOrLineBreaks(componentBlock) ||
             componentBlock.children.length === 0
           ) {
-            emptyBlocks.push(componentBlock)
+            context.report({
+              node: componentBlock,
+              loc: componentBlock.loc,
+              messageId: 'unexpected',
+              data: {
+                blockName: componentBlock.name
+              },
+              fix(fixer) {
+                return fixer.remove(componentBlock)
+              }
+            })
           }
-        }
-
-        if (emptyBlocks.length === 0) return
-
-        for (const componentBlock of emptyBlocks) {
-          context.report({
-            node: componentBlock,
-            loc: componentBlock.loc,
-            messageId: 'unexpected',
-            data: {
-              blockName: componentBlock.name
-            },
-            fix(fixer) {
-              return fixer.remove(componentBlock)
-            }
-          })
         }
       }
     }

--- a/lib/rules/no-empty-component-block.js
+++ b/lib/rules/no-empty-component-block.js
@@ -105,32 +105,22 @@ module.exports = {
 
         if (emptyBlocks.length === 0) return
 
-        if (autofix) {
-          const firstEmptyBlock = emptyBlocks[0]
+        for (const componentBlock of emptyBlocks) {
           context.report({
-            node: firstEmptyBlock,
-            loc: firstEmptyBlock.loc,
+            node: componentBlock,
+            loc: componentBlock.loc,
             messageId: 'unexpected',
             data: {
-              blockName: firstEmptyBlock.name
+              blockName: componentBlock.name
             },
-            *fix(fixer) {
-              for (const componentBlock of emptyBlocks) {
-                yield fixer.remove(componentBlock)
-              }
-            }
+            fix: autofix
+              ? function* (fixer) {
+                  for (const componentBlock of emptyBlocks) {
+                    yield fixer.remove(componentBlock)
+                  }
+                }
+              : undefined
           })
-        } else {
-          for (const componentBlock of emptyBlocks) {
-            context.report({
-              node: componentBlock,
-              loc: componentBlock.loc,
-              messageId: 'unexpected',
-              data: {
-                blockName: componentBlock.name
-              }
-            })
-          }
         }
       }
     }

--- a/lib/rules/no-empty-component-block.js
+++ b/lib/rules/no-empty-component-block.js
@@ -46,15 +46,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-empty-component-block.html'
     },
     fixable: 'code',
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          autofix: { type: 'boolean' }
-        },
-        additionalProperties: false
-      }
-    ],
+    schema: [],
     messages: {
       unexpected: '`<{{ blockName }}>` is empty. Empty block is not allowed.'
     }
@@ -73,9 +65,6 @@ module.exports = {
     if (!documentFragment) {
       return {}
     }
-
-    const options = context.options[0]
-    const autofix = options?.autofix === true
 
     const componentBlocks = documentFragment.children.filter(isVElement)
 
@@ -113,7 +102,9 @@ module.exports = {
             data: {
               blockName: componentBlock.name
             },
-            fix: autofix ? (fixer) => fixer.remove(componentBlock) : undefined
+            fix(fixer) {
+              return fixer.remove(componentBlock)
+            }
           })
         }
       }

--- a/lib/rules/no-empty-component-block.js
+++ b/lib/rules/no-empty-component-block.js
@@ -45,8 +45,16 @@ module.exports = {
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-empty-component-block.html'
     },
-    fixable: null,
-    schema: [],
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          autofix: { type: 'boolean' }
+        },
+        additionalProperties: false
+      }
+    ],
     messages: {
       unexpected: '`<{{ blockName }}>` is empty. Empty block is not allowed.'
     }
@@ -66,10 +74,16 @@ module.exports = {
       return {}
     }
 
+    const options = context.options[0]
+    const autofix = options?.autofix === true
+
     const componentBlocks = documentFragment.children.filter(isVElement)
 
     return {
       Program() {
+        /** @type {VElement[]} */
+        const emptyBlocks = []
+
         for (const componentBlock of componentBlocks) {
           if (
             componentBlock.name !== 'template' &&
@@ -85,6 +99,29 @@ module.exports = {
             isValueOnlyWhiteSpacesOrLineBreaks(componentBlock) ||
             componentBlock.children.length === 0
           ) {
+            emptyBlocks.push(componentBlock)
+          }
+        }
+
+        if (emptyBlocks.length === 0) return
+
+        if (autofix) {
+          const firstEmptyBlock = emptyBlocks[0]
+          context.report({
+            node: firstEmptyBlock,
+            loc: firstEmptyBlock.loc,
+            messageId: 'unexpected',
+            data: {
+              blockName: firstEmptyBlock.name
+            },
+            *fix(fixer) {
+              for (const componentBlock of emptyBlocks) {
+                yield fixer.remove(componentBlock)
+              }
+            }
+          })
+        } else {
+          for (const componentBlock of emptyBlocks) {
             context.report({
               node: componentBlock,
               loc: componentBlock.loc,

--- a/lib/rules/no-empty-component-block.js
+++ b/lib/rules/no-empty-component-block.js
@@ -113,13 +113,7 @@ module.exports = {
             data: {
               blockName: componentBlock.name
             },
-            fix: autofix
-              ? function* (fixer) {
-                  for (const componentBlock of emptyBlocks) {
-                    yield fixer.remove(componentBlock)
-                  }
-                }
-              : undefined
+            fix: autofix ? (fixer) => fixer.remove(componentBlock) : undefined
           })
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vue",
-  "version": "9.29.1",
+  "version": "9.30.0",
   "description": "Official ESLint plugin for Vue.js",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/tests/lib/rules/no-empty-component-block.js
+++ b/tests/lib/rules/no-empty-component-block.js
@@ -169,8 +169,8 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template></template> <script></script> <style></style>',
-      output: '  ',
+      code: '<template></template><script></script><style></style>',
+      output: '',
       options: [{ autofix: true }],
       errors: [
         {
@@ -185,8 +185,8 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template /> <script /> <style />',
-      output: '  ',
+      code: '<template /><script /><style />',
+      output: '',
       options: [{ autofix: true }],
       errors: [
         {
@@ -201,8 +201,8 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template src="" /> <script src="" /> <style src="" />',
-      output: '  ',
+      code: '<template src="" /><script src="" /><style src="" />',
+      output: '',
       options: [{ autofix: true }],
       errors: [
         {
@@ -217,8 +217,8 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template><p></p></template> <script src="" /> <style src="" />',
-      output: '<template><p></p></template>  ',
+      code: '<template><p></p></template><script src="" /><style src="" />',
+      output: '<template><p></p></template>',
       options: [{ autofix: true }],
       errors: [
         {

--- a/tests/lib/rules/no-empty-component-block.js
+++ b/tests/lib/rules/no-empty-component-block.js
@@ -22,11 +22,17 @@ tester.run('no-empty-component-block', rule, {
     `<template src="./template.html" /><script src="./script.js" />`,
     `<template src="./template.html"></template><script src="./script.js"></script><style src="./style.css"></style>`,
     `<template src="./template.html" /><script src="./script.js" /><style src="./style.css" />`,
-    `var a = 1`
+    `var a = 1`,
+    // options
+    {
+      code: '<template><p>foo</p></template>',
+      options: [{ autofix: true }]
+    }
   ],
   invalid: [
     {
       code: `<template></template>`,
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -35,6 +41,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: `<template> </template>`,
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -44,6 +51,7 @@ tester.run('no-empty-component-block', rule, {
     {
       code: `<template>
 </template>`,
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -52,6 +60,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template />',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -60,6 +69,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template src="" />',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -68,6 +78,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template></template><script></script>',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -79,6 +90,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template /><script />',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -90,6 +102,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template src="" /><script src="" />',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -101,6 +114,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template></template><script></script><style></style>',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -115,6 +129,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template /><script /><style />',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -129,6 +144,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template src="" /><script src="" /><style src="" />',
+      output: null,
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -138,6 +154,47 @@ tester.run('no-empty-component-block', rule, {
         },
         {
           message: '`<style>` is empty. Empty block is not allowed.'
+        }
+      ]
+    },
+    // autofix
+    {
+      code: `<template></template>`,
+      output: '',
+      options: [{ autofix: true }],
+      errors: [
+        {
+          message: '`<template>` is empty. Empty block is not allowed.'
+        }
+      ]
+    },
+    {
+      code: '<template></template><script></script><style></style>',
+      output: '',
+      options: [{ autofix: true }],
+      errors: [
+        {
+          message: '`<template>` is empty. Empty block is not allowed.'
+        }
+      ]
+    },
+    {
+      code: '<template /><script /><style />',
+      output: '',
+      options: [{ autofix: true }],
+      errors: [
+        {
+          message: '`<template>` is empty. Empty block is not allowed.'
+        }
+      ]
+    },
+    {
+      code: '<template src="" /><script src="" /><style src="" />',
+      output: '',
+      options: [{ autofix: true }],
+      errors: [
+        {
+          message: '`<template>` is empty. Empty block is not allowed.'
         }
       ]
     }

--- a/tests/lib/rules/no-empty-component-block.js
+++ b/tests/lib/rules/no-empty-component-block.js
@@ -170,7 +170,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template></template><script></script><style></style>',
-      output: '',
+      output: '<script></script>',
       options: [{ autofix: true }],
       errors: [
         {
@@ -185,8 +185,8 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template /><script /><style />',
-      output: '',
+      code: '<template></template> <script></script> <style></style>',
+      output: '  ',
       options: [{ autofix: true }],
       errors: [
         {
@@ -201,8 +201,8 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template src="" /><script src="" /><style src="" />',
-      output: '',
+      code: '<template /> <script /> <style />',
+      output: '  ',
       options: [{ autofix: true }],
       errors: [
         {
@@ -217,8 +217,24 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template><p></p></template><script src="" /><style src="" />',
-      output: '<template><p></p></template>',
+      code: '<template src="" /> <script src="" /> <style src="" />',
+      output: '  ',
+      options: [{ autofix: true }],
+      errors: [
+        {
+          message: '`<template>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<script>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<style>` is empty. Empty block is not allowed.'
+        }
+      ]
+    },
+    {
+      code: '<template><p></p></template> <script src="" /> <style src="" />',
+      output: '<template><p></p></template>  ',
       options: [{ autofix: true }],
       errors: [
         {

--- a/tests/lib/rules/no-empty-component-block.js
+++ b/tests/lib/rules/no-empty-component-block.js
@@ -169,42 +169,63 @@ tester.run('no-empty-component-block', rule, {
       ]
     },
     {
-      code: '<template></template><script></script><style></style>',
-      output: '',
+      code: '<template></template> <script></script> <style></style>',
+      output: '  ',
       options: [{ autofix: true }],
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<script>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<style>` is empty. Empty block is not allowed.'
         }
       ]
     },
     {
-      code: '<template /><script /><style />',
-      output: '',
+      code: '<template /> <script /> <style />',
+      output: '  ',
       options: [{ autofix: true }],
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<script>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<style>` is empty. Empty block is not allowed.'
         }
       ]
     },
     {
-      code: '<template src="" /><script src="" /><style src="" />',
-      output: '',
+      code: '<template src="" /> <script src="" /> <style src="" />',
+      output: '  ',
       options: [{ autofix: true }],
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<script>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<style>` is empty. Empty block is not allowed.'
         }
       ]
     },
     {
-      code: '<template><p></p></template><script src="" /><style src="" />',
-      output: '<template><p></p></template>',
+      code: '<template><p></p></template> <script src="" /> <style src="" />',
+      output: '<template><p></p></template>  ',
       options: [{ autofix: true }],
       errors: [
         {
           message: '`<script>` is empty. Empty block is not allowed.'
+        },
+        {
+          message: '`<style>` is empty. Empty block is not allowed.'
         }
       ]
     }

--- a/tests/lib/rules/no-empty-component-block.js
+++ b/tests/lib/rules/no-empty-component-block.js
@@ -197,6 +197,16 @@ tester.run('no-empty-component-block', rule, {
           message: '`<template>` is empty. Empty block is not allowed.'
         }
       ]
+    },
+    {
+      code: '<template><p></p></template><script src="" /><style src="" />',
+      output: '<template><p></p></template>',
+      options: [{ autofix: true }],
+      errors: [
+        {
+          message: '`<script>` is empty. Empty block is not allowed.'
+        }
+      ]
     }
   ]
 })

--- a/tests/lib/rules/no-empty-component-block.js
+++ b/tests/lib/rules/no-empty-component-block.js
@@ -22,17 +22,12 @@ tester.run('no-empty-component-block', rule, {
     `<template src="./template.html" /><script src="./script.js" />`,
     `<template src="./template.html"></template><script src="./script.js"></script><style src="./style.css"></style>`,
     `<template src="./template.html" /><script src="./script.js" /><style src="./style.css" />`,
-    `var a = 1`,
-    // options
-    {
-      code: '<template><p>foo</p></template>',
-      options: [{ autofix: true }]
-    }
+    `var a = 1`
   ],
   invalid: [
     {
       code: `<template></template>`,
-      output: null,
+      output: '',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -41,7 +36,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: `<template> </template>`,
-      output: null,
+      output: '',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -51,7 +46,7 @@ tester.run('no-empty-component-block', rule, {
     {
       code: `<template>
 </template>`,
-      output: null,
+      output: '',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -60,7 +55,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template />',
-      output: null,
+      output: '',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -69,7 +64,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template src="" />',
-      output: null,
+      output: '',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -78,7 +73,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template></template><script></script>',
-      output: null,
+      output: '<script></script>',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -90,7 +85,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template /><script />',
-      output: null,
+      output: '<script />',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -102,7 +97,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template src="" /><script src="" />',
-      output: null,
+      output: '<script src="" />',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -114,7 +109,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template></template><script></script><style></style>',
-      output: null,
+      output: '<script></script>',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -129,7 +124,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template /><script /><style />',
-      output: null,
+      output: '<script />',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -144,7 +139,7 @@ tester.run('no-empty-component-block', rule, {
     },
     {
       code: '<template src="" /><script src="" /><style src="" />',
-      output: null,
+      output: '<script src="" />',
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -157,37 +152,10 @@ tester.run('no-empty-component-block', rule, {
         }
       ]
     },
-    // autofix
-    {
-      code: `<template></template>`,
-      output: '',
-      options: [{ autofix: true }],
-      errors: [
-        {
-          message: '`<template>` is empty. Empty block is not allowed.'
-        }
-      ]
-    },
-    {
-      code: '<template></template><script></script><style></style>',
-      output: '<script></script>',
-      options: [{ autofix: true }],
-      errors: [
-        {
-          message: '`<template>` is empty. Empty block is not allowed.'
-        },
-        {
-          message: '`<script>` is empty. Empty block is not allowed.'
-        },
-        {
-          message: '`<style>` is empty. Empty block is not allowed.'
-        }
-      ]
-    },
+    // auto fix with whitespace
     {
       code: '<template></template> <script></script> <style></style>',
       output: '  ',
-      options: [{ autofix: true }],
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -203,7 +171,6 @@ tester.run('no-empty-component-block', rule, {
     {
       code: '<template /> <script /> <style />',
       output: '  ',
-      options: [{ autofix: true }],
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -219,7 +186,6 @@ tester.run('no-empty-component-block', rule, {
     {
       code: '<template src="" /> <script src="" /> <style src="" />',
       output: '  ',
-      options: [{ autofix: true }],
       errors: [
         {
           message: '`<template>` is empty. Empty block is not allowed.'
@@ -235,7 +201,6 @@ tester.run('no-empty-component-block', rule, {
     {
       code: '<template><p></p></template> <script src="" /> <style src="" />',
       output: '<template><p></p></template>  ',
-      options: [{ autofix: true }],
       errors: [
         {
           message: '`<script>` is empty. Empty block is not allowed.'


### PR DESCRIPTION
resolve #2564

~~Chose this approach is because I couldn't find a better way to handle reporting & fixing each `emptyBlock` within a for loop,  as removing the first block will affect the range of the second block😵‍💫.~~

UPDATE: support auto delete empty blocks

