### PR TITLE
feat(no-duplicate-attr-inheritance): ignore multi root

### DIFF
--- a/docs/rules/no-duplicate-attr-inheritance.md
+++ b/docs/rules/no-duplicate-attr-inheritance.md
@@ -15,7 +15,7 @@ since: v7.0.0
 This rule aims to prevent duplicate attribute inheritance.  
 This rule to warn to apply `inheritAttrs: false` when it detects `v-bind="$attrs"` being used.
 
-<eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error']}">
+<eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error', { checkMultiRootNodes: false }]}">
 
 ```vue
 <template>
@@ -26,11 +26,12 @@ export default {
   /* ✓ GOOD */
   inheritAttrs: false
 }
+</script>
 ```
 
 </eslint-code-block>
 
-<eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error']}">
+<eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error', { checkMultiRootNodes: false }]}">
 
 ```vue
 <template>
@@ -41,13 +42,41 @@ export default {
   /* ✗ BAD */
   // inheritAttrs: true (default)
 }
+</script>
+```
+
+</eslint-code-block>
+
+### `"checkMultiRootNodes": true`
+
+<eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error', { checkMultiRootNodes: true }]}">
+
+```vue
+<template>
+  <div v-bind="$attrs" />
+  <div />
+</template>
+<script>
+export default {
+  /* ✗ BAD */
+  // inheritAttrs: true (default)
+}
+</script>
 ```
 
 </eslint-code-block>
 
 ## :wrench: Options
 
-Nothing.
+```json
+{
+  "vue/no-duplicate-attr-inheritance": ["error", {
+    "checkMultiRootNodes": false,
+  }]
+}
+```
+
+- `"checkMultiRootNodes"` ... If `true`, check and warn when there are multiple root nodes. (Default: `false`)
 
 ## :books: Further Reading
 

--- a/docs/rules/no-duplicate-attr-inheritance.md
+++ b/docs/rules/no-duplicate-attr-inheritance.md
@@ -12,8 +12,8 @@ since: v7.0.0
 
 ## :book: Rule Details
 
-This rule aims to prevent duplicate attribute inheritance.
-This rule to warn to apply `inheritAttrs: false` when it detects `v-bind="$attrs"` being used.
+This rule aims to prevent duplicate attribute inheritance.  
+This rule suggests applying `inheritAttrs: false` when it detects `v-bind="$attrs"` being used.
 
 <eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error', { checkMultiRootNodes: false }]}">
 
