### PR TITLE
fix(no-multiple-objects-in-class): improve grammar of description

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -233,7 +233,7 @@ For example:
 | [vue/no-deprecated-model-definition] | disallow deprecated `model` definition (in Vue.js 3.0.0+) | :bulb: | :warning: |
 | [vue/no-duplicate-attr-inheritance] | enforce `inheritAttrs` to be set to `false` when using `v-bind="$attrs"` |  | :hammer: |
 | [vue/no-empty-component-block] | disallow the `<template>` `<script>` `<style>` block to be empty | :wrench: | :hammer: |
-| [vue/no-multiple-objects-in-class] | disallow to pass multiple objects into array to class |  | :hammer: |
+| [vue/no-multiple-objects-in-class] | disallow passing multiple objects in an array to class |  | :hammer: |
 | [vue/no-potential-component-option-typo] | disallow a potential typo in your component property | :bulb: | :hammer: |
 | [vue/no-ref-object-reactivity-loss] | disallow usages of ref objects that can lead to loss of reactivity |  | :warning: |
 | [vue/no-required-prop-with-default] | enforce props with default values to be optional | :wrench::bulb: | :warning: |

--- a/docs/rules/no-multiple-objects-in-class.md
+++ b/docs/rules/no-multiple-objects-in-class.md
@@ -2,13 +2,13 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/no-multiple-objects-in-class
-description: disallow to pass multiple objects into array to class
+description: disallow passing multiple objects in an array to class
 since: v7.0.0
 ---
 
 # vue/no-multiple-objects-in-class
 
-> disallow to pass multiple objects into array to class
+> disallow passing multiple objects in an array to class
 
 ## :book: Rule Details
 

--- a/lib/rules/no-multiple-objects-in-class.js
+++ b/lib/rules/no-multiple-objects-in-class.js
@@ -21,7 +21,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'disallow to pass multiple objects into array to class',
+      description: 'disallow passing multiple objects in an array to class',
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/no-multiple-objects-in-class.html'
     },


### PR DESCRIPTION
This phrasing is more correct 🙂 