### PR TITLE
fix(no-multiple-slot-args): improve grammar of description

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -179,7 +179,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/attributes-order] | enforce order of attributes | :wrench: | :three::two::hammer: |
 | [vue/component-tags-order] | enforce order of component top-level elements | :wrench::no_entry_sign: | :three::two::hammer: |
 | [vue/no-lone-template] | disallow unnecessary `<template>` |  | :three::two::warning: |
-| [vue/no-multiple-slot-args] | disallow to pass multiple arguments to scoped slots |  | :three::two::warning: |
+| [vue/no-multiple-slot-args] | disallow passing multiple arguments to scoped slots |  | :three::two::warning: |
 | [vue/no-v-html] | disallow use of v-html to prevent XSS attack |  | :three::two::hammer: |
 | [vue/order-in-components] | enforce order of properties in components | :wrench::bulb: | :three::two::hammer: |
 | [vue/this-in-template] | disallow usage of `this` in template | :wrench: | :three::two::hammer: |

--- a/docs/rules/no-multiple-slot-args.md
+++ b/docs/rules/no-multiple-slot-args.md
@@ -2,13 +2,13 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/no-multiple-slot-args
-description: disallow to pass multiple arguments to scoped slots
+description: disallow passing multiple arguments to scoped slots
 since: v7.0.0
 ---
 
 # vue/no-multiple-slot-args
 
-> disallow to pass multiple arguments to scoped slots
+> disallow passing multiple arguments to scoped slots
 
 - :gear: This rule is included in all of `"plugin:vue/vue3-recommended"`, `*.configs["flat/recommended"]`, `"plugin:vue/recommended"` and `*.configs["flat/vue2-recommended"]`.
 

--- a/lib/rules/no-multiple-slot-args.js
+++ b/lib/rules/no-multiple-slot-args.js
@@ -11,7 +11,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'disallow to pass multiple arguments to scoped slots',
+      description: 'disallow passing multiple arguments to scoped slots',
       categories: ['vue3-recommended', 'vue2-recommended'],
       url: 'https://eslint.vuejs.org/rules/no-multiple-slot-args.html'
     },


### PR DESCRIPTION
This phrasing is more correct 🙂 