@@ -57,7 +57,7 @@ export default {
 }
 ```
 
-- `"checkMultiRootNodes"`: If set to `true`, check and warn to apply `inheritAttrs: false` whenever it detects `v-bind="$attrs"` being used. Default is `false`, will ignore the components with multiple root nodes, because Vue encourages adding `v-bind="$attrs"` in this case to prevent runtime warnings. See [attribute inheritance on multiple root nodes](https://vuejs.org/guide/components/attrs.html#attribute-inheritance-on-multiple-root-nodes) for more.
+- `"checkMultiRootNodes"`: If set to `true`, also suggest applying `inheritAttrs: false` to components with multiple root nodes (where `inheritAttrs: false` is the implicit default, see [attribute inheritance on multiple root nodes](https://vuejs.org/guide/components/attrs.html#attribute-inheritance-on-multiple-root-nodes)), whenever it detects `v-bind="$attrs"` being used. Default is `false`, which will ignore components with multiple root nodes.
 
 ### `"checkMultiRootNodes": true`
 

--- a/docs/rules/no-duplicate-attr-inheritance.md
+++ b/docs/rules/no-duplicate-attr-inheritance.md
@@ -12,7 +12,7 @@ since: v7.0.0
 
 ## :book: Rule Details
 
-This rule aims to prevent duplicate attribute inheritance.  
+This rule aims to prevent duplicate attribute inheritance.
 This rule to warn to apply `inheritAttrs: false` when it detects `v-bind="$attrs"` being used.
 
 <eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error', { checkMultiRootNodes: false }]}">
@@ -47,6 +47,18 @@ export default {
 
 </eslint-code-block>
 
+## :wrench: Options
+
+```json
+{
+  "vue/no-duplicate-attr-inheritance": ["error", {
+    "checkMultiRootNodes": false,
+  }]
+}
+```
+
+- `"checkMultiRootNodes"`: If set to `true`, check and warn to apply `inheritAttrs: false` whenever it detects `v-bind="$attrs"` being used. Default is `false`, will ignore the components with multiple root nodes, because Vue encourages adding `v-bind="$attrs"` in this case to prevent runtime warnings. See [attribute inheritance on multiple root nodes](https://vuejs.org/guide/components/attrs.html#attribute-inheritance-on-multiple-root-nodes) for more.
+
 ### `"checkMultiRootNodes": true`
 
 <eslint-code-block :rules="{'vue/no-duplicate-attr-inheritance': ['error', { checkMultiRootNodes: true }]}">
@@ -66,21 +78,10 @@ export default {
 
 </eslint-code-block>
 
-## :wrench: Options
-
-```json
-{
-  "vue/no-duplicate-attr-inheritance": ["error", {
-    "checkMultiRootNodes": false,
-  }]
-}
-```
-
-- `"checkMultiRootNodes"` ... If `true`, check and warn when there are multiple root nodes. (Default: `false`)
-
 ## :books: Further Reading
 
 - [API - inheritAttrs](https://vuejs.org/api/options-misc.html#inheritattrs)
+- [Fallthrough Attributes](https://vuejs.org/guide/components/attrs.html#attribute-inheritance-on-multiple-root-nodes)
 
 ## :rocket: Version
 

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -6,6 +6,43 @@
 
 const utils = require('../utils')
 
+/** @param {VElement[]} elements */
+function isConditionalGroup(elements) {
+  let hasIf = false
+  let hasElse = false
+
+  for (const element of elements) {
+    if (utils.hasDirective(element, 'if')) {
+      if (hasIf || hasElse) {
+        return false
+      }
+      hasIf = true
+    } else if (utils.hasDirective(element, 'else-if')) {
+      if (!hasIf || hasElse) {
+        return false
+      }
+    } else if (utils.hasDirective(element, 'else')) {
+      if (!hasIf || hasElse) {
+        return false
+      }
+      hasElse = true
+    } else {
+      return false
+    }
+  }
+
+  return hasIf && (elements.length === 1 || hasElse)
+}
+
+/** @param {VElement[]} elements */
+function isMultiRoot(elements) {
+  if (elements.length > 1 && !isConditionalGroup(elements)) {
+    return true
+  }
+
+  return false
+}
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -77,7 +114,10 @@ module.exports = {
           }
 
           const rootElements = element.children.filter(utils.isVElement)
-          if (rootElements.length === 1 && attrsRefs.length > 0) {
+          // ignore multi root
+          if (isMultiRoot(rootElements)) return
+
+          if (attrsRefs.length > 0) {
             for (const attrsRef of attrsRefs) {
               context.report({
                 node: attrsRef.id,

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -35,7 +35,7 @@ function isConditionalGroup(elements) {
 }
 
 /** @param {VElement[]} elements */
-function isMultiRoot(elements) {
+function isMultiRootNodes(elements) {
   if (elements.length > 1 && !isConditionalGroup(elements)) {
     return true
   }
@@ -54,13 +54,26 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html'
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          checkMultiRootNodes: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ],
     messages: {
       noDuplicateAttrInheritance: 'Set "inheritAttrs" to false.'
     }
   },
   /** @param {RuleContext} context */
   create(context) {
+    const options = context.options[0] || {}
+    const checkMultiRootNodes = options.checkMultiRootNodes === true
+
     /** @type {string | number | boolean | RegExp | BigInt | null} */
     let inheritsAttrs = true
     /** @type {VReference[]} */
@@ -114,8 +127,8 @@ module.exports = {
           }
 
           const rootElements = element.children.filter(utils.isVElement)
-          // ignore multi root
-          if (isMultiRoot(rootElements)) return
+
+          if (checkMultiRootNodes && isMultiRootNodes(rootElements)) return
 
           if (attrsRefs.length > 0) {
             for (const attrsRef of attrsRefs) {

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -12,7 +12,7 @@ function isConditionalGroup(elements) {
     return false
   }
 
-  const firstElement = element[0]
+  const firstElement = elements[0]
   const lastElement = elements[elements.length - 1]
   const inBetweenElements = elements.slice(1, -1)
 

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -26,6 +26,8 @@ module.exports = {
   create(context) {
     /** @type {string | number | boolean | RegExp | BigInt | null} */
     let inheritsAttrs = true
+    /** @type {VReference[]} */
+    const attrsRefs = []
 
     /** @param {ObjectExpression} node */
     function processOptions(node) {
@@ -54,7 +56,7 @@ module.exports = {
           if (!inheritsAttrs) {
             return
           }
-          const attrsRef = node.references.find((reference) => {
+          const reference = node.references.find((reference) => {
             if (reference.variable != null) {
               // Not vm reference
               return false
@@ -62,14 +64,29 @@ module.exports = {
             return reference.id.name === '$attrs'
           })
 
-          if (attrsRef) {
-            context.report({
-              node: attrsRef.id,
-              messageId: 'noDuplicateAttrInheritance'
-            })
+          if (reference) {
+            attrsRefs.push(reference)
           }
         }
-      })
+      }),
+      {
+        'Program:exit'(program) {
+          const element = program.templateBody
+          if (element == null) {
+            return
+          }
+
+          const rootElements = element.children.filter(utils.isVElement)
+          if (rootElements.length === 1 && attrsRefs.length > 0) {
+            for (const attrsRef of attrsRefs) {
+              context.report({
+                node: attrsRef.id,
+                messageId: 'noDuplicateAttrInheritance'
+              })
+            }
+          }
+        }
+      }
     )
   }
 }

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -8,30 +8,20 @@ const utils = require('../utils')
 
 /** @param {VElement[]} elements */
 function isConditionalGroup(elements) {
-  let hasIf = false
-  let hasElse = false
-
-  for (const element of elements) {
-    if (utils.hasDirective(element, 'if')) {
-      if (hasIf || hasElse) {
-        return false
-      }
-      hasIf = true
-    } else if (utils.hasDirective(element, 'else-if')) {
-      if (!hasIf || hasElse) {
-        return false
-      }
-    } else if (utils.hasDirective(element, 'else')) {
-      if (!hasIf || hasElse) {
-        return false
-      }
-      hasElse = true
-    } else {
-      return false
-    }
+  if (elements.length < 2) {
+    return false
   }
 
-  return hasIf && (elements.length === 1 || hasElse)
+  const firstElement = element[0]
+  const lastElement = elements[elements.length - 1]
+  const inBetweenElements = elements.slice(1, -1)
+
+  return (
+    utils.hasDirective(firstElement, 'if') &&
+    (utils.hasDirective(lastElement, 'else-if') ||
+      utils.hasDirective(lastElement, 'else')) &&
+    inBetweenElements.every((element) => utils.hasDirective(element, 'else-if'))
+  )
 }
 
 /** @param {VElement[]} elements */

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -128,7 +128,7 @@ module.exports = {
 
           const rootElements = element.children.filter(utils.isVElement)
 
-          if (checkMultiRootNodes && isMultiRootNodes(rootElements)) return
+          if (!checkMultiRootNodes && isMultiRootNodes(rootElements)) return
 
           if (attrsRefs.length > 0) {
             for (const attrsRef of attrsRefs) {

--- a/tests/lib/rules/no-duplicate-attr-inheritance.js
+++ b/tests/lib/rules/no-duplicate-attr-inheritance.js
@@ -46,6 +46,15 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
     {
       filename: 'test.vue',
       code: `
