### PR TITLE
Remove legacy schema from `vue/custom-event-name-casing`

### DIFF
--- a/lib/rules/custom-event-name-casing.js
+++ b/lib/rules/custom-event-name-casing.js
@@ -54,18 +54,6 @@ function getCalleeMemberNode(node) {
   return null
 }
 
-const OBJECT_OPTION_SCHEMA = {
-  type: 'object',
-  properties: {
-    ignores: {
-      type: 'array',
-      items: { type: 'string' },
-      uniqueItems: true,
-      additionalItems: false
-    }
-  },
-  additionalProperties: false
-}
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -75,19 +63,23 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/custom-event-name-casing.html'
     },
     fixable: null,
-    schema: {
-      anyOf: [
-        {
-          type: 'array',
-          items: [
-            {
-              enum: ALLOWED_CASE_OPTIONS
-            },
-            OBJECT_OPTION_SCHEMA
-          ]
-        }
-      ]
-    },
+    schema: [
+      {
+        enum: ALLOWED_CASE_OPTIONS
+      },
+      {
+        type: 'object',
+        properties: {
+          ignores: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+            additionalItems: false
+          }
+        },
+        additionalProperties: false
+      }
+    ],
     messages: {
       unexpected: "Custom event name '{{name}}' must be {{caseType}}."
     }

--- a/lib/rules/custom-event-name-casing.js
+++ b/lib/rules/custom-event-name-casing.js
@@ -85,11 +85,6 @@ module.exports = {
             },
             OBJECT_OPTION_SCHEMA
           ]
-        },
-        // For backward compatibility
-        {
-          type: 'array',
-          items: [OBJECT_OPTION_SCHEMA]
         }
       ]
     },
@@ -102,13 +97,8 @@ module.exports = {
     /** @type {Map<ObjectExpression|Program, {contextReferenceIds:Set<Identifier>,emitReferenceIds:Set<Identifier>}>} */
     const setupContexts = new Map()
     let emitParamName = ''
-    const options =
-      context.options.length === 1 && typeof context.options[0] !== 'string'
-        ? // For backward compatibility
-          [undefined, context.options[0]]
-        : context.options
-    const caseType = options[0] || DEFAULT_CASE
-    const objectOption = options[1] || {}
+    const caseType = context.options[0] || DEFAULT_CASE
+    const objectOption = context.options[1] || {}
     const caseChecker = casing.getChecker(caseType)
     /** @type {RegExp[]} */
     const ignores = (objectOption.ignores || []).map(toRegExp)

--- a/tests/lib/rules/custom-event-name-casing.js
+++ b/tests/lib/rules/custom-event-name-casing.js
@@ -237,18 +237,6 @@ tester.run('custom-event-name-casing', rule, {
       ]
     },
 
-    // For backward compatibility
-    {
-      filename: 'test.vue',
-      code: `
-      <template>
-        <input
-          @click="$emit('fooBar')">
-      </template>
-      `,
-      options: [{ ignores: ['fooBar'] }]
-    },
-
     // camelCase
     {
       filename: 'test.vue',


### PR DESCRIPTION
See https://github.com/vuejs/eslint-plugin-vue/blame/207eb981df3bbab5d63846d7456d0925ab82394c/lib/rules/custom-event-name-casing.js#L89-L93