### PR TITLE
Deprecate Vue 2 only rules

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -110,7 +110,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/valid-define-emits] | enforce valid `defineEmits` compiler macro |  | :three::two::warning: |
 | [vue/valid-define-options] | enforce valid `defineOptions` compiler macro |  | :three::warning: |
 | [vue/valid-define-props] | enforce valid `defineProps` compiler macro |  | :three::two::warning: |
-| [vue/valid-model-definition] | require valid keys in model option |  | :two::warning: |
+| [vue/valid-model-definition] | require valid keys in model option | :no_entry_sign: | :two::warning: |
 | [vue/valid-next-tick] | enforce valid `nextTick` function calls | :wrench::bulb: | :three::two::warning: |
 | [vue/valid-template-root] | enforce valid template root |  | :three::two::warning: |
 | [vue/valid-v-bind-sync] | enforce valid `.sync` modifier on `v-bind` directives |  | :two::warning: |
@@ -351,6 +351,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 |:--------|:------------|
 | [vue/no-v-for-template-key] | (no replacement) |
 | [vue/no-v-model-argument] | (no replacement) |
+| [vue/valid-model-definition] | (no replacement) |
 
 ## Removed
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -113,7 +113,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/valid-model-definition] | require valid keys in model option | :no_entry_sign: | :two::warning: |
 | [vue/valid-next-tick] | enforce valid `nextTick` function calls | :wrench::bulb: | :three::two::warning: |
 | [vue/valid-template-root] | enforce valid template root |  | :three::two::warning: |
-| [vue/valid-v-bind-sync] | enforce valid `.sync` modifier on `v-bind` directives |  | :two::warning: |
+| [vue/valid-v-bind-sync] | enforce valid `.sync` modifier on `v-bind` directives | :no_entry_sign: | :two::warning: |
 | [vue/valid-v-bind] | enforce valid `v-bind` directives |  | :three::two::warning: |
 | [vue/valid-v-cloak] | enforce valid `v-cloak` directives |  | :three::two::warning: |
 | [vue/valid-v-else-if] | enforce valid `v-else-if` directives |  | :three::two::warning: |
@@ -352,6 +352,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/no-v-for-template-key] | (no replacement) |
 | [vue/no-v-model-argument] | (no replacement) |
 | [vue/valid-model-definition] | (no replacement) |
+| [vue/valid-v-bind-sync] | (no replacement) |
 
 ## Removed
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -91,7 +91,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/no-use-v-if-with-v-for] | disallow using `v-if` on the same element as `v-for` |  | :three::two::hammer: |
 | [vue/no-useless-template-attributes] | disallow useless attribute on `<template>` |  | :three::two::warning: |
 | [vue/no-v-for-template-key-on-child] | disallow key of `<template v-for>` placed on child elements |  | :three::warning: |
-| [vue/no-v-for-template-key] | disallow `key` attribute on `<template v-for>` |  | :two::warning: |
+| [vue/no-v-for-template-key] | disallow `key` attribute on `<template v-for>` | :no_entry_sign: | :two::warning: |
 | [vue/no-v-model-argument] | disallow adding an argument to `v-model` used in custom component |  | :two::warning: |
 | [vue/no-v-text-v-html-on-component] | disallow v-text / v-html on component |  | :three::two::warning: |
 | [vue/no-watch-after-await] | disallow asynchronously registered `watch` |  | :three::hammer: |
@@ -341,6 +341,15 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | [vue/template-curly-spacing] | Require or disallow spacing around embedded expressions of template strings in `<template>` | :wrench: | :lipstick: |
 
 </rules-table>
+
+## Deprecated
+
+- :no_entry_sign: We're going to remove deprecated rules in the next major release. Please migrate to successor/new rules.
+- :innocent: We don't fix bugs which are in deprecated rules since we don't have enough resources.
+
+| Rule ID | Replaced by |
+|:--------|:------------|
+| [vue/no-v-for-template-key] | (no replacement) |
 
 ## Removed
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -92,7 +92,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/no-useless-template-attributes] | disallow useless attribute on `<template>` |  | :three::two::warning: |
 | [vue/no-v-for-template-key-on-child] | disallow key of `<template v-for>` placed on child elements |  | :three::warning: |
 | [vue/no-v-for-template-key] | disallow `key` attribute on `<template v-for>` | :no_entry_sign: | :two::warning: |
-| [vue/no-v-model-argument] | disallow adding an argument to `v-model` used in custom component |  | :two::warning: |
+| [vue/no-v-model-argument] | disallow adding an argument to `v-model` used in custom component | :no_entry_sign: | :two::warning: |
 | [vue/no-v-text-v-html-on-component] | disallow v-text / v-html on component |  | :three::two::warning: |
 | [vue/no-watch-after-await] | disallow asynchronously registered `watch` |  | :three::hammer: |
 | [vue/prefer-import-from-vue] | enforce import from 'vue' instead of import from '@vue/*' | :wrench: | :three::hammer: |
@@ -350,6 +350,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 | Rule ID | Replaced by |
 |:--------|:------------|
 | [vue/no-v-for-template-key] | (no replacement) |
+| [vue/no-v-model-argument] | (no replacement) |
 
 ## Removed
 

--- a/docs/rules/no-v-for-template-key.md
+++ b/docs/rules/no-v-for-template-key.md
@@ -10,6 +10,7 @@ since: v7.0.0
 
 > disallow `key` attribute on `<template v-for>`
 
+- :no_entry_sign: This rule was **deprecated**.
 - :gear: This rule is included in all of `"plugin:vue/vue2-essential"`, `*.configs["flat/vue2-essential"]`, `"plugin:vue/vue2-strongly-recommended"`, `*.configs["flat/vue2-strongly-recommended"]`, `"plugin:vue/vue2-recommended"` and `*.configs["flat/vue2-recommended"]`.
 
 ## :book: Rule Details

