### PR TITLE
Change legacy base config so that vue-eslint-parser is only used for `.vue`

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -154,13 +154,12 @@ If you have issues with these, please also refer to the [FAQ](#does-not-work-wel
 
 ### Running ESLint from the command line
 
-If you want to run `eslint` from the command line, make sure you include the `.vue` extension using [the `--ext` option](https://eslint.org/docs/user-guide/configuring#specifying-target-files-to-lint) or a glob pattern, because ESLint targets only `.js` files by default.
+If you want to run `eslint` from the command line, ESLint will automatically check for the `.vue` extension if you use the config provided by the plugin.
 
 Examples:
 
 ```bash
-eslint --ext .js,.vue src
-eslint "src/**/*.{js,vue}"
+eslint src
 ```
 
 ::: tip
@@ -393,7 +392,7 @@ See also: "[How to use a custom parser?](#how-to-use-a-custom-parser)" section.
 
 1. Make sure your tool is set to lint `.vue` files.
 
-    - CLI targets only `.js` files by default. You have to specify additional extensions with the `--ext` option or glob patterns. E.g. `eslint "src/**/*.{js,vue}"` or `eslint src --ext .vue`. If you use `@vue/cli-plugin-eslint` and the `vue-cli-service lint` command - you don't have to worry about it.
+    - Make sure you are using the shareable config provided by `eslint-plugin-vue`.
     - If you are having issues with configuring editor, please read [editor integrations](#editor-integrations)
 
 ### Conflict with [Prettier]

--- a/lib/configs/base.js
+++ b/lib/configs/base.js
@@ -4,7 +4,6 @@
  * in order to update its content execute "npm run update"
  */
 module.exports = {
-  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: 'module'
@@ -17,5 +16,11 @@ module.exports = {
   rules: {
     'vue/comment-directive': 'error',
     'vue/jsx-uses-vars': 'error'
-  }
+  },
+  overrides: [
+    {
+      files: '*.vue',
+      parser: require.resolve('vue-eslint-parser')
+    }
+  ]
 }

--- a/tools/update-lib-configs.js
+++ b/tools/update-lib-configs.js
@@ -56,7 +56,6 @@ function formatCategory(category) {
  * in order to update its content execute "npm run update"
  */
 module.exports = {
-  parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: 'module'
@@ -68,7 +67,13 @@ module.exports = {
   plugins: [
     'vue'
   ],
-  rules: ${formatRules(category.rules, category.categoryId)}
+  rules: ${formatRules(category.rules, category.categoryId)},
+  overrides: [
+    {
+      files: '*.vue',
+      parser: require.resolve('vue-eslint-parser')
+    }
+  ]
 }
 `
   }


### PR DESCRIPTION
close #2036