### PR TITLE
Remove unused `runOutsideVue` option from `vue/sort-keys`

### DIFF
--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -99,10 +99,6 @@ module.exports = {
           natural: {
             type: 'boolean',
             default: false
-          },
-          runOutsideVue: {
-            type: 'boolean',
-            default: true
           }
         },
         additionalProperties: false


### PR DESCRIPTION
Related to

* #1865
* #1866
* #2166

Since this options is unused and undocumented, I think we should remove it in the next major version. Adding it again can be a backwards-compatible enhancement.