+      <script setup>
+      defineOptions({ inheritAttrs: true })
+      </script>
+      <template><div v-bind="$attrs"/><div/></template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
         <template><div><div></div></div></template>
         <script>
         const inheritAttrs = false;

--- a/tests/lib/rules/no-duplicate-attr-inheritance.js
+++ b/tests/lib/rules/no-duplicate-attr-inheritance.js
@@ -50,7 +50,8 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
       defineOptions({ inheritAttrs: true })
       </script>
       <template><div v-bind="$attrs"/><div/></template>
-      `
+      `,
+      options: [{ checkMultiRootNodes: true }]
     },
     // ignore multi root
     {
@@ -61,7 +62,8 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-if="condition2" v-bind="$attrs"></div>
           <div v-else></div>
         </template>
-      `
+      `,
+      options: [{ checkMultiRootNodes: true }]
     },
     {
       filename: 'test.vue',
@@ -71,7 +73,8 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-else-if="condition2"></div>
           <div v-bind="$attrs"></div>
         </template>
-      `
+      `,
+      options: [{ checkMultiRootNodes: true }]
     },
     {
       filename: 'test.vue',
@@ -81,7 +84,8 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-if="condition1"></div>
           <div v-else></div>
         </template>
-      `
+      `,
+      options: [{ checkMultiRootNodes: true }]
     },
     {
       filename: 'test.vue',
@@ -91,7 +95,8 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-else-if="condition2"></div>
           <div v-if="condition3" v-bind="$attrs"></div>
         </template>
-      `
+      `,
+      options: [{ checkMultiRootNodes: true }]
     },
     {
       filename: 'test.vue',
@@ -202,6 +207,17 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
         }
       ]
     },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineOptions({ inheritAttrs: true })
