### PR TITLE
Add `defaultOptions` to all rules

### DIFF
--- a/eslint-internal-rules/no-invalid-meta-default-options.js
+++ b/eslint-internal-rules/no-invalid-meta-default-options.js
@@ -1,0 +1,156 @@
+/**
+ * @fileoverview Internal rule to enforce valid default options.
+ * @author Flo Edelmann
+ */
+
+'use strict'
+
+const Ajv = require('ajv')
+const metaSchema = require('ajv/lib/refs/json-schema-draft-04.json')
+
+// from https://github.com/eslint/eslint/blob/main/lib/shared/ajv.js
+const ajv = new Ajv({
+  meta: false,
+  useDefaults: true,
+  validateSchema: false,
+  missingRefs: 'ignore',
+  verbose: true,
+  schemaId: 'auto'
+})
+ajv.addMetaSchema(metaSchema)
+ajv._opts.defaultMeta = metaSchema.id
+
+// from https://github.com/eslint/eslint/blob/main/lib/config/flat-config-helpers.js
+const noOptionsSchema = Object.freeze({
+  type: 'array',
+  minItems: 0,
+  maxItems: 0
+})
+function getRuleOptionsSchema(schema) {
+  if (schema === false || typeof schema !== 'object' || schema === null) {
+    return null
+  }
+
+  if (!Array.isArray(schema)) {
+    return schema
+  }
+
+  if (schema.length === 0) {
+    return { ...noOptionsSchema }
+  }
+
+  return {
+    type: 'array',
+    items: schema,
+    minItems: 0,
+    maxItems: schema.length
+  }
+}
+
+/**
+ * @param {RuleContext} context
+ * @param {ASTNode} node
+ * @returns {any}
+ */
+function getNodeValue(context, node) {
+  try {
+    // eslint-disable-next-line no-eval
+    return eval(context.getSourceCode().getText(node))
+  } catch (error) {
+    return undefined
+  }
+}
+
+/**
+ * Gets the property of the Object node passed in that has the name specified.
+ *
+ * @param {string} propertyName Name of the property to return.
+ * @param {ASTNode} node The ObjectExpression node.
+ * @returns {ASTNode} The Property node or null if not found.
+ */
+function getPropertyFromObject(propertyName, node) {
+  if (node && node.type === 'ObjectExpression') {
+    for (const property of node.properties) {
+      if (property.type === 'Property' && property.key.name === propertyName) {
+        return property
+      }
+    }
+  }
+  return null
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'enforce correct use of `meta` property in core rules',
+      categories: ['Internal']
+    },
+    schema: [],
+    messages: {
+      defaultOptionsNotMatchingSchema:
+        'Default options do not match the schema.'
+    }
+  },
+
+  create(context) {
+    /** @type {ASTNode} */
+    let exportsNode
+
+    return {
+      AssignmentExpression(node) {
+        if (
+          node.left &&
+          node.right &&
+          node.left.type === 'MemberExpression' &&
+          node.left.object.name === 'module' &&
+          node.left.property.name === 'exports'
+        ) {
+          exportsNode = node.right
+        }
+      },
+
+      'Program:exit'() {
+        const metaProperty = getPropertyFromObject('meta', exportsNode)
+        if (!metaProperty) {
+          return
+        }
+
+        const metaSchema = getPropertyFromObject('schema', metaProperty.value)
+        const metaDefaultOptions = getPropertyFromObject(
+          'defaultOptions',
+          metaProperty.value
+        )
+
+        if (
+          !metaSchema ||
+          !metaDefaultOptions ||
+          metaDefaultOptions.value.type !== 'ArrayExpression'
+        ) {
+          return
+        }
+
+        const defaultOptions = getNodeValue(context, metaDefaultOptions.value)
+        const schema = getNodeValue(context, metaSchema.value)
+
+        if (!defaultOptions || !schema) {
+          return
+        }
+
+        let validate
+        try {
+          validate = ajv.compile(getRuleOptionsSchema(schema))
+        } catch (error) {
+          return
+        }
+
+        if (!validate(defaultOptions)) {
+          context.report({
+            node: metaDefaultOptions.value,
+            messageId: 'defaultOptionsNotMatchingSchema'
+          })
+        }
+      }
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ module.exports = [
       internal: {
         rules: {
           'no-invalid-meta': require('./eslint-internal-rules/no-invalid-meta'),
+          'no-invalid-meta-default-options': require('./eslint-internal-rules/no-invalid-meta-default-options'),
           'no-invalid-meta-docs-categories': require('./eslint-internal-rules/no-invalid-meta-docs-categories'),
           'require-eslint-community': require('./eslint-internal-rules/require-eslint-community')
         }
@@ -224,6 +225,7 @@ module.exports = [
         { pattern: 'https://eslint.vuejs.org/rules/{{name}}.html' }
       ],
       'internal/no-invalid-meta': 'error',
+      'internal/no-invalid-meta-default-options': 'error',
       'internal/no-invalid-meta-docs-categories': 'error'
     }
   },
@@ -232,6 +234,7 @@ module.exports = [
     rules: {
       'eslint-plugin/require-meta-docs-url': 'off',
       'internal/no-invalid-meta': 'error',
+      'internal/no-invalid-meta-default-options': 'error',
       'internal/no-invalid-meta-docs-categories': 'error'
     }
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,6 @@ module.exports = [
   // turn off some rules from shared configs in all files
   {
     rules: {
-      'eslint-plugin/require-meta-default-options': 'off', // TODO: enable when all rules have defaultOptions
       'eslint-plugin/require-meta-docs-recommended': 'off', // use `categories` instead
       'eslint-plugin/require-meta-schema-description': 'off',
 

--- a/lib/rules/attribute-hyphenation.js
+++ b/lib/rules/attribute-hyphenation.js
@@ -68,6 +68,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      'always',
+      {
+        ignore: [],
+        ignoreTags: []
+      }
+    ],
     messages: {
       mustBeHyphenated: "Attribute '{{text}}' must be hyphenated.",
       cannotBeHyphenated: "Attribute '{{text}}' can't be hyphenated."

--- a/lib/rules/attributes-order.js
+++ b/lib/rules/attributes-order.js
@@ -455,6 +455,24 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        order: [
+          ATTRS.DEFINITION,
+          ATTRS.LIST_RENDERING,
+          ATTRS.CONDITIONALS,
+          ATTRS.RENDER_MODIFIERS,
+          ATTRS.GLOBAL,
+          [ATTRS.UNIQUE, ATTRS.SLOT],
+          ATTRS.TWO_WAY_BINDING,
+          ATTRS.OTHER_DIRECTIVES,
+          [ATTRS.ATTR_DYNAMIC, ATTRS.ATTR_STATIC, ATTRS.ATTR_SHORTHAND_BOOL],
+          ATTRS.EVENTS,
+          ATTRS.CONTENT
+        ],
+        alphabetical: false
+      }
+    ],
     messages: {
       expectedOrder: `Attribute "{{currentNode}}" should go before "{{prevNode}}".`
     }

--- a/lib/rules/block-lang.js
+++ b/lib/rules/block-lang.js
@@ -151,6 +151,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        script: { allowNoLang: true },
+        template: { allowNoLang: true },
+        style: { allowNoLang: true }
+      }
+    ],
     messages: {
       expected:
         "Only {{allows}} can be used for the 'lang' attribute of '<{{tag}}>'.",

--- a/lib/rules/block-order.js
+++ b/lib/rules/block-order.js
@@ -61,6 +61,11 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        order: [['script', 'template'], 'style']
+      }
+    ],
     messages: {
       unexpected:
         "'<{{elementName}}{{elementAttributes}}>' should be above '<{{firstUnorderedName}}{{firstUnorderedAttributes}}>' on line {{line}}."

--- a/lib/rules/block-tag-newline.js
+++ b/lib/rules/block-tag-newline.js
@@ -71,6 +71,14 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        singleline: 'consistent',
+        multiline: 'always',
+        maxEmptyLines: 0,
+        blocks: {}
+      }
+    ],
     messages: {
       unexpectedOpeningLinebreak:
         "There should be no line break after '<{{tag}}>'.",

--- a/lib/rules/comment-directive.js
+++ b/lib/rules/comment-directive.js
@@ -289,6 +289,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ reportUnusedDisableDirectives: false }],
     messages: {
       disableBlock: '--block {{key}}',
       enableBlock: '++block',

--- a/lib/rules/component-api-style.js
+++ b/lib/rules/component-api-style.js
@@ -216,6 +216,7 @@ module.exports = {
         minItems: 1
       }
     ],
