### PR TITLE
feat: add `ignoreTags` option

### DIFF
--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -45,8 +45,8 @@ This rule enforces using hyphenated attribute names on custom components in Vue 
 Default casing is set to `always`. By default the following attributes are ignored: `data-`, `aria-`, `slot-scope`,
 and all the [SVG attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute) with either an upper case letter or an hyphen.
 
-- `"always"` (default) ... Use hyphenated name.
-- `"never"` ... Don't use hyphenated name except the ones that are ignored.
+- `"always"` (default) ... Use hyphenated attribute name.
+- `"never"` ... Don't use hyphenated attribute name.
 - `"ignore"` ... Array of ignored names.
 - `"ignoreTags"` ... Array of exclude tag names.
 

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -113,8 +113,6 @@ Don't use hyphenated name but allow custom attributes
 
 ### `"never", { "ignoreTags": ["/^custom-/"] }`
 
-Ignore tags from applying this rule.
-
 <eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never', { ignoreTags: ['/^custom-/'] }]}">
 
 ```vue

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -37,7 +37,7 @@ This rule enforces using hyphenated attribute names on custom components in Vue 
 {
   "vue/attribute-hyphenation": ["error", "always" | "never", {
     "ignore": [],
-    "exclude": []
+    "ignoreTags": []
   }]
 }
 ```