+      </script>
+      <template><div v-bind="$attrs"/><div/></template>
+      `,
+      options: [{ checkMultiRootNodes: false }],
+      errors: [{ message: 'Set "inheritAttrs" to false.' }]
+    },
     // single root with a condition group
     {
       filename: 'test.vue',
@@ -212,6 +228,7 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-else></div>
         </template>
       `,
+      options: [{ checkMultiRootNodes: true }],
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     },
     {
@@ -224,6 +241,7 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-else></div>
         </template>
       `,
+      options: [{ checkMultiRootNodes: true }],
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     },
     {
@@ -234,6 +252,7 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-else></div>
         </template>
       `,
+      options: [{ checkMultiRootNodes: true }],
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     },
     {
@@ -243,6 +262,7 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           <div v-if="condition1" v-bind="$attrs"></div>
         </template>
       `,
+      options: [{ checkMultiRootNodes: true }],
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     }
   ]

--- a/tests/lib/rules/no-duplicate-attr-inheritance.js
+++ b/tests/lib/rules/no-duplicate-attr-inheritance.js
@@ -52,6 +52,47 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
       <template><div v-bind="$attrs"/><div/></template>
       `
     },
+    // ignore multi root
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="condition1"></div>
+          <div v-if="condition2" v-bind="$attrs"></div>
+          <div v-else></div>
+        </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="condition1"></div>
+          <div v-else-if="condition2"></div>
+          <div v-bind="$attrs"></div>
+        </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-bind="$attrs"></div>
+          <div v-if="condition1"></div>
+          <div v-else></div>
+        </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="condition1"></div>
+          <div v-else-if="condition2"></div>
+          <div v-if="condition3" v-bind="$attrs"></div>
+        </template>
+      `
+    },
     {
       filename: 'test.vue',
       code: `
@@ -160,6 +201,49 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
           line: 5
         }
       ]
+    },
+    // single root with a condition group
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="condition1" v-bind="$attrs"></div>
+          <div v-else-if="condition2"></div>
+          <div v-else></div>
+        </template>
+      `,
+      errors: [{ message: 'Set "inheritAttrs" to false.' }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="condition1" v-bind="$attrs"></div>
+          <div v-else-if="condition2"></div>
+          <div v-else-if="condition3"></div>
+          <div v-else></div>
+        </template>
+      `,
+      errors: [{ message: 'Set "inheritAttrs" to false.' }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="condition1" v-bind="$attrs"></div>
+          <div v-else></div>
+        </template>
+      `,
+      errors: [{ message: 'Set "inheritAttrs" to false.' }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <div v-if="condition1" v-bind="$attrs"></div>
+        </template>
+      `,
+      errors: [{ message: 'Set "inheritAttrs" to false.' }]
     }
   ]
 })

--- a/tests/lib/rules/no-duplicate-attr-inheritance.js
+++ b/tests/lib/rules/no-duplicate-attr-inheritance.js
@@ -43,6 +43,7 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
         </script>
       `
     },
+    // ignore multi root by default
     {
       filename: 'test.vue',
       code: `
@@ -50,53 +51,48 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
       defineOptions({ inheritAttrs: true })
       </script>
       <template><div v-bind="$attrs"/><div/></template>
