### PR TITLE
Chore: workaround for ESLint Stylistic issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@ota-meshi/site-kit-eslint-editor-vue": "^0.2.4",
-    "@stylistic/eslint-plugin": "^2.9.0",
+    "@stylistic/eslint-plugin": "~2.10.0",
     "@types/eslint": "^8.56.2",
     "@types/eslint-visitor-keys": "^3.3.2",
     "@types/natural-compare": "^1.4.3",


### PR DESCRIPTION
This PR will temporarily work around the ESLint style issue by pinning `@stylistic/eslint-plugin` to 2.10.

related to #2618