@@ -48,7 +48,7 @@ and all the [SVG attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/At
 - `"always"` (default) ... Use hyphenated name.
 - `"never"` ... Don't use hyphenated name except the ones that are ignored.
 - `"ignore"` ... Array of ignored names.
-- `"exclude"` ... Array of exclude tag names.
+- `"ignoreTags"` ... Array of exclude tag names.
 
 ### `"always"`
 
@@ -111,11 +111,11 @@ Don't use hyphenated name but allow custom attributes
 
 </eslint-code-block>
 
-### `"never", { "exclude": ["/^custom-/"] }`
+### `"never", { "ignoreTags": ["/^custom-/"] }`
 
-Exclude tags from applying this rule.
+Ignore tags from applying this rule.
 
-<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never', { exclude: ['/^custom-/'] }]}">
+<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never', { ignoreTags: ['/^custom-/'] }]}">
 
 ```vue
 <template>

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -120,10 +120,10 @@ Ignore tags from applying this rule.
 ```vue
 <template>
   <!-- ✓ GOOD -->
-  <custom-component custom-prop="prop" />
+  <custom-component my-prop="prop" />
 
   <!-- ✗ BAD -->
-  <my-component custom-prop="prop" />
+  <my-component my-prop="prop" />
 </template>
 ```
 

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -47,8 +47,8 @@ and all the [SVG attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/At
 
 - `"always"` (default) ... Use hyphenated attribute name.
 - `"never"` ... Don't use hyphenated attribute name.
-- `"ignore"` ... Array of ignored names.
-- `"ignoreTags"` ... Array of exclude tag names.
+- `"ignore"` ... Array of attribute names that don't need to follow the specified casing.
+- `"ignoreTags"` ... Array of tag names whose attributes don't need to follow the specified casing.
 
 ### `"always"`
 

--- a/docs/rules/attribute-hyphenation.md
+++ b/docs/rules/attribute-hyphenation.md
@@ -36,7 +36,8 @@ This rule enforces using hyphenated attribute names on custom components in Vue 
 ```json
 {
   "vue/attribute-hyphenation": ["error", "always" | "never", {
-    "ignore": []
+    "ignore": [],
+    "exclude": []
   }]
 }
 ```
@@ -46,7 +47,8 @@ and all the [SVG attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/At
 
 - `"always"` (default) ... Use hyphenated name.
 - `"never"` ... Don't use hyphenated name except the ones that are ignored.
-- `"ignore"` ... Array of ignored names
+- `"ignore"` ... Array of ignored names.
+- `"exclude"` ... Array of exclude tag names.
 
 ### `"always"`
 
@@ -104,6 +106,24 @@ Don't use hyphenated name but allow custom attributes
 
   <!-- ✗ BAD -->
   <MyComponent my-prop="prop" />
+</template>
+```
+
+</eslint-code-block>
+
+### `"never", { "exclude": ["/^custom-/"] }`
+
+Exclude tags from applying this rule.
+
+<eslint-code-block fix :rules="{'vue/attribute-hyphenation': ['error', 'never', { exclude: ['/^custom-/'] }]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <custom-component custom-prop="prop" />
+
+  <!-- ✗ BAD -->
+  <my-component custom-prop="prop" />
 </template>
 ```
 

--- a/docs/rules/v-on-event-hyphenation.md
+++ b/docs/rules/v-on-event-hyphenation.md
@@ -45,8 +45,8 @@ This rule enforces using hyphenated v-on event names on custom components in Vue
 }
 ```
 
-- `"always"` (default) ... Use hyphenated name.
-- `"never"` ... Don't use hyphenated name.
+- `"always"` (default) ... Use hyphenated event name.
+- `"never"` ... Don't use hyphenated event name.
 - `"ignore"` ... Array of ignored names.
 - `"ignoreTags"` ... Array of exclude tag names.
 - `"autofix"` ... If `true`, enable autofix. If you are using Vue 2, we recommend that you do not use it due to its side effects.

--- a/docs/rules/v-on-event-hyphenation.md
+++ b/docs/rules/v-on-event-hyphenation.md
@@ -108,17 +108,15 @@ Don't use hyphenated name but allow custom event names
 
 ### `"never", { "ignoreTags": ["/^custom-/"] }`
 
-Ignore tags from applying this rule.
-
 <eslint-code-block fix :rules="{'vue/v-on-event-hyphenation': ['error', 'never', { ignoreTags: ['/^custom-/'], autofix: true }]}">
 
 ```vue
 <template>
   <!-- ✓ GOOD -->
-  <custom-component v-on:custom-event="handleEvent" />
+  <custom-component v-on:my-event="handleEvent" />
 
   <!-- ✗ BAD -->
-  <my-component v-on:custom-event="handleEvent" />
+  <my-component v-on:my-event="handleEvent" />
 </template>
 ```
 

--- a/docs/rules/v-on-event-hyphenation.md
+++ b/docs/rules/v-on-event-hyphenation.md
@@ -40,7 +40,7 @@ This rule enforces using hyphenated v-on event names on custom components in Vue
   "vue/v-on-event-hyphenation": ["error", "always" | "never", {
     "autofix": false,
     "ignore": [],
-    "exclude": []
+    "ignoreTags": []
   }]
 }
 ```
@@ -48,7 +48,7 @@ This rule enforces using hyphenated v-on event names on custom components in Vue
 - `"always"` (default) ... Use hyphenated name.
 - `"never"` ... Don't use hyphenated name.
 - `"ignore"` ... Array of ignored names.
-- `"exclude"` ... Array of exclude tag names.
+- `"ignoreTags"` ... Array of exclude tag names.
 - `"autofix"` ... If `true`, enable autofix. If you are using Vue 2, we recommend that you do not use it due to its side effects.
 
 ### `"always"`
@@ -106,11 +106,11 @@ Don't use hyphenated name but allow custom event names
 
 </eslint-code-block>
 
-### `"never", { "exclude": ["/^custom-/"] }`
+### `"never", { "ignoreTags": ["/^custom-/"] }`
 
-Exclude tags from applying this rule.
+Ignore tags from applying this rule.
 
-<eslint-code-block fix :rules="{'vue/v-on-event-hyphenation': ['error', 'never', { exclude: ['/^custom-/'], autofix: true }]}">
+<eslint-code-block fix :rules="{'vue/v-on-event-hyphenation': ['error', 'never', { ignoreTags: ['/^custom-/'], autofix: true }]}">
 
 ```vue
 <template>

--- a/docs/rules/v-on-event-hyphenation.md
+++ b/docs/rules/v-on-event-hyphenation.md
@@ -47,8 +47,8 @@ This rule enforces using hyphenated v-on event names on custom components in Vue
 
 - `"always"` (default) ... Use hyphenated event name.
 - `"never"` ... Don't use hyphenated event name.
-- `"ignore"` ... Array of ignored names.
-- `"ignoreTags"` ... Array of exclude tag names.
+- `"ignore"` ... Array of event names that don't need to follow the specified casing.
+- `"ignoreTags"` ... Array of tag names whose events don't need to follow the specified casing.
 - `"autofix"` ... If `true`, enable autofix. If you are using Vue 2, we recommend that you do not use it due to its side effects.
 
 ### `"always"`