-      `,
-      options: [{ checkMultiRootNodes: true }]
-    },
-    // ignore multi root
-    {
-      filename: 'test.vue',
-      code: `
-        <template>
-          <div v-if="condition1"></div>
-          <div v-if="condition2" v-bind="$attrs"></div>
-          <div v-else></div>
-        </template>
-      `,
-      options: [{ checkMultiRootNodes: true }]
+      `
     },
     {
       filename: 'test.vue',
       code: `
-        <template>
-          <div v-if="condition1"></div>
-          <div v-else-if="condition2"></div>
-          <div v-bind="$attrs"></div>
-        </template>
-      `,
-      options: [{ checkMultiRootNodes: true }]
+      <template>
+        <div v-if="condition1"></div>
+        <div v-if="condition2" v-bind="$attrs"></div>
+        <div v-else></div>
+      </template>
+      `
     },
     {
       filename: 'test.vue',
       code: `
-        <template>
-          <div v-bind="$attrs"></div>
-          <div v-if="condition1"></div>
-          <div v-else></div>
-        </template>
-      `,
-      options: [{ checkMultiRootNodes: true }]
+      <template>
+        <div v-if="condition1"></div>
+        <div v-else-if="condition2"></div>
+        <div v-bind="$attrs"></div>
+      </template>
+      `
     },
     {
       filename: 'test.vue',
       code: `
-        <template>
-          <div v-if="condition1"></div>
-          <div v-else-if="condition2"></div>
-          <div v-if="condition3" v-bind="$attrs"></div>
-        </template>
+      <template>
+        <div v-bind="$attrs"></div>
+        <div v-if="condition1"></div>
+        <div v-else></div>
+      </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div v-if="condition1"></div>
+        <div v-else-if="condition2"></div>
+        <div v-if="condition3" v-bind="$attrs"></div>
+      </template>
       `,
-      options: [{ checkMultiRootNodes: true }]
+      options: [{ checkMultiRootNodes: false }]
     },
     {
       filename: 'test.vue',
@@ -209,60 +205,63 @@ ruleTester.run('no-duplicate-attr-inheritance', rule, {
     },
     {
       filename: 'test.vue',
-      code: `
-      <script setup>
-      defineOptions({ inheritAttrs: true })
-      </script>
-      <template><div v-bind="$attrs"/><div/></template>
-      `,
-      options: [{ checkMultiRootNodes: false }],
-      errors: [{ message: 'Set "inheritAttrs" to false.' }]
-    },
-    // single root with a condition group
-    {
-      filename: 'test.vue',
-      code: `
-        <template>
-          <div v-if="condition1" v-bind="$attrs"></div>
-          <div v-else-if="condition2"></div>
-          <div v-else></div>
-        </template>
-      `,
+      code: `<template><div v-bind="$attrs"></div><div></div></template>`,
       options: [{ checkMultiRootNodes: true }],
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     },
     {
       filename: 'test.vue',
       code: `
-        <template>
-          <div v-if="condition1" v-bind="$attrs"></div>
-          <div v-else-if="condition2"></div>
-          <div v-else-if="condition3"></div>
-          <div v-else></div>
-        </template>
+      <template>
+        <div v-if="condition1" v-bind="$attrs"></div>
+        <div v-else></div>
+        <div v-if="condition2"></div>
+      </template>
       `,
       options: [{ checkMultiRootNodes: true }],
+      errors: [{ message: 'Set "inheritAttrs" to false.' }]
+    },
+    // condition group as a single root node
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div v-if="condition1" v-bind="$attrs"></div>
+        <div v-else-if="condition2"></div>
+        <div v-else></div>
+      </template>
+      `,
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     },
     {
       filename: 'test.vue',
       code: `
-        <template>
-          <div v-if="condition1" v-bind="$attrs"></div>
-          <div v-else></div>
-        </template>
+      <template>
+        <div v-if="condition1" v-bind="$attrs"></div>
+        <div v-else-if="condition2"></div>
+        <div v-else-if="condition3"></div>
+        <div v-else></div>
+      </template>
       `,
-      options: [{ checkMultiRootNodes: true }],
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     },
     {
       filename: 'test.vue',
       code: `
-        <template>
-          <div v-if="condition1" v-bind="$attrs"></div>
-        </template>
+      <template>
+        <div v-if="condition1" v-bind="$attrs"></div>
+        <div v-else></div>
+      </template>
       `,
-      options: [{ checkMultiRootNodes: true }],
+      errors: [{ message: 'Set "inheritAttrs" to false.' }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div v-if="condition1" v-bind="$attrs"></div>
+      </template>
+      `,
       errors: [{ message: 'Set "inheritAttrs" to false.' }]
     }
   ]


### PR DESCRIPTION
resolve #2596.

- since this will result in fewer errors, should we still consider adding an option to control this?
- multi root could also be a group of `v-if` / `v-else` / `v-else` nodes. Should we consider treating it as a "single" root?