--- a/docs/rules/no-v-model-argument.md
+++ b/docs/rules/no-v-model-argument.md
@@ -10,6 +10,7 @@ since: v7.0.0
 
 > disallow adding an argument to `v-model` used in custom component
 
+- :no_entry_sign: This rule was **deprecated**.
 - :gear: This rule is included in all of `"plugin:vue/vue2-essential"`, `*.configs["flat/vue2-essential"]`, `"plugin:vue/vue2-strongly-recommended"`, `*.configs["flat/vue2-strongly-recommended"]`, `"plugin:vue/vue2-recommended"` and `*.configs["flat/vue2-recommended"]`.
 
 This rule checks whether `v-model` used on custom component do not have an argument.

--- a/docs/rules/valid-model-definition.md
+++ b/docs/rules/valid-model-definition.md
@@ -10,6 +10,7 @@ since: v9.0.0
 
 > require valid keys in model option
 
+- :no_entry_sign: This rule was **deprecated**.
 - :gear: This rule is included in all of `"plugin:vue/vue2-essential"`, `*.configs["flat/vue2-essential"]`, `"plugin:vue/vue2-strongly-recommended"`, `*.configs["flat/vue2-strongly-recommended"]`, `"plugin:vue/vue2-recommended"` and `*.configs["flat/vue2-recommended"]`.
 
 ## :book: Rule Details

--- a/docs/rules/valid-v-bind-sync.md
+++ b/docs/rules/valid-v-bind-sync.md
@@ -10,6 +10,7 @@ since: v7.0.0
 
 > enforce valid `.sync` modifier on `v-bind` directives
 
+- :no_entry_sign: This rule was **deprecated**.
 - :gear: This rule is included in all of `"plugin:vue/vue2-essential"`, `*.configs["flat/vue2-essential"]`, `"plugin:vue/vue2-strongly-recommended"`, `*.configs["flat/vue2-strongly-recommended"]`, `"plugin:vue/vue2-recommended"` and `*.configs["flat/vue2-recommended"]`.
 
 This rule checks whether every `.sync` modifier on `v-bind` directives is valid.

--- a/lib/rules/no-v-for-template-key.js
+++ b/lib/rules/no-v-for-template-key.js
@@ -14,6 +14,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-v-for-template-key.html'
     },
     fixable: null,
+    deprecated: true,
     schema: [],
     messages: {
       disallow:

--- a/lib/rules/no-v-model-argument.js
+++ b/lib/rules/no-v-model-argument.js
@@ -16,6 +16,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-v-model-argument.html'
     },
     fixable: null,
+    deprecated: true,
     schema: [],
     messages: {
       vModelRequireNoArgument: "'v-model' directives require no argument."

--- a/lib/rules/valid-model-definition.js
+++ b/lib/rules/valid-model-definition.js
@@ -17,6 +17,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/valid-model-definition.html'
     },
     fixable: null,
+    deprecated: true,
     schema: [],
     messages: {
       invalidKey: "Invalid key '{{name}}' in model option."

--- a/lib/rules/valid-v-bind-sync.js
+++ b/lib/rules/valid-v-bind-sync.js
@@ -79,6 +79,7 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/valid-v-bind-sync.html'
     },
     fixable: null,
+    deprecated: true,
     schema: [],
     messages: {
       unexpectedInvalidElement:


### PR DESCRIPTION
These rules are currently in configs for Vue 2 (in all of `essential`, `strongly-recommended` and `recommended`), but not in configs for Vue 3:

- [vue/no-custom-modifiers-on-v-model](https://eslint.vuejs.org/rules/no-custom-modifiers-on-v-model.html)
  → could be useful as an uncategorized rule for Vue 3 to disallow [custom modifiers](https://vuejs.org/guide/components/v-model.html#handling-v-model-modifiers), so let's not deprecate it
- [vue/no-multiple-template-root](https://eslint.vuejs.org/rules/no-multiple-template-root.html)
  → could be useful as an uncategorized rule for Vue 3 to prevent [attribute inheritance problems](https://vuejs.org/guide/components/attrs.html#attribute-inheritance-on-multiple-root-nodes), so let's not deprecate it
- [vue/no-v-for-template-key](https://eslint.vuejs.org/rules/no-v-for-template-key.html)
  → makes no sense for Vue 3, so deprecate it (see [Vue 3 Migration Guide: `key` Attribute](https://v3-migration.vuejs.org/breaking-changes/key-attribute.html))
- [vue/no-v-model-argument](https://eslint.vuejs.org/rules/no-v-model-argument.html)
  → makes no sense for Vue 3, so deprecate it (see [Vue 3 Migration Guide: `v-model`](https://v3-migration.vuejs.org/breaking-changes/v-model.html))
- [vue/valid-model-definition](https://eslint.vuejs.org/rules/valid-model-definition.html)
  → makes no sense for Vue 3, so deprecate it (see [Vue 3 Migration Guide: `v-model`](https://v3-migration.vuejs.org/breaking-changes/v-model.html))
- [vue/valid-v-bind-sync](https://eslint.vuejs.org/rules/valid-v-bind-sync.html)
  → makes no sense for Vue 3, so deprecate it (see [Vue 3 Migration Guide: `v-model`](https://v3-migration.vuejs.org/breaking-changes/v-model.html))

I didn't find any [uncategorized](https://eslint.vuejs.org/rules/#uncategorized) rules that would only be useful for Vue 2.

> [!NOTE]
> These rules will continue to work fine in the upcoming major version `v10`, but no longer receive much maintenance work, and we'll remove them in `v11`.

Thus, deprecating them is not technically a breaking change, but I think it will receive more attention if we do it in a major version.