--- a/docs/rules/v-on-event-hyphenation.md
+++ b/docs/rules/v-on-event-hyphenation.md
@@ -39,14 +39,16 @@ This rule enforces using hyphenated v-on event names on custom components in Vue
 {
   "vue/v-on-event-hyphenation": ["error", "always" | "never", {
     "autofix": false,
-    "ignore": []
+    "ignore": [],
+    "exclude": []
   }]
 }
 ```
 
 - `"always"` (default) ... Use hyphenated name.
 - `"never"` ... Don't use hyphenated name.
-- `"ignore"` ... Array of ignored names
+- `"ignore"` ... Array of ignored names.
+- `"exclude"` ... Array of exclude tag names.
 - `"autofix"` ... If `true`, enable autofix. If you are using Vue 2, we recommend that you do not use it due to its side effects.
 
 ### `"always"`
@@ -99,6 +101,24 @@ Don't use hyphenated name but allow custom event names
 
   <!-- ✗ BAD -->
   <MyComponent v-on:my-event="handleEvent" />
+</template>
+```
+
+</eslint-code-block>
+
+### `"never", { "exclude": ["/^custom-/"] }`
+
+Exclude tags from applying this rule.
+
+<eslint-code-block fix :rules="{'vue/v-on-event-hyphenation': ['error', 'never', { exclude: ['/^custom-/'], autofix: true }]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <custom-component v-on:custom-event="handleEvent" />
+
+  <!-- ✗ BAD -->
+  <my-component v-on:custom-event="handleEvent" />
 </template>
 ```
 

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -6,6 +6,7 @@
 
 const utils = require('../utils')
 const casing = require('../utils/casing')
+const { toRegExp } = require('../utils/regexp')
 const svgAttributes = require('../utils/svg-attributes-weird-case.json')
 
 /**
@@ -56,6 +57,12 @@ module.exports = {
             },
             uniqueItems: true,
             additionalItems: false
+          },
+          exclude: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+            additionalItems: false
           }
         },
         additionalProperties: false
@@ -72,6 +79,10 @@ module.exports = {
     const option = context.options[0]
     const optionsPayload = context.options[1]
     const useHyphenated = option !== 'never'
+    /** @type {RegExp[]} */
+    const excludedTags = ((optionsPayload && optionsPayload.exclude) || []).map(
+      toRegExp
+    )
     const ignoredAttributes = ['data-', 'aria-', 'slot-scope', ...svgAttributes]
 
     if (optionsPayload && optionsPayload.ignore) {
@@ -130,11 +141,19 @@ module.exports = {
       return useHyphenated ? value.toLowerCase() === value : !/-/.test(value)
     }
 
+    /**
+     * @param {string} name
+     */
+    function isExcludedTags(name) {
+      return excludedTags.some((re) => re.test(name))
+    }
+
     return utils.defineTemplateBodyVisitor(context, {
       VAttribute(node) {
+        const element = node.parent.parent
         if (
-          !utils.isCustomComponent(node.parent.parent) &&
-          node.parent.parent.name !== 'slot'
+          (!utils.isCustomComponent(element) && element.name !== 'slot') ||
+          isExcludedTags(element.rawName)
         )
           return
 

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -80,7 +80,7 @@ module.exports = {
     const optionsPayload = context.options[1]
     const useHyphenated = option !== 'never'
     /** @type {RegExp[]} */
-    const ignoreTags = (
+    const ignoredTagsRegexps = (
       (optionsPayload && optionsPayload.ignoreTags) ||
       []
     ).map(toRegExp)
@@ -144,7 +144,7 @@ module.exports = {
 
     /** @param {string} name */
     function isIgnoredTagName(name) {
-      return ignoreTags.some((re) => re.test(name))
+      return ignoredTagsRegexps.some((re) => re.test(name))
     }
 
     return utils.defineTemplateBodyVisitor(context, {

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -143,7 +143,7 @@ module.exports = {
     }
 
     /** @param {string} name */
-    function isIgnoredTags(name) {
+    function isIgnoredTagName(name) {
       return ignoreTags.some((re) => re.test(name))
     }
 
@@ -152,7 +152,7 @@ module.exports = {
         const element = node.parent.parent
         if (
           (!utils.isCustomComponent(element) && element.name !== 'slot') ||
-          isIgnoredTags(element.rawName)
+          isIgnoredTagName(element.rawName)
         )
           return
 

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -58,7 +58,7 @@ module.exports = {
             uniqueItems: true,
             additionalItems: false
           },
-          exclude: {
+          ignoreTags: {
             type: 'array',
             items: { type: 'string' },
             uniqueItems: true,
@@ -80,9 +80,10 @@ module.exports = {
     const optionsPayload = context.options[1]
     const useHyphenated = option !== 'never'
     /** @type {RegExp[]} */
-    const excludedTags = ((optionsPayload && optionsPayload.exclude) || []).map(
-      toRegExp
-    )
+    const ignoreTags = (
+      (optionsPayload && optionsPayload.ignoreTags) ||
+      []
+    ).map(toRegExp)
     const ignoredAttributes = ['data-', 'aria-', 'slot-scope', ...svgAttributes]
 
     if (optionsPayload && optionsPayload.ignore) {
@@ -144,8 +145,8 @@ module.exports = {
     /**
      * @param {string} name
      */
-    function isExcludedTags(name) {
-      return excludedTags.some((re) => re.test(name))
+    function isIgnoredTags(name) {
+      return ignoreTags.some((re) => re.test(name))
     }
 
     return utils.defineTemplateBodyVisitor(context, {
@@ -153,7 +154,7 @@ module.exports = {
         const element = node.parent.parent
         if (
           (!utils.isCustomComponent(element) && element.name !== 'slot') ||
-          isExcludedTags(element.rawName)
+          isIgnoredTags(element.rawName)
         )
           return
 

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -142,9 +142,7 @@ module.exports = {
       return useHyphenated ? value.toLowerCase() === value : !/-/.test(value)
     }
 
-    /**
-     * @param {string} name
-     */
+    /** @param {string} name */
     function isIgnoredTags(name) {
       return ignoreTags.some((re) => re.test(name))
     }

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -112,7 +112,7 @@ module.exports = {
     }
 
     /** @param {string} name */
-    function isIgnoreTags(name) {
+    function isIgnoredTagName(name) {
       return ignoreTags.some((re) => re.test(name))
     }
 
@@ -121,7 +121,7 @@ module.exports = {
         const element = node.parent.parent
         if (
           !utils.isCustomComponent(element) ||
-          isIgnoreTags(element.rawName)
+          isIgnoredTagName(element.rawName)
         ) {
           return
         }

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -37,7 +37,7 @@ module.exports = {
             uniqueItems: true,
             additionalItems: false
           },
-          exclude: {
+          ignoreTags: {
             type: 'array',
             items: { type: 'string' },
             uniqueItems: true,
@@ -64,9 +64,10 @@ module.exports = {
     /** @type {string[]} */
     const ignoredAttributes = (optionsPayload && optionsPayload.ignore) || []
     /** @type {RegExp[]} */
-    const excludedTags = ((optionsPayload && optionsPayload.exclude) || []).map(
-      toRegExp
-    )
+    const ignoreTags = (
+      (optionsPayload && optionsPayload.ignoreTags) ||
+      []
+    ).map(toRegExp)
     const autofix = Boolean(optionsPayload && optionsPayload.autofix)
 
     const caseConverter = casing.getConverter(
@@ -113,8 +114,8 @@ module.exports = {
     /**
      * @param {string} name
      */
-    function isExcludedTags(name) {
-      return excludedTags.some((re) => re.test(name))
+    function isIgnoreTags(name) {
+      return ignoreTags.some((re) => re.test(name))
     }
 
     return utils.defineTemplateBodyVisitor(context, {
@@ -122,7 +123,7 @@ module.exports = {
         const element = node.parent.parent
         if (
           !utils.isCustomComponent(element) ||
-          isExcludedTags(element.rawName)
+          isIgnoreTags(element.rawName)
         ) {
           return
         }

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -111,9 +111,7 @@ module.exports = {
       return useHyphenated ? value.toLowerCase() === value : !/-/.test(value)
     }
 
-    /**
-     * @param {string} name
-     */
+    /** @param {string} name */
     function isIgnoreTags(name) {
       return ignoreTags.some((re) => re.test(name))
     }

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -2,6 +2,7 @@
 
 const utils = require('../utils')
 const casing = require('../utils/casing')
+const { toRegExp } = require('../utils/regexp')
 
 module.exports = {
   meta: {
@@ -35,6 +36,12 @@ module.exports = {
             },
             uniqueItems: true,
             additionalItems: false
+          },
+          exclude: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+            additionalItems: false
           }
         },
         additionalProperties: false
@@ -56,6 +63,10 @@ module.exports = {
     const useHyphenated = option !== 'never'
     /** @type {string[]} */
     const ignoredAttributes = (optionsPayload && optionsPayload.ignore) || []
+    /** @type {RegExp[]} */
+    const excludedTags = ((optionsPayload && optionsPayload.exclude) || []).map(
+      toRegExp
+    )
     const autofix = Boolean(optionsPayload && optionsPayload.autofix)
 
     const caseConverter = casing.getConverter(
@@ -99,9 +110,22 @@ module.exports = {
       return useHyphenated ? value.toLowerCase() === value : !/-/.test(value)
     }
 
+    /**
+     * @param {string} name
+     */
+    function isExcludedTags(name) {
+      return excludedTags.some((re) => re.test(name))
+    }
+
     return utils.defineTemplateBodyVisitor(context, {
       "VAttribute[directive=true][key.name.name='on']"(node) {
-        if (!utils.isCustomComponent(node.parent.parent)) return
+        const element = node.parent.parent
+        if (
+          !utils.isCustomComponent(element) ||
+          isExcludedTags(element.rawName)
+        ) {
+          return
+        }
         if (!node.key.argument || node.key.argument.type !== 'VIdentifier') {
           return
         }

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -64,7 +64,7 @@ module.exports = {
     /** @type {string[]} */
     const ignoredAttributes = (optionsPayload && optionsPayload.ignore) || []
     /** @type {RegExp[]} */
-    const ignoreTags = (
+    const ignoredTagsRegexps = (
       (optionsPayload && optionsPayload.ignoreTags) ||
       []
     ).map(toRegExp)
@@ -113,7 +113,7 @@ module.exports = {
 
     /** @param {string} name */
     function isIgnoredTagName(name) {
-      return ignoreTags.some((re) => re.test(name))
+      return ignoredTagsRegexps.some((re) => re.test(name))
     }
 
     return utils.defineTemplateBodyVisitor(context, {

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -85,6 +85,16 @@ ruleTester.run('attribute-hyphenation', rule, {
       filename: 'test.vue',
       code: '<template><div><custom :myName.sync="prop"></custom></div></template>',
       options: ['never']
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <VueComponent my-prop></VueComponent>
+        <custom-component my-prop></custom-component>
+      </template>
+      `,
+      options: ['never', { exclude: ['VueComponent', '/^custom-/'] }]
     }
   ],
 