+    defaultOptions: [['script-setup', 'composition']],
     messages: {
       disallowScriptSetup:
         '`<script setup>` is not allowed in your project. Use {{allowedApis}} instead.',

--- a/lib/rules/component-definition-name-casing.js
+++ b/lib/rules/component-definition-name-casing.js
@@ -35,6 +35,7 @@ module.exports = {
         enum: allowedCaseOptions
       }
     ],
+    defaultOptions: ['PascalCase'],
     messages: {
       incorrectCase: 'Property name "{{value}}" is not {{caseType}}.'
     }

--- a/lib/rules/component-name-in-template-casing.js
+++ b/lib/rules/component-name-in-template-casing.js
@@ -70,6 +70,14 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      defaultCase,
+      {
+        globals: [],
+        ignores: [],
+        registeredComponentsOnly: true
+      }
+    ],
     messages: {
       incorrectCase: 'Component name "{{name}}" is not {{caseType}}.'
     }

--- a/lib/rules/component-options-name-casing.js
+++ b/lib/rules/component-options-name-casing.js
@@ -33,6 +33,7 @@ module.exports = {
     fixable: 'code',
     hasSuggestions: true,
     schema: [{ enum: casing.allowedCaseOptions }],
+    defaultOptions: ['PascalCase'],
     messages: {
       caseNotMatched: 'Component name "{{component}}" is not {{caseType}}.',
       possibleRenaming: 'Rename component name to be in {{caseType}}.'

--- a/lib/rules/custom-event-name-casing.js
+++ b/lib/rules/custom-event-name-casing.js
@@ -13,7 +13,6 @@ const { toRegExp } = require('../utils/regexp')
  * @typedef {import('../utils').VueObjectData} VueObjectData
  */
 
-const ALLOWED_CASE_OPTIONS = ['kebab-case', 'camelCase']
 const DEFAULT_CASE = 'camelCase'
 
 /**
@@ -81,7 +80,7 @@ module.exports = {
           type: 'array',
           items: [
             {
-              enum: ALLOWED_CASE_OPTIONS
+              enum: ['kebab-case', 'camelCase']
             },
             OBJECT_OPTION_SCHEMA
           ]
@@ -93,6 +92,7 @@ module.exports = {
         }
       ]
     },
+    defaultOptions: ['camelCase', { ignores: [] }],
     messages: {
       unexpected: "Custom event name '{{name}}' must be {{caseType}}."
     }

--- a/lib/rules/define-emits-declaration.js
+++ b/lib/rules/define-emits-declaration.js
@@ -25,6 +25,7 @@ module.exports = {
         enum: ['type-based', 'type-literal', 'runtime']
       }
     ],
+    defaultOptions: ['type-based'],
     messages: {
       hasArg: 'Use type based declaration instead of runtime declaration.',
       hasTypeArg: 'Use runtime declaration instead of type based declaration.',

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -382,6 +382,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ order: DEFAULT_ORDER, defineExposeLast: false }],
     messages: {
       macrosNotOnTop:
         '{{macro}} should be the first statement in `<script setup>` (after any potential import statements or type definitions).',

--- a/lib/rules/define-props-declaration.js
+++ b/lib/rules/define-props-declaration.js
@@ -20,6 +20,7 @@ module.exports = {
         enum: ['type-based', 'runtime']
       }
     ],
+    defaultOptions: ['type-based'],
     messages: {
       hasArg: 'Use type-based declaration instead of runtime declaration.',
       hasTypeArg: 'Use runtime declaration instead of type-based declaration.'

--- a/lib/rules/enforce-style-attribute.js
+++ b/lib/rules/enforce-style-attribute.js
@@ -71,6 +71,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allow: ['scoped'] }],
     messages: {
       notAllowedScoped:
         'The scoped attribute is not allowed. Allowed: {{ allowedAttrsString }}.',

--- a/lib/rules/first-attribute-linebreak.js
+++ b/lib/rules/first-attribute-linebreak.js
@@ -25,6 +25,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ multiline: 'below', singleline: 'ignore' }],
     messages: {
       expected: 'Expected a linebreak before this attribute.',
       unexpected: 'Expected no linebreak before this attribute.'

--- a/lib/rules/html-button-has-type.js
+++ b/lib/rules/html-button-has-type.js
@@ -42,6 +42,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ button: true, submit: true, reset: true }],
     messages: {
       missingTypeAttribute: 'Missing an explicit type attribute for button.',
       invalidTypeAttribute:

--- a/lib/rules/html-closing-bracket-newline.js
+++ b/lib/rules/html-closing-bracket-newline.js
@@ -92,6 +92,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        singleline: 'never',
+        multiline: 'always',
+        selfClosingTag: undefined
+      }
+    ],
     messages: {
       expectedBeforeClosingBracket:
         'Expected {{expected}} before closing bracket, but {{actual}} found.'

--- a/lib/rules/html-closing-bracket-spacing.js
+++ b/lib/rules/html-closing-bracket-spacing.js
@@ -71,6 +71,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        startTag: 'never',
+        endTag: 'never',
+        selfClosingTag: 'always'
+      }
+    ],
     messages: {
       missing: "Expected a space before '{{bracket}}', but not found.",
       unexpected: "Expected no space before '{{bracket}}', but found."

--- a/lib/rules/html-comment-content-newline.js
+++ b/lib/rules/html-comment-content-newline.js
@@ -68,6 +68,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        singleline: 'never',
+        multiline: 'always'
+      },
+      { exceptions: [] }
+    ],
     messages: {
       expectedAfterHTMLCommentOpen: "Expected line break after '<!--'.",
       expectedBeforeHTMLCommentOpen: "Expected line break before '-->'.",

--- a/lib/rules/html-comment-content-spacing.js
+++ b/lib/rules/html-comment-content-spacing.js
@@ -37,6 +37,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: ['always', { exceptions: [] }],
     messages: {
       expectedAfterHTMLCommentOpen: "Expected space after '<!--'.",
       expectedBeforeHTMLCommentOpen: "Expected space before '-->'.",

--- a/lib/rules/html-comment-indent.js
+++ b/lib/rules/html-comment-indent.js
@@ -71,6 +71,7 @@ module.exports = {
         oneOf: [{ type: 'integer', minimum: 0 }, { enum: ['tab'] }]
       }
     ],
+    defaultOptions: [2],
     messages: {
       unexpectedBaseIndentation:
         'Expected base point indentation of {{expected}}, but found {{actual}}.',

--- a/lib/rules/html-indent.js
+++ b/lib/rules/html-indent.js
@@ -71,6 +71,21 @@ module.exports = {
         },
         additionalProperties: false
       }
+    ],
+    defaultOptions: [
+      2,
+      {
+        attribute: 1,
+        baseIndent: 1,
+        closeBracket: {
+          startTag: 0,
+          endTag: 0,
+          selfClosingTag: 0
+        },
+        switchCase: 0,
+        alignAttributesVertically: true,
+        ignores: []
+      }
     ]
   }
 }

--- a/lib/rules/html-quotes.js
+++ b/lib/rules/html-quotes.js
@@ -28,6 +28,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: ['double', { avoidEscape: false }],
     messages: {
       expected: 'Expected to be enclosed by {{kind}}.'
     }

--- a/lib/rules/html-self-closing.js
+++ b/lib/rules/html-self-closing.js
@@ -120,6 +120,17 @@ module.exports = {
       ],
       maxItems: 1
     },
+    defaultOptions: [
+      {
+        html: {
+          normal: 'always',
+          void: 'never',
+          component: 'always'
+        },
+        svg: 'always',
+        math: 'always'
+      }
+    ],
     messages: {
       requireSelfClosing:
         'Require self-closing on {{elementType}} (<{{name}}>).',

--- a/lib/rules/match-component-file-name.js
+++ b/lib/rules/match-component-file-name.js
@@ -50,6 +50,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ extensions: ['jsx'], shouldMatchCase: false }],
     messages: {
       shouldMatchFileName:
         'Component name `{{name}}` should match file name `{{filename}}`.'

--- a/lib/rules/max-attributes-per-line.js
+++ b/lib/rules/max-attributes-per-line.js
@@ -113,6 +113,12 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        singleline: 1,
+        multiline: 1
+      }
+    ],
     messages: {
       shouldBeOnNewLine: "'{{name}}' should be on a new line."
     }

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -184,6 +184,25 @@ module.exports = {
       OPTIONS_OR_INTEGER_SCHEMA,
       OPTIONS_SCHEMA
     ],
+    defaultOptions: [
+      undefined,
+      undefined,
+      {
+        code: 80,
+        template: undefined,
+        tabWidth: 2, // default value of `vue/html-indent`
+        comments: undefined,
+        ignorePattern: undefined,
+        ignoreComments: false,
+        ignoreTrailingComments: false,
+        ignoreUrls: false,
+        ignoreStrings: false,
+        ignoreTemplateLiterals: false,
+        ignoreRegExpLiterals: false,
+        ignoreHTMLAttributeValues: false,
+        ignoreHTMLTextContents: false
+      }
+    ],
     messages: {
       max: 'This line has a length of {{lineLength}}. Maximum allowed is {{maxLength}}.',
       maxComment:

--- a/lib/rules/max-lines-per-block.js
+++ b/lib/rules/max-lines-per-block.js
@@ -47,6 +47,14 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        style: undefined,
+        template: undefined,
+        script: undefined,
+        skipBlankLines: false
+      }
+    ],
     messages: {
       tooManyLines:
         'Block has too many lines ({{lineCount}}). Maximum allowed is {{limit}}.'

--- a/lib/rules/max-props.js
+++ b/lib/rules/max-props.js
@@ -27,6 +27,7 @@ module.exports = {
         minProperties: 1
       }
     ],
+    defaultOptions: [{ maxProps: 1 }],
     messages: {
       tooManyProps:
         'Component has too many props ({{propCount}}). Maximum allowed is {{limit}}.'

--- a/lib/rules/max-template-depth.js
+++ b/lib/rules/max-template-depth.js
@@ -26,6 +26,7 @@ module.exports = {
         minProperties: 1
       }
     ],
+    defaultOptions: [{ maxDepth: 1 }],
     messages: {
       templateTooDeep:
         'Element is nested too deeply (depth of {{depth}}, maximum allowed is {{limit}}).'

--- a/lib/rules/multi-word-component-names.js
+++ b/lib/rules/multi-word-component-names.js
@@ -34,6 +34,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignores: [] }],
     messages: {
       unexpected: 'Component name "{{value}}" should always be multi-word.'
     }

--- a/lib/rules/multiline-html-element-content-newline.js
+++ b/lib/rules/multiline-html-element-content-newline.js
@@ -85,6 +85,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        ignores: ['pre', 'textarea', ...INLINE_ELEMENTS],
+        ignoreWhenEmpty: true,
+        allowEmptyLines: false
+      }
+    ],
     messages: {
       unexpectedAfterClosingBracket:
         'Expected 1 line break after opening tag (`<{{name}}>`), but {{actual}} line breaks found.',

--- a/lib/rules/mustache-interpolation-spacing.js
+++ b/lib/rules/mustache-interpolation-spacing.js
@@ -20,6 +20,7 @@ module.exports = {
         enum: ['always', 'never']
       }
     ],
+    defaultOptions: ['always'],
     messages: {
       expectedSpaceAfter: "Expected 1 space after '{{', but not found.",
       expectedSpaceBefore: "Expected 1 space before '}}', but not found.",

--- a/lib/rules/new-line-between-multi-line-property.js
+++ b/lib/rules/new-line-between-multi-line-property.js
@@ -68,6 +68,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ minLineOfMultilineProperty: 2 }],
     messages: {
       missingEmptyLine:
         'Enforce new lines between multi-line properties in Vue components.'

--- a/lib/rules/next-tick-style.js
+++ b/lib/rules/next-tick-style.js
@@ -89,6 +89,7 @@ module.exports = {
     },
     fixable: 'code',
     schema: [{ enum: ['promise', 'callback'] }],
+    defaultOptions: ['promise'],
     messages: {
       usePromise:
         'Use the Promise returned by `nextTick` instead of passing a callback function.',

--- a/lib/rules/no-bare-strings-in-template.js
+++ b/lib/rules/no-bare-strings-in-template.js
@@ -137,6 +137,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        allowlist: DEFAULT_ALLOWLIST,
+        attributes: DEFAULT_ATTRIBUTES,
+        directives: DEFAULT_DIRECTIVES
+      }
+    ],
     messages: {
       unexpected: 'Unexpected non-translated string used.',
       unexpectedInAttr: 'Unexpected non-translated string used in `{{attr}}`.'

--- a/lib/rules/no-boolean-default.js
+++ b/lib/rules/no-boolean-default.js
@@ -53,6 +53,7 @@ module.exports = {
         enum: ['default-false', 'no-default']
       }
     ],
+    defaultOptions: ['no-default'],
     messages: {
       noBooleanDefault:
         'Boolean prop should not set a default (Vue defaults it to false).',

--- a/lib/rules/no-child-content.js
+++ b/lib/rules/no-child-content.js
@@ -96,6 +96,8 @@ module.exports = {
         required: ['additionalDirectives']
       }
     ],
+    // eslint-disable-next-line internal/no-invalid-meta-default-options -- minItems intentionally violated for default options
+    defaultOptions: [{ additionalDirectives: [] }],
     messages: {
       disallowedChildContent:
         'Child content is disallowed because it will be overwritten by the v-{{ directiveName }} directive.',

--- a/lib/rules/no-deprecated-model-definition.js
+++ b/lib/rules/no-deprecated-model-definition.js
@@ -61,6 +61,7 @@ module.exports = {
         }
       }
     ],
+    defaultOptions: [{ allowVue3Compat: false }],
     messages: {
       deprecatedModel: '`model` definition is deprecated.',
       vue3Compat:

--- a/lib/rules/no-deprecated-router-link-tag-prop.js
+++ b/lib/rules/no-deprecated-router-link-tag-prop.js
@@ -49,6 +49,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ components: ['RouterLink'] }],
     messages: {
       deprecated:
         "'tag' property on '{{element}}' component is deprecated. Use scoped slots instead."

--- a/lib/rules/no-deprecated-slot-attribute.js
+++ b/lib/rules/no-deprecated-slot-attribute.js
@@ -30,6 +30,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignore: [] }],
     messages: {
       forbiddenSlotAttribute: '`slot` attributes are deprecated.'
     }

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -78,6 +78,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ groups: [] }],
     messages: {
       duplicateKey:
         "Duplicate key '{{name}}'. May cause name collision in script or template tag."

--- a/lib/rules/no-duplicate-attr-inheritance.js
+++ b/lib/rules/no-duplicate-attr-inheritance.js
@@ -54,6 +54,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ checkMultiRootNodes: false }],
     messages: {
       noDuplicateAttrInheritance: 'Set "inheritAttrs" to false.'
     }

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -51,6 +51,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allowCoexistClass: true, allowCoexistStyle: true }],
     messages: {
       duplicateAttribute: "Duplicate attribute '{{name}}'."
     }

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -41,6 +41,16 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        skipComments: false,
+        skipStrings: true,
+        skipTemplates: false,
+        skipRegExps: false,
+        skipHTMLAttributeValues: false,
+        skipHTMLTextContents: false
+      }
+    ],
     messages: {
       disallow: 'Irregular whitespace not allowed.'
     }

--- a/lib/rules/no-lone-template.js
+++ b/lib/rules/no-lone-template.js
@@ -56,6 +56,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignoreAccessible: false }],
     messages: {
       requireDirective: '`<template>` require directive.'
     }

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -35,6 +35,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignoreProperties: false }],
     messages: {
       multipleSpaces: "Multiple spaces found before '{{displayValue}}'.",
       useLatestParser:

--- a/lib/rules/no-mutating-props.js
+++ b/lib/rules/no-mutating-props.js
@@ -121,6 +121,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ shallowOnly: false }],
     messages: {
       unexpectedMutation: 'Unexpected mutation of "{{key}}" prop.'
     }

--- a/lib/rules/no-parsing-error.js
+++ b/lib/rules/no-parsing-error.js
@@ -68,6 +68,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [DEFAULT_OPTIONS],
     messages: {
       parsingError: 'Parsing error: {{message}}.'
     }

--- a/lib/rules/no-potential-component-option-typo.js
+++ b/lib/rules/no-potential-component-option-typo.js
@@ -43,6 +43,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        presets: ['vue'],
+        custom: [],
+        threshold: 1
+      }
+    ],
     messages: {
       potentialTypo: `'{{name}}' may be a typo, which is similar to option [{{option}}].`
     }

--- a/lib/rules/no-required-prop-with-default.js
+++ b/lib/rules/no-required-prop-with-default.js
@@ -33,6 +33,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ autofix: false }],
     messages: {
       requireOptional: `Prop "{{ key }}" should be optional.`,
       fixRequiredProp: `Change this prop to be optional.`

--- a/lib/rules/no-reserved-component-names.js
+++ b/lib/rules/no-reserved-component-names.js
@@ -85,6 +85,13 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        disallowVueBuiltInComponents: false,
+        disallowVue3BuiltInComponents: false,
+        htmlElementCaseSensitive: false
+      }
+    ],
     messages: {
       reserved: 'Name "{{name}}" is reserved.',
       reservedInHtml: 'Name "{{name}}" is reserved in HTML.',

--- a/lib/rules/no-reserved-keys.js
+++ b/lib/rules/no-reserved-keys.js
@@ -44,6 +44,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ reserved: [], groups: [] }],
     messages: {
       reserved: "Key '{{name}}' is reserved.",
       startsWithUnderscore:

--- a/lib/rules/no-reserved-props.js
+++ b/lib/rules/no-reserved-props.js
@@ -39,6 +39,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ vueVersion: 3 }],
     messages: {
       reserved:
         "'{{propName}}' is a reserved attribute and cannot be used as props."

--- a/lib/rules/no-restricted-block.js
+++ b/lib/rules/no-restricted-block.js
@@ -79,7 +79,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
-
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restrictedBlock: '{{message}}'

--- a/lib/rules/no-restricted-call-after-await.js
+++ b/lib/rules/no-restricted-call-after-await.js
@@ -61,6 +61,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restricted: '{{message}}'

--- a/lib/rules/no-restricted-class.js
+++ b/lib/rules/no-restricted-class.js
@@ -116,6 +116,7 @@ module.exports = {
         type: 'string'
       }
     },
+    defaultOptions: [],
     messages: {
       forbiddenClass: "'{{class}}' class is not allowed."
     }

--- a/lib/rules/no-restricted-component-names.js
+++ b/lib/rules/no-restricted-component-names.js
@@ -96,6 +96,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       disallow: '{{message}}',

--- a/lib/rules/no-restricted-component-options.js
+++ b/lib/rules/no-restricted-component-options.js
@@ -159,7 +159,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
-
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restrictedOption: '{{message}}'

--- a/lib/rules/no-restricted-custom-event.js
+++ b/lib/rules/no-restricted-custom-event.js
@@ -116,7 +116,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
-
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restrictedEvent: '{{message}}',

--- a/lib/rules/no-restricted-html-elements.js
+++ b/lib/rules/no-restricted-html-elements.js
@@ -34,6 +34,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
+    defaultOptions: [],
     messages: {
       forbiddenElement: 'Unexpected use of forbidden HTML element {{name}}.',
       // eslint-disable-next-line eslint-plugin/report-message-format

--- a/lib/rules/no-restricted-props.js
+++ b/lib/rules/no-restricted-props.js
@@ -81,7 +81,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
-
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restrictedProp: '{{message}}',

--- a/lib/rules/no-restricted-static-attribute.js
+++ b/lib/rules/no-restricted-static-attribute.js
@@ -127,7 +127,7 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
-
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restrictedAttr: '{{message}}'

--- a/lib/rules/no-restricted-v-bind.js
+++ b/lib/rules/no-restricted-v-bind.js
@@ -147,7 +147,13 @@ module.exports = {
       uniqueItems: true,
       minItems: 0
     },
-
+    defaultOptions: [
+      {
+        argument: '/^v-/',
+        message:
+          'Using `:v-xxx` is not allowed. Instead, remove `:` and use it as directive.'
+      }
+    ],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restrictedVBind: '{{message}}'

--- a/lib/rules/no-restricted-v-on.js
+++ b/lib/rules/no-restricted-v-on.js
@@ -148,6 +148,7 @@ module.exports = {
       },
       uniqueItems: true
     },
+    defaultOptions: [],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       restrictedVOn: '{{message}}'

--- a/lib/rules/no-static-inline-styles.js
+++ b/lib/rules/no-static-inline-styles.js
@@ -101,6 +101,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allowBinding: false }],
     messages: {
       forbiddenStaticInlineStyle: 'Static inline `style` are forbidden.',
       forbiddenStyleAttr: '`style` attributes are forbidden.'

--- a/lib/rules/no-template-shadow.js
+++ b/lib/rules/no-template-shadow.js
@@ -56,6 +56,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allow: [] }],
     messages: {
       alreadyDeclaredInUpperScope:
         "Variable '{{name}}' is already declared in the upper scope."

--- a/lib/rules/no-template-target-blank.js
+++ b/lib/rules/no-template-target-blank.js
@@ -117,6 +117,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allowReferrer: false, enforceDynamicLinks: 'always' }],
     messages: {
       missingRel:
         'Using target="_blank" without rel="noopener noreferrer" is a security risk.'

--- a/lib/rules/no-undef-components.js
+++ b/lib/rules/no-undef-components.js
@@ -125,6 +125,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignorePatterns: [] }],
     messages: {
       undef: "The '<{{name}}>' component has been used, but not defined.",
       typeOnly:

--- a/lib/rules/no-undef-properties.js
+++ b/lib/rules/no-undef-properties.js
@@ -98,6 +98,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignores: [String.raw`/^\$/`] }],
     messages: {
       undef: "'{{name}}' is not defined.",
       undefProps: "'{{name}}' is not defined in props."

--- a/lib/rules/no-unsupported-features.js
+++ b/lib/rules/no-unsupported-features.js
@@ -95,6 +95,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ version: undefined, ignores: [] }],
     messages: {
       // Vue.js 2.5.0+
       forbiddenSlotScopeAttribute:

--- a/lib/rules/no-unused-components.js
+++ b/lib/rules/no-unused-components.js
@@ -28,6 +28,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignoreWhenBindingPresent: true }],
     messages: {
       unused: 'The "{{name}}" component has been registered but not used.'
     }

--- a/lib/rules/no-unused-properties.js
+++ b/lib/rules/no-unused-properties.js
@@ -222,6 +222,14 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        groups: [GROUP_PROPERTY],
+        deepData: false,
+        ignorePublicMembers: false,
+        unreferencedOptions: []
+      }
+    ],
     messages: {
       unused: "'{{name}}' of {{group}} found, but never used."
     }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -71,6 +71,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ ignorePattern: '' }],
     messages: {
       unusedVariable: "'{{name}}' is defined but never used.",
       replaceWithUnderscore:

--- a/lib/rules/no-use-v-if-with-v-for.js
+++ b/lib/rules/no-use-v-if-with-v-for.js
@@ -54,6 +54,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allowUsingIterationVar: false }],
     messages: {
       movedToWrapper: "This 'v-if' should be moved to the wrapper element.",
       shouldUseComputed:

--- a/lib/rules/no-useless-mustaches.js
+++ b/lib/rules/no-useless-mustaches.js
@@ -52,6 +52,9 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      { ignoreIncludesComment: false, ignoreStringEscape: false }
+    ],
     messages: {
       unexpected:
         'Unexpected mustache interpolation with a string literal value.'

--- a/lib/rules/no-useless-v-bind.js
+++ b/lib/rules/no-useless-v-bind.js
@@ -32,6 +32,9 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      { ignoreIncludesComment: false, ignoreStringEscape: false }
+    ],
     messages: {
       unexpected: 'Unexpected `v-bind` with a string literal value.'
     }

--- a/lib/rules/no-v-text-v-html-on-component.js
+++ b/lib/rules/no-v-text-v-html-on-component.js
@@ -34,6 +34,12 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        allow: [],
+        ignoreElementNamespaces: false
+      }
+    ],
     messages: {
       disallow:
         "Using {{directiveName}} on component may break component's content."

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -230,6 +230,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ order: defaultOrder }],
     messages: {
       order:
         'The "{{name}}" property should be above the "{{firstUnorderedPropertyName}}" property on line {{line}}.',

--- a/lib/rules/padding-line-between-blocks.js
+++ b/lib/rules/padding-line-between-blocks.js
@@ -126,6 +126,7 @@ module.exports = {
         enum: Object.keys(PaddingTypes)
       }
     ],
+    defaultOptions: ['always'],
     messages: {
       never: 'Unexpected blank line before this block.',
       always: 'Expected blank line before this block.'

--- a/lib/rules/padding-line-between-tags.js
+++ b/lib/rules/padding-line-between-tags.js
@@ -190,6 +190,7 @@ module.exports = {
         }
       }
     ],
+    defaultOptions: [[{ blankLine: 'always', prev: '*', next: '*' }]],
     messages: {
       never: 'Unexpected blank line before this tag.',
       always: 'Expected blank line before this tag.'

--- a/lib/rules/padding-lines-in-component-definition.js
+++ b/lib/rules/padding-lines-in-component-definition.js
@@ -164,6 +164,7 @@ module.exports = {
         ]
       }
     ],
+    defaultOptions: [AvailablePaddingOptions.Always],
     messages: {
       never: 'Unexpected blank line before this definition.',
       always: 'Expected blank line before this definition.',

--- a/lib/rules/prefer-true-attribute-shorthand.js
+++ b/lib/rules/prefer-true-attribute-shorthand.js
@@ -18,6 +18,7 @@ module.exports = {
     fixable: null,
     hasSuggestions: true,
     schema: [{ enum: ['always', 'never'] }],
+    defaultOptions: ['always'],
     messages: {
       expectShort:
         "Boolean prop with 'true' value should be written in shorthand form.",

--- a/lib/rules/prop-name-casing.js
+++ b/lib/rules/prop-name-casing.js
@@ -66,6 +66,7 @@ module.exports = {
         enum: allowedCaseOptions
       }
     ],
+    defaultOptions: ['camelCase'],
     messages: {
       invalidCase: 'Prop "{{name}}" is not in {{caseType}}.'
     }

--- a/lib/rules/require-direct-export.js
+++ b/lib/rules/require-direct-export.js
@@ -24,6 +24,11 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        disallowFunctionalComponentFunction: false
+      }
+    ],
     messages: {
       expectedDirectExport:
         'Expected the component literal to be directly exported.'

--- a/lib/rules/require-explicit-emits.js
+++ b/lib/rules/require-explicit-emits.js
@@ -92,6 +92,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allowProps: false }],
     messages: {
       missing:
         'The "{{name}}" event has been triggered but not declared on {{emitsKind}}.',

--- a/lib/rules/require-macro-variable-name.js
+++ b/lib/rules/require-macro-variable-name.js
@@ -37,6 +37,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [DEFAULT_OPTIONS],
     messages: {
       requireName:
         'The variable name of "{{macroName}}" must be "{{variableName}}".',

--- a/lib/rules/require-prop-comment.js
+++ b/lib/rules/require-prop-comment.js
@@ -25,6 +25,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ type: 'JSDoc' }],
     messages: {
       requireAnyComment: 'The "{{name}}" property should have a comment.',
       requireLineComment: 'The "{{name}}" property should have a line comment.',

--- a/lib/rules/require-toggle-inside-transition.js
+++ b/lib/rules/require-toggle-inside-transition.js
@@ -64,6 +64,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ additionalDirectives: [] }],
     messages: {
       expected:
         'The element inside `<transition>` is expected to have a {{allowedDirectives}} directive.'

--- a/lib/rules/restricted-component-names.js
+++ b/lib/rules/restricted-component-names.js
@@ -44,6 +44,7 @@ module.exports = {
         }
       }
     ],
+    defaultOptions: [{ allow: [] }],
     messages: {
       invalidName: 'Component name "{{name}}" is not allowed.'
     }

--- a/lib/rules/return-in-computed-property.js
+++ b/lib/rules/return-in-computed-property.js
@@ -31,6 +31,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ treatUndefinedAsUnspecified: true }],
     messages: {
       expectedReturnInFunction:
         'Expected to return a value in computed function.',

--- a/lib/rules/script-indent.js
+++ b/lib/rules/script-indent.js
@@ -41,7 +41,8 @@ module.exports = {
         },
         additionalProperties: false
       }
-    ]
+    ],
+    defaultOptions: [2, { baseIndent: 0, switchCase: 0, ignores: [] }]
   },
   /** @param {RuleContext} context */
   create(context) {

--- a/lib/rules/singleline-html-element-content-newline.js
+++ b/lib/rules/singleline-html-element-content-newline.js
@@ -79,6 +79,14 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      {
+        ignores: ['pre', 'textarea', ...INLINE_ELEMENTS],
+        externalIgnores: [],
+        ignoreWhenNoAttributes: true,
+        ignoreWhenEmpty: true
+      }
+    ],
     messages: {
       unexpectedAfterClosingBracket:
         'Expected 1 line break after opening tag (`<{{name}}>`), but no line breaks found.',

--- a/lib/rules/slot-name-casing.js
+++ b/lib/rules/slot-name-casing.js
@@ -38,6 +38,7 @@ module.exports = {
         enum: allowedCaseOptions
       }
     ],
+    defaultOptions: ['camelCase'],
     messages: {
       invalidCase: 'Slot name "{{name}}" is not {{caseType}}.'
     }

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -104,6 +104,22 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      'asc',
+      {
+        caseSensitive: true,
+        ignoreChildrenOf: ['model'],
+        ignoreGrandchildrenOf: [
+          'computed',
+          'directives',
+          'inject',
+          'props',
+          'watch'
+        ],
+        minKeys: 2,
+        natural: false
+      }
+    ],
     messages: {
       sortKeys:
         "Expected object keys to be in {{natural}}{{insensitive}}{{order}}ending order. '{{thisName}}' should be before '{{prevName}}'."

--- a/lib/rules/this-in-template.js
+++ b/lib/rules/this-in-template.js
@@ -21,6 +21,7 @@ module.exports = {
         enum: ['always', 'never']
       }
     ],
+    defaultOptions: ['never'],
     messages: {
       unexpected: "Unexpected usage of 'this'.",
       expected: "Expected 'this'."

--- a/lib/rules/v-bind-style.js
+++ b/lib/rules/v-bind-style.js
@@ -68,6 +68,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: ['shorthand', { sameNameShorthand: 'ignore' }],
     messages: {
       expectedLonghand: "Expected 'v-bind' before ':'.",
       unexpectedLonghand: "Unexpected 'v-bind' before ':'.",

--- a/lib/rules/v-for-delimiter-style.js
+++ b/lib/rules/v-for-delimiter-style.js
@@ -18,6 +18,7 @@ module.exports = {
     },
     fixable: 'code',
     schema: [{ enum: ['in', 'of'] }],
+    defaultOptions: ['in'],
     messages: {
       expected:
         "Expected '{{preferredDelimiter}}' instead of '{{usedDelimiter}}' in 'v-for'."

--- a/lib/rules/v-on-event-hyphenation.js
+++ b/lib/rules/v-on-event-hyphenation.js
@@ -47,6 +47,14 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      'always',
+      {
+        ignore: [],
+        ignoreTags: [],
+        autofix: false
+      }
+    ],
     messages: {
       // eslint-disable-next-line eslint-plugin/report-message-format
       mustBeHyphenated: "v-on event '{{text}}' must be hyphenated.",

--- a/lib/rules/v-on-function-call.js
+++ b/lib/rules/v-on-function-call.js
@@ -85,6 +85,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: ['never', { ignoreIncludesComment: false }],
     messages: {
       always: "Method calls inside of 'v-on' directives must have parentheses.",
       never:

--- a/lib/rules/v-on-handler-style.js
+++ b/lib/rules/v-on-handler-style.js
@@ -139,6 +139,10 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [
+      ['method', 'inline-function'],
+      { ignoreIncludesComment: false }
+    ],
     messages: {
       preferMethodOverInline:
         'Prefer method handler over inline handler in v-on.',

--- a/lib/rules/v-on-style.js
+++ b/lib/rules/v-on-style.js
@@ -17,6 +17,7 @@ module.exports = {
     },
     fixable: 'code',
     schema: [{ enum: ['shorthand', 'longform'] }],
+    defaultOptions: ['shorthand'],
     messages: {
       expectedShorthand: "Expected '@' instead of 'v-on:'.",
       expectedLonghand: "Expected 'v-on:' instead of '@'."

--- a/lib/rules/v-slot-style.js
+++ b/lib/rules/v-slot-style.js
@@ -106,6 +106,13 @@ module.exports = {
         ]
       }
     ],
+    defaultOptions: [
+      {
+        atComponent: 'v-slot',
+        default: 'shorthand',
+        named: 'shorthand'
+      }
+    ],
     messages: {
       expectedShorthand: "Expected '#{{argument}}' instead of '{{actual}}'.",
       expectedLongform:

--- a/lib/rules/valid-v-on.js
+++ b/lib/rules/valid-v-on.js
@@ -78,6 +78,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ modifiers: [] }],
     messages: {
       unsupportedModifier:
         "'v-on' directives don't support the modifier '{{modifier}}'.",

--- a/lib/rules/valid-v-slot.js
+++ b/lib/rules/valid-v-slot.js
@@ -256,6 +256,7 @@ module.exports = {
         additionalProperties: false
       }
     ],
+    defaultOptions: [{ allowModifiers: false }],
     messages: {
       ownerMustBeCustomElement:
         "'v-slot' directive must be owned by a custom element, but '{{name}}' is not.",


### PR DESCRIPTION
ESLint [v9.17.0](https://github.com/eslint/eslint/releases/tag/v9.15.0) introduced `defaultOptions`:

* Documentation: https://eslint.org/docs/latest/extend/custom-rules#option-defaults
* RFC: https://github.com/eslint/rfcs/tree/main/designs/2023-rule-options-defaults

Even though earlier ESLint versions don't have official support for this property (i.e. `context.options` returns the raw user-provided options rather than merged user options and default options), adding it shouldn't hurt.

In the future, we could write our own helper function to merge user options and default options and thus standardize how rules normalize the user-provided options. Also, we could automate (parts of) the rule docs' "Options" sections.