### PR TITLE
feat: Add a test case to require-valid-default-prop

### DIFF
--- a/tests/lib/rules/require-valid-default-prop.js
+++ b/tests/lib/rules/require-valid-default-prop.js
@@ -108,6 +108,7 @@ ruleTester.run('require-valid-default-prop', rule, {
           foo: { type: String, default () { return Foo } },
           foo: { type: Number, default () { return Foo } },
           foo: { type: Object, default () { return Foo } },
+          foo: { type: Object, default: null },
         }
       })`,
       languageOptions


### PR DESCRIPTION
The documentation for Vue props, as well as the `require-valid-default-prop` rule, are not clear if setting a default value of `null` to a prop with type `Object` requires a factory function:

```js
props: {
  foo: { type: Object, default: () => null },
},
```

vs.

```js
props: {
  foo: { type: Object, default: null },
},
```

On one hand, `typeof null === 'object'`. On the other hand, the reason for using a factory function is so each instance of the prop has a different object reference, whereas `null` is always the same reference anyway.

This adds a valid test case for setting a default value of `null` to a prop with type `Object` without a factory function. The test passes, so it's evident that `null` does not require a factory function.