@@ -448,6 +458,28 @@ ruleTester.run('attribute-hyphenation', rule, {
           message: "Attribute ':my-age.sync' can't be hyphenated.",
           type: 'VDirectiveKey',
           line: 1
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <custom my-prop/>
+        <CustomComponent my-prop/>
+      </template>
+      `,
+      output: `
+      <template>
+        <custom myProp/>
+        <CustomComponent my-prop/>
+      </template>
+      `,
+      options: ['never', { exclude: ['CustomComponent'] }],
+      errors: [
+        {
+          message: "Attribute 'my-prop' can't be hyphenated.",
+          type: 'VIdentifier',
+          line: 3
         }
       ]
     }

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -95,6 +95,16 @@ ruleTester.run('attribute-hyphenation', rule, {
       </template>
       `,
       options: ['never', { ignoreTags: ['VueComponent', '/^custom-/'] }]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <VueComponent myProp="prop"></VueComponent>
+        <custom-component myProp="prop"></custom-component>
+      </template>
+      `,
+      options: ['always', { ignoreTags: ['VueComponent', '/^custom-/'] }]
     }
   ],
 
@@ -478,6 +488,29 @@ ruleTester.run('attribute-hyphenation', rule, {
       errors: [
         {
           message: "Attribute 'my-prop' can't be hyphenated.",
+          type: 'VIdentifier',
+          line: 3,
+          column: 17
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <custom myProp/>
+        <CustomComponent myProp/>
+      </template>
+      `,
+      output: `
+      <template>
+        <custom my-prop/>
+        <CustomComponent myProp/>
+      </template>
+      `,
+      options: ['always', { ignoreTags: ['CustomComponent'] }],
+      errors: [
+        {
+          message: "Attribute 'myProp' must be hyphenated.",
           type: 'VIdentifier',
           line: 3,
           column: 17

--- a/tests/lib/rules/attribute-hyphenation.js
+++ b/tests/lib/rules/attribute-hyphenation.js
@@ -94,7 +94,7 @@ ruleTester.run('attribute-hyphenation', rule, {
         <custom-component my-prop></custom-component>
       </template>
       `,
-      options: ['never', { exclude: ['VueComponent', '/^custom-/'] }]
+      options: ['never', { ignoreTags: ['VueComponent', '/^custom-/'] }]
     }
   ],
 
@@ -474,12 +474,13 @@ ruleTester.run('attribute-hyphenation', rule, {
         <CustomComponent my-prop/>
       </template>
       `,
-      options: ['never', { exclude: ['CustomComponent'] }],
+      options: ['never', { ignoreTags: ['CustomComponent'] }],
       errors: [
         {
           message: "Attribute 'my-prop' can't be hyphenated.",
           type: 'VIdentifier',
-          line: 3
+          line: 3,
+          column: 17
         }
       ]
     }

--- a/tests/lib/rules/v-on-event-hyphenation.js
+++ b/tests/lib/rules/v-on-event-hyphenation.js
@@ -61,6 +61,15 @@ tester.run('v-on-event-hyphenation', rule, {
       </template>
       `,
       options: ['never', { ignoreTags: ['/^Vue/', 'custom-component'] }]
+    },
+    {
+      code: `
+      <template>
+          <VueComponent v-on:customEvent="events"/>
+          <custom-component v-on:customEvent="events"/>
+      </template>
+      `,
+      options: ['always', { ignoreTags: ['/^Vue/', 'custom-component'] }]
     }
   ],
   invalid: [
@@ -214,6 +223,28 @@ tester.run('v-on-event-hyphenation', rule, {
       errors: [
         {
           message: "v-on event 'v-on:custom-event' can't be hyphenated.",
+          line: 3,
+          column: 23
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <VueComponent v-on:customEvent="events"/>
+        <CustomComponent v-on:customEvent="events"/>
+      </template>
+      `,
+      output: `
+      <template>
+        <VueComponent v-on:custom-event="events"/>
+        <CustomComponent v-on:customEvent="events"/>
+      </template>
+      `,
+      options: ['always', { autofix: true, ignoreTags: ['CustomComponent'] }],
+      errors: [
+        {
+          message: "v-on event 'v-on:customEvent' must be hyphenated.",
           line: 3,
           column: 23
         }

--- a/tests/lib/rules/v-on-event-hyphenation.js
+++ b/tests/lib/rules/v-on-event-hyphenation.js
@@ -44,6 +44,23 @@ tester.run('v-on-event-hyphenation', rule, {
       </template>
       `,
       options: ['never', { ignore: ['custom'] }]
+    },
+    {
+      code: `
+      <template>
+          <VueComponent v-on:custom-event="events"/>
+      </template>
+      `,
+      options: ['never', { ignore: ['custom-event'] }]
+    },
+    {
+      code: `
+      <template>
+          <VueComponent v-on:custom-event="events"/>
+          <custom-component v-on:custom-event="events"/>
+      </template>
+      `,
+      options: ['never', { exclude: ['/^Vue/', 'custom-component'] }]
     }
   ],
   invalid: [
@@ -179,6 +196,22 @@ tester.run('v-on-event-hyphenation', rule, {
         "v-on event '@upDate:model-value' can't be hyphenated.",
         "v-on event '@up-date:model-value' can't be hyphenated."
       ]
+    },
+    {
+      code: `
+      <template>
+        <VueComponent v-on:custom-event="events"/>
+        <CustomComponent v-on:custom-event="events"/>
+      </template>
+      `,
+      output: `
+      <template>
+        <VueComponent v-on:customEvent="events"/>
+        <CustomComponent v-on:custom-event="events"/>
+      </template>
+      `,
+      options: ['never', { autofix: true, exclude: ['CustomComponent'] }],
+      errors: ["v-on event 'v-on:custom-event' can't be hyphenated."]
     }
   ]
 })

--- a/tests/lib/rules/v-on-event-hyphenation.js
+++ b/tests/lib/rules/v-on-event-hyphenation.js
@@ -60,7 +60,7 @@ tester.run('v-on-event-hyphenation', rule, {
           <custom-component v-on:custom-event="events"/>
       </template>
       `,
-      options: ['never', { exclude: ['/^Vue/', 'custom-component'] }]
+      options: ['never', { ignoreTags: ['/^Vue/', 'custom-component'] }]
     }
   ],
   invalid: [
@@ -210,8 +210,14 @@ tester.run('v-on-event-hyphenation', rule, {
         <CustomComponent v-on:custom-event="events"/>
       </template>
       `,
-      options: ['never', { autofix: true, exclude: ['CustomComponent'] }],
-      errors: ["v-on event 'v-on:custom-event' can't be hyphenated."]
+      options: ['never', { autofix: true, ignoreTags: ['CustomComponent'] }],
+      errors: [
+        {
+          message: "v-on event 'v-on:custom-event' can't be hyphenated.",
+          line: 3,
+          column: 23
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
resolve #2605 

Add an `exclude` option to exclude specified tag names in the `vue/attribute-hyphenation` and `vue/v-on-event-hyphenation` rules.