### PR TITLE
Add `vue/block-order` to recommended configs

### DIFF
--- a/docs/rules/block-order.md
+++ b/docs/rules/block-order.md
@@ -10,6 +10,7 @@ since: v9.16.0
 
 > enforce order of component top-level elements
 
+- :gear: This rule is included in all of `"plugin:vue/vue3-recommended"`, `*.configs["flat/recommended"]`, `"plugin:vue/recommended"` and `*.configs["flat/vue2-recommended"]`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/docs/rules/component-tags-order.md
+++ b/docs/rules/component-tags-order.md
@@ -11,7 +11,6 @@ since: v6.1.0
 > enforce order of component top-level elements
 
 - :no_entry_sign: This rule was **deprecated** and replaced by [vue/block-order](block-order.md) rule.
-- :gear: This rule is included in all of `"plugin:vue/vue3-recommended"`, `*.configs["flat/recommended"]`, `"plugin:vue/recommended"` and `*.configs["flat/vue2-recommended"]`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -177,7 +177,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | Rule ID | Description |    |    |
 |:--------|:------------|:--:|:--:|
 | [vue/attributes-order](./attributes-order.md) | enforce order of attributes | :wrench: | :three::two::hammer: |
-| [vue/component-tags-order](./component-tags-order.md) | enforce order of component top-level elements | :wrench::no_entry_sign: | :three::two::hammer: |
+| [vue/block-order](./block-order.md) | enforce order of component top-level elements | :wrench: | :three::two::hammer: |
 | [vue/no-lone-template](./no-lone-template.md) | disallow unnecessary `<template>` |  | :three::two::warning: |
 | [vue/no-multiple-slot-args](./no-multiple-slot-args.md) | disallow to pass multiple arguments to scoped slots |  | :three::two::warning: |
 | [vue/no-v-html](./no-v-html.md) | disallow use of v-html to prevent XSS attack |  | :three::two::hammer: |
@@ -206,7 +206,6 @@ For example:
 | Rule ID | Description |    |    |
 |:--------|:------------|:--:|:--:|
 | [vue/block-lang](./block-lang.md) | disallow use other than available `lang` |  | :hammer: |
-| [vue/block-order](./block-order.md) | enforce order of component top-level elements | :wrench: | :hammer: |
 | [vue/block-tag-newline](./block-tag-newline.md) | enforce line breaks after opening and before closing block-level tags | :wrench: | :lipstick: |
 | [vue/component-api-style](./component-api-style.md) | enforce component API style |  | :hammer: |
 | [vue/component-name-in-template-casing](./component-name-in-template-casing.md) | enforce specific casing for the component naming style in template | :wrench: | :hammer: |

--- a/lib/configs/flat/vue2-recommended.js
+++ b/lib/configs/flat/vue2-recommended.js
@@ -12,7 +12,7 @@ module.exports = [
     name: 'vue/vue2-recommended/rules',
     rules: {
       'vue/attributes-order': 'warn',
-      'vue/component-tags-order': 'warn',
+      'vue/block-order': 'warn',
       'vue/no-lone-template': 'warn',
       'vue/no-multiple-slot-args': 'warn',
       'vue/no-v-html': 'warn',

--- a/lib/configs/flat/vue3-recommended.js
+++ b/lib/configs/flat/vue3-recommended.js
@@ -12,7 +12,7 @@ module.exports = [
     name: 'vue/recommended/rules',
     rules: {
       'vue/attributes-order': 'warn',
-      'vue/component-tags-order': 'warn',
+      'vue/block-order': 'warn',
       'vue/no-lone-template': 'warn',
       'vue/no-multiple-slot-args': 'warn',
       'vue/no-v-html': 'warn',

--- a/lib/configs/vue2-recommended.js
+++ b/lib/configs/vue2-recommended.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: require.resolve('./vue2-strongly-recommended'),
   rules: {
     'vue/attributes-order': 'warn',
-    'vue/component-tags-order': 'warn',
+    'vue/block-order': 'warn',
     'vue/no-lone-template': 'warn',
     'vue/no-multiple-slot-args': 'warn',
     'vue/no-v-html': 'warn',

--- a/lib/configs/vue3-recommended.js
+++ b/lib/configs/vue3-recommended.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: require.resolve('./vue3-strongly-recommended'),
   rules: {
     'vue/attributes-order': 'warn',
-    'vue/component-tags-order': 'warn',
+    'vue/block-order': 'warn',
     'vue/no-lone-template': 'warn',
     'vue/no-multiple-slot-args': 'warn',
     'vue/no-v-html': 'warn',

--- a/lib/rules/block-order.js
+++ b/lib/rules/block-order.js
@@ -38,7 +38,7 @@ module.exports = {
     type: 'suggestion',
     docs: {
       description: 'enforce order of component top-level elements',
-      categories: undefined,
+      categories: ['vue3-recommended', 'vue2-recommended'],
       url: 'https://eslint.vuejs.org/rules/block-order.html'
     },
     fixable: 'code',

--- a/lib/rules/component-tags-order.js
+++ b/lib/rules/component-tags-order.js
@@ -10,7 +10,7 @@ module.exports = {
     type: baseRule.meta.type,
     docs: {
       description: baseRule.meta.docs.description,
-      categories: ['vue3-recommended', 'vue2-recommended'],
+      categories: undefined,
       url: 'https://eslint.vuejs.org/rules/component-tags-order.html'
     },
     deprecated: true,


### PR DESCRIPTION
instead of `vue/component-tags-order`