### PR TITLE
docs: fix missing options `allow` value

### DIFF
--- a/docs/rules/restricted-component-names.md
+++ b/docs/rules/restricted-component-names.md
@@ -39,7 +39,7 @@ This rule enforces consistency in component names.
 }
 ```
 
-### `"allow"`
+### `"allow: ['/^custom-/']"`
 
 <eslint-code-block :rules="{'vue/restricted-component-names': ['error', { 'allow': ['/^custom-/'] }]}">
 


### PR DESCRIPTION
This PR adds the missing value for option `allow` to rule `vue/restricted-component-names` docs.