### PR TITLE
feat(no-ref-as-operand): use `ref.value` to replace `ref` when emit 

### DIFF
--- a/docs/rules/no-ref-as-operand.md
+++ b/docs/rules/no-ref-as-operand.md
@@ -25,7 +25,7 @@ You must use `.value` to access the `Ref` value.
 import { ref } from 'vue'
 
 export default {
-  setup() {
+  setup(_props, { emit }) {
     const count = ref(0)
     const ok = ref(true)
 
@@ -34,12 +34,14 @@ export default {
     count.value + 1
     1 + count.value
     var msg = ok.value ? 'yes' : 'no'
+    emit('increment', count.value)
 
     /* ✗ BAD */
     count++
     count + 1
     1 + count
     var msg = ok ? 'yes' : 'no'
+    emit('increment', count)
 
     return {
       count

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -125,11 +125,7 @@ module.exports = {
           ) {
             // verify setup(props,{emit}) {emit()}
             node.arguments
-              .filter(
-                (node) =>
-                  node.type === 'Identifier' &&
-                  isRefInit(refReferences.get(node))
-              )
+              .filter((node) => node.type === 'Identifier')
               .forEach((node) => {
                 reportIfRefWrapped(node)
               })
@@ -143,11 +139,7 @@ module.exports = {
             ) {
               // verify setup(props,context) {context.emit()}
               emit.member.parent.arguments
-                .filter(
-                  (node) =>
-                    node.type === 'Identifier' &&
-                    isRefInit(refReferences.get(node))
-                )
+                .filter((node) => node.type === 'Identifier')
                 .forEach((node) => {
                   reportIfRefWrapped(node)
                 })

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -4,6 +4,7 @@
  */
 'use strict'
 
+const { findVariable } = require('@eslint-community/eslint-utils')
 const { extractRefObjectReferences } = require('../utils/ref-object-references')
 const utils = require('../utils')
 
@@ -24,6 +25,40 @@ function isRefInit(data) {
   }
   return data.defineChain.includes(/** @type {any} */ (init))
 }
+
+/**
+ * Get the callee member node from the given CallExpression
+ * @param {CallExpression} node CallExpression
+ */
+function getNameParamNode(node) {
+  const nameLiteralNode = node.arguments[0]
+  if (nameLiteralNode && utils.isStringLiteral(nameLiteralNode)) {
+    const name = utils.getStringLiteralValue(nameLiteralNode)
+    if (name != null) {
+      return { name, loc: nameLiteralNode.loc }
+    }
+  }
+
+  // cannot check
+  return null
+}
+
+/**
+ * Get the callee member node from the given CallExpression
+ * @param {CallExpression} node CallExpression
+ */
+function getCalleeMemberNode(node) {
+  const callee = utils.skipChainExpression(node.callee)
+
+  if (callee.type === 'MemberExpression') {
+    const name = utils.getStaticPropertyName(callee)
+    if (name) {
+      return { name, member: callee }
+    }
+  }
+  return null
+}
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -44,6 +79,7 @@ module.exports = {
   create(context) {
     /** @type {RefObjectReferences} */
     let refReferences
+    const setupContexts = new Map()
 
     /**
      * @param {Identifier} node
@@ -64,90 +100,244 @@ module.exports = {
         }
       })
     }
-    return {
-      Program() {
-        refReferences = extractRefObjectReferences(context)
-      },
-      // if (refValue)
-      /** @param {Identifier} node */
-      'IfStatement>Identifier'(node) {
-        reportIfRefWrapped(node)
-      },
-      // switch (refValue)
-      /** @param {Identifier} node */
-      'SwitchStatement>Identifier'(node) {
-        reportIfRefWrapped(node)
-      },
-      // -refValue, +refValue, !refValue, ~refValue, typeof refValue
-      /** @param {Identifier} node */
-      'UnaryExpression>Identifier'(node) {
-        reportIfRefWrapped(node)
-      },
-      // refValue++, refValue--
-      /** @param {Identifier} node */
-      'UpdateExpression>Identifier'(node) {
-        reportIfRefWrapped(node)
-      },
-      // refValue+1, refValue-1
-      /** @param {Identifier} node */
-      'BinaryExpression>Identifier'(node) {
-        reportIfRefWrapped(node)
-      },
-      // refValue+=1, refValue-=1, foo+=refValue, foo-=refValue
-      /** @param {Identifier & {parent: AssignmentExpression}} node */
-      'AssignmentExpression>Identifier'(node) {
-        if (node.parent.operator === '=' && node.parent.left !== node) {
+
+    const programNode = context.getSourceCode().ast
+
+    const callVisitor = {
+      /**
+       * @param {CallExpression} node
+       * @param {import('../utils').VueObjectData} [info]
+       */
+      CallExpression(node, info) {
+        const nameWithLoc = getNameParamNode(node)
+        if (!nameWithLoc) {
+          // cannot check
           return
         }
-        reportIfRefWrapped(node)
-      },
-      // refValue || other, refValue && other. ignore: other || refValue
-      /** @param {Identifier & {parent: LogicalExpression}} node */
-      'LogicalExpression>Identifier'(node) {
-        if (node.parent.left !== node) {
-          return
+
+        // verify setup context
+        const setupContext = setupContexts.get(info ? info.node : programNode)
+        if (setupContext) {
+          const { contextReferenceIds, emitReferenceIds } = setupContext
+          if (
+            node.callee.type === 'Identifier' &&
+            emitReferenceIds.has(node.callee)
+          ) {
+            // verify setup(props,{emit}) {emit()}
+            node.arguments
+              .filter(
+                (node) =>
+                  node.type === 'Identifier' &&
+                  isRefInit(refReferences.get(node))
+              )
+              .forEach((node) => {
+                reportIfRefWrapped(node)
+              })
+          } else {
+            const emit = getCalleeMemberNode(node)
+            if (
+              emit &&
+              emit.name === 'emit' &&
+              emit.member.object.type === 'Identifier' &&
+              contextReferenceIds.has(emit.member.object)
+            ) {
+              // verify setup(props,context) {context.emit()}
+              emit.member.parent.arguments
+                .filter(
+                  (node) =>
+                    node.type === 'Identifier' &&
+                    isRefInit(refReferences.get(node))
+                )
+                .forEach((node) => {
+                  reportIfRefWrapped(node)
+                })
+            }
+          }
         }
-        // Report only constants.
-        const data = refReferences.get(node)
-        if (
-          !data ||
-          !data.variableDeclaration ||
-          data.variableDeclaration.kind !== 'const'
-        ) {
-          return
-        }
-        reportIfRefWrapped(node)
-      },
-      // refValue ? x : y
-      /** @param {Identifier & {parent: ConditionalExpression}} node */
-      'ConditionalExpression>Identifier'(node) {
-        if (node.parent.test !== node) {
-          return
-        }
-        reportIfRefWrapped(node)
-      },
-      // `${refValue}`
-      /** @param {Identifier} node */
-      'TemplateLiteral>Identifier'(node) {
-        reportIfRefWrapped(node)
-      },
-      // refValue.x
-      /** @param {Identifier & {parent: MemberExpression}} node */
-      'MemberExpression>Identifier'(node) {
-        if (node.parent.object !== node) {
-          return
-        }
-        const name = utils.getStaticPropertyName(node.parent)
-        if (
-          name === 'value' ||
-          name == null ||
-          // WritableComputedRef
-          name === 'effect'
-        ) {
-          return
-        }
-        reportIfRefWrapped(node)
       }
     }
+
+    return utils.compositingVisitors(
+      {
+        Program() {
+          refReferences = extractRefObjectReferences(context)
+        },
+        // if (refValue)
+        /** @param {Identifier} node */
+        'IfStatement>Identifier'(node) {
+          reportIfRefWrapped(node)
+        },
+        // switch (refValue)
+        /** @param {Identifier} node */
+        'SwitchStatement>Identifier'(node) {
+          reportIfRefWrapped(node)
+        },
+        // -refValue, +refValue, !refValue, ~refValue, typeof refValue
+        /** @param {Identifier} node */
+        'UnaryExpression>Identifier'(node) {
+          reportIfRefWrapped(node)
+        },
+        // refValue++, refValue--
+        /** @param {Identifier} node */
+        'UpdateExpression>Identifier'(node) {
+          reportIfRefWrapped(node)
+        },
+        // refValue+1, refValue-1
+        /** @param {Identifier} node */
+        'BinaryExpression>Identifier'(node) {
+          reportIfRefWrapped(node)
+        },
+        // refValue+=1, refValue-=1, foo+=refValue, foo-=refValue
+        /** @param {Identifier & {parent: AssignmentExpression}} node */
+        'AssignmentExpression>Identifier'(node) {
+          if (node.parent.operator === '=' && node.parent.left !== node) {
+            return
+          }
+          reportIfRefWrapped(node)
+        },
+        // refValue || other, refValue && other. ignore: other || refValue
+        /** @param {Identifier & {parent: LogicalExpression}} node */
+        'LogicalExpression>Identifier'(node) {
+          if (node.parent.left !== node) {
+            return
+          }
+          // Report only constants.
+          const data = refReferences.get(node)
+          if (
+            !data ||
+            !data.variableDeclaration ||
+            data.variableDeclaration.kind !== 'const'
+          ) {
+            return
+          }
+          reportIfRefWrapped(node)
+        },
+        // refValue ? x : y
+        /** @param {Identifier & {parent: ConditionalExpression}} node */
+        'ConditionalExpression>Identifier'(node) {
+          if (node.parent.test !== node) {
+            return
+          }
+          reportIfRefWrapped(node)
+        },
+        // `${refValue}`
+        /** @param {Identifier} node */
+        'TemplateLiteral>Identifier'(node) {
+          reportIfRefWrapped(node)
+        },
+        // refValue.x
+        /** @param {Identifier & {parent: MemberExpression}} node */
+        'MemberExpression>Identifier'(node) {
+          if (node.parent.object !== node) {
+            return
+          }
+          const name = utils.getStaticPropertyName(node.parent)
+          if (
+            name === 'value' ||
+            name == null ||
+            // WritableComputedRef
+            name === 'effect'
+          ) {
+            return
+          }
+          reportIfRefWrapped(node)
+        }
+      },
+      utils.compositingVisitors(
+        utils.defineScriptSetupVisitor(context, {
+          onDefineEmitsEnter(node) {
+            if (
+              !node.parent ||
+              node.parent.type !== 'VariableDeclarator' ||
+              node.parent.init !== node
+            ) {
+              return
+            }
+
+            const emitParam = node.parent.id
+            if (emitParam.type !== 'Identifier') {
+              return
+            }
+
+            // const emit = defineEmits()
+            const variable = findVariable(
+              utils.getScope(context, emitParam),
+              emitParam
+            )
+            if (!variable) {
+              return
+            }
+            const emitReferenceIds = new Set()
+            for (const reference of variable.references) {
+              emitReferenceIds.add(reference.identifier)
+            }
+            setupContexts.set(programNode, {
+              contextReferenceIds: new Set(),
+              emitReferenceIds
+            })
+          },
+          ...callVisitor
+        }),
+        utils.defineVueVisitor(context, {
+          onSetupFunctionEnter(node, { node: vueNode }) {
+            const contextParam = utils.skipDefaultParamValue(node.params[1])
+            if (!contextParam) {
+              // no arguments
+              return
+            }
+            if (
+              contextParam.type === 'RestElement' ||
+              contextParam.type === 'ArrayPattern'
+            ) {
+              // cannot check
+              return
+            }
+            const contextReferenceIds = new Set()
+            const emitReferenceIds = new Set()
+            if (contextParam.type === 'ObjectPattern') {
+              const emitProperty = utils.findAssignmentProperty(
+                contextParam,
+                'emit'
+              )
+              if (!emitProperty || emitProperty.value.type !== 'Identifier') {
+                return
+              }
+              const emitParam = emitProperty.value
+              // `setup(props, {emit})`
+              const variable = findVariable(
+                utils.getScope(context, emitParam),
+                emitParam
+              )
+              if (!variable) {
+                return
+              }
+              for (const reference of variable.references) {
+                emitReferenceIds.add(reference.identifier)
+              }
+            } else {
+              // `setup(props, context)`
+              const variable = findVariable(
+                utils.getScope(context, contextParam),
+                contextParam
+              )
+              if (!variable) {
+                return
+              }
+              for (const reference of variable.references) {
+                contextReferenceIds.add(reference.identifier)
+              }
+            }
+            setupContexts.set(vueNode, {
+              contextReferenceIds,
+              emitReferenceIds
+            })
+          },
+          ...callVisitor,
+          onVueObjectExit(node) {
+            setupContexts.delete(node)
+          }
+        })
+      )
+    )
   }
 }

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -138,7 +138,7 @@ module.exports = {
               contextReferenceIds.has(emit.member.object)
             ) {
               // verify setup(props,context) {context.emit()}
-              emit.member.parent.arguments
+              node.arguments
                 .filter((node) => node.type === 'Identifier')
                 .forEach((node) => {
                   reportIfRefWrapped(node)

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -124,11 +124,12 @@ module.exports = {
             emitReferenceIds.has(node.callee)
           ) {
             // verify setup(props,{emit}) {emit()}
-            node.arguments
-              .filter((node) => node.type === 'Identifier')
-              .forEach((node) => {
-                reportIfRefWrapped(node)
-              })
+            const nodes = node.arguments.filter(
+              (node) => node.type === 'Identifier'
+            )
+            for (const node of nodes) {
+              reportIfRefWrapped(node)
+            }
           } else {
             const emit = getCalleeMemberNode(node)
             if (
@@ -138,11 +139,12 @@ module.exports = {
               contextReferenceIds.has(emit.member.object)
             ) {
               // verify setup(props,context) {context.emit()}
-              node.arguments
-                .filter((node) => node.type === 'Identifier')
-                .forEach((node) => {
-                  reportIfRefWrapped(node)
-                })
+              const nodes = node.arguments.filter(
+                (node) => node.type === 'Identifier'
+              )
+              for (const node of nodes) {
+                reportIfRefWrapped(node)
+              }
             }
           }
         }
@@ -235,23 +237,66 @@ module.exports = {
           reportIfRefWrapped(node)
         }
       },
-      utils.compositingVisitors(
-        utils.defineScriptSetupVisitor(context, {
-          onDefineEmitsEnter(node) {
-            if (
-              !node.parent ||
-              node.parent.type !== 'VariableDeclarator' ||
-              node.parent.init !== node
-            ) {
+      utils.defineScriptSetupVisitor(context, {
+        onDefineEmitsEnter(node) {
+          if (
+            !node.parent ||
+            node.parent.type !== 'VariableDeclarator' ||
+            node.parent.init !== node
+          ) {
+            return
+          }
+
+          const emitParam = node.parent.id
+          if (emitParam.type !== 'Identifier') {
+            return
+          }
+
+          // const emit = defineEmits()
+          const variable = findVariable(
+            utils.getScope(context, emitParam),
+            emitParam
+          )
+          if (!variable) {
+            return
+          }
+          const emitReferenceIds = new Set()
+          for (const reference of variable.references) {
+            emitReferenceIds.add(reference.identifier)
+          }
+          setupContexts.set(programNode, {
+            contextReferenceIds: new Set(),
+            emitReferenceIds
+          })
+        },
+        ...callVisitor
+      }),
+      utils.defineVueVisitor(context, {
+        onSetupFunctionEnter(node, { node: vueNode }) {
+          const contextParam = utils.skipDefaultParamValue(node.params[1])
+          if (!contextParam) {
+            // no arguments
+            return
+          }
+          if (
+            contextParam.type === 'RestElement' ||
+            contextParam.type === 'ArrayPattern'
+          ) {
+            // cannot check
+            return
+          }
+          const contextReferenceIds = new Set()
+          const emitReferenceIds = new Set()
+          if (contextParam.type === 'ObjectPattern') {
+            const emitProperty = utils.findAssignmentProperty(
+              contextParam,
+              'emit'
+            )
+            if (!emitProperty || emitProperty.value.type !== 'Identifier') {
               return
             }
-
-            const emitParam = node.parent.id
-            if (emitParam.type !== 'Identifier') {
-              return
-            }
-
-            // const emit = defineEmits()
+            const emitParam = emitProperty.value
+            // `setup(props, {emit})`
             const variable = findVariable(
               utils.getScope(context, emitParam),
               emitParam
@@ -259,77 +304,32 @@ module.exports = {
             if (!variable) {
               return
             }
-            const emitReferenceIds = new Set()
             for (const reference of variable.references) {
               emitReferenceIds.add(reference.identifier)
             }
-            setupContexts.set(programNode, {
-              contextReferenceIds: new Set(),
-              emitReferenceIds
-            })
-          },
-          ...callVisitor
-        }),
-        utils.defineVueVisitor(context, {
-          onSetupFunctionEnter(node, { node: vueNode }) {
-            const contextParam = utils.skipDefaultParamValue(node.params[1])
-            if (!contextParam) {
-              // no arguments
+          } else {
+            // `setup(props, context)`
+            const variable = findVariable(
+              utils.getScope(context, contextParam),
+              contextParam
+            )
+            if (!variable) {
               return
             }
-            if (
-              contextParam.type === 'RestElement' ||
-              contextParam.type === 'ArrayPattern'
-            ) {
-              // cannot check
-              return
+            for (const reference of variable.references) {
+              contextReferenceIds.add(reference.identifier)
             }
-            const contextReferenceIds = new Set()
-            const emitReferenceIds = new Set()
-            if (contextParam.type === 'ObjectPattern') {
-              const emitProperty = utils.findAssignmentProperty(
-                contextParam,
-                'emit'
-              )
-              if (!emitProperty || emitProperty.value.type !== 'Identifier') {
-                return
-              }
-              const emitParam = emitProperty.value
-              // `setup(props, {emit})`
-              const variable = findVariable(
-                utils.getScope(context, emitParam),
-                emitParam
-              )
-              if (!variable) {
-                return
-              }
-              for (const reference of variable.references) {
-                emitReferenceIds.add(reference.identifier)
-              }
-            } else {
-              // `setup(props, context)`
-              const variable = findVariable(
-                utils.getScope(context, contextParam),
-                contextParam
-              )
-              if (!variable) {
-                return
-              }
-              for (const reference of variable.references) {
-                contextReferenceIds.add(reference.identifier)
-              }
-            }
-            setupContexts.set(vueNode, {
-              contextReferenceIds,
-              emitReferenceIds
-            })
-          },
-          ...callVisitor,
-          onVueObjectExit(node) {
-            setupContexts.delete(node)
           }
-        })
-      )
+          setupContexts.set(vueNode, {
+            contextReferenceIds,
+            emitReferenceIds
+          })
+        },
+        ...callVisitor,
+        onVueObjectExit(node) {
+          setupContexts.delete(node)
+        }
+      })
     )
   }
 }

--- a/lib/rules/no-ref-as-operand.js
+++ b/lib/rules/no-ref-as-operand.js
@@ -82,6 +82,21 @@ module.exports = {
     const setupContexts = new Map()
 
     /**
+     * Collect identifier id
+     * @param {Identifier} node
+     * @param {Set<Identifier>} referenceIds
+     */
+    function collectReferenceIds(node, referenceIds) {
+      const variable = findVariable(utils.getScope(context, node), node)
+      if (!variable) {
+        return
+      }
+      for (const reference of variable.references) {
+        referenceIds.add(reference.identifier)
+      }
+    }
+
+    /**
      * @param {Identifier} node
      */
     function reportIfRefWrapped(node) {
@@ -101,6 +116,16 @@ module.exports = {
       })
     }
 
+    /**
+     * @param {CallExpression} node
+     */
+    function reportWrappedIdentifiers(node) {
+      const nodes = node.arguments.filter((node) => node.type === 'Identifier')
+      for (const node of nodes) {
+        reportIfRefWrapped(node)
+      }
+    }
+
     const programNode = context.getSourceCode().ast
 
     const callVisitor = {
@@ -117,35 +142,27 @@ module.exports = {
 
         // verify setup context
         const setupContext = setupContexts.get(info ? info.node : programNode)
-        if (setupContext) {
-          const { contextReferenceIds, emitReferenceIds } = setupContext
+        if (!setupContext) {
+          return
+        }
+
+        const { contextReferenceIds, emitReferenceIds } = setupContext
+        if (
+          node.callee.type === 'Identifier' &&
+          emitReferenceIds.has(node.callee)
+        ) {
+          // verify setup(props,{emit}) {emit()}
+          reportWrappedIdentifiers(node)
+        } else {
+          const emit = getCalleeMemberNode(node)
           if (
-            node.callee.type === 'Identifier' &&
-            emitReferenceIds.has(node.callee)
+            emit &&
+            emit.name === 'emit' &&
+            emit.member.object.type === 'Identifier' &&
+            contextReferenceIds.has(emit.member.object)
           ) {
-            // verify setup(props,{emit}) {emit()}
-            const nodes = node.arguments.filter(
-              (node) => node.type === 'Identifier'
-            )
-            for (const node of nodes) {
-              reportIfRefWrapped(node)
-            }
-          } else {
-            const emit = getCalleeMemberNode(node)
-            if (
-              emit &&
-              emit.name === 'emit' &&
-              emit.member.object.type === 'Identifier' &&
-              contextReferenceIds.has(emit.member.object)
-            ) {
-              // verify setup(props,context) {context.emit()}
-              const nodes = node.arguments.filter(
-                (node) => node.type === 'Identifier'
-              )
-              for (const node of nodes) {
-                reportIfRefWrapped(node)
-              }
-            }
+            // verify setup(props,context) {context.emit()}
+            reportWrappedIdentifiers(node)
           }
         }
       }
@@ -253,17 +270,9 @@ module.exports = {
           }
 
           // const emit = defineEmits()
-          const variable = findVariable(
-            utils.getScope(context, emitParam),
-            emitParam
-          )
-          if (!variable) {
-            return
-          }
           const emitReferenceIds = new Set()
-          for (const reference of variable.references) {
-            emitReferenceIds.add(reference.identifier)
-          }
+          collectReferenceIds(emitParam, emitReferenceIds)
+
           setupContexts.set(programNode, {
             contextReferenceIds: new Set(),
             emitReferenceIds
@@ -285,6 +294,7 @@ module.exports = {
             // cannot check
             return
           }
+
           const contextReferenceIds = new Set()
           const emitReferenceIds = new Set()
           if (contextParam.type === 'ObjectPattern') {
@@ -295,30 +305,12 @@ module.exports = {
             if (!emitProperty || emitProperty.value.type !== 'Identifier') {
               return
             }
-            const emitParam = emitProperty.value
+
             // `setup(props, {emit})`
-            const variable = findVariable(
-              utils.getScope(context, emitParam),
-              emitParam
-            )
-            if (!variable) {
-              return
-            }
-            for (const reference of variable.references) {
-              emitReferenceIds.add(reference.identifier)
-            }
+            collectReferenceIds(emitProperty.value, emitReferenceIds)
           } else {
             // `setup(props, context)`
-            const variable = findVariable(
-              utils.getScope(context, contextParam),
-              contextParam
-            )
-            if (!variable) {
-              return
-            }
-            for (const reference of variable.references) {
-              contextReferenceIds.add(reference.identifier)
-            }
+            collectReferenceIds(contextParam, contextReferenceIds)
           }
           setupContexts.set(vueNode, {
             contextReferenceIds,

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -191,7 +191,53 @@ tester.run('no-ref-as-operand', rule, {
       model.value = value;
     }
     </script>
+    `,
     `
+    <script setup>
+    const emit = defineEmits(['test'])
+    const [model, mod] = defineModel();
+    
+    function update() {
+      emit('test', model.value)
+    }
+    </script>
+    `,
+    `
+    <script>
+    import { ref, defineComponent } from 'vue'
+
+    export default defineComponent({
+      emits: ['incremented'],
+      setup(_, ctx) {
+        const counter = ref(0)
+
+        ctx.emit('incremented', counter.value)
+
+        return {
+          counter
+        }
+      }
+    })
+    </script>
+    `,
+    `
+    <script>
+    import { ref, defineComponent } from 'vue'
+
+    export default defineComponent({
+      emits: ['incremented'],
+      setup(_, { emit }) {
+        const counter = ref(0)
+
+        emit('incremented', counter.value)
+
+        return {
+          counter
+        }
+      }
+    })
+    </script>
+    `,
   ],
   invalid: [
     {
@@ -821,6 +867,130 @@ tester.run('no-ref-as-operand', rule, {
             'Must use `.value` to read or write the value wrapped by `defineModel()`.',
           line: 9
         }
+      ]
+    },
+    {
+      code: `
+      <script setup>
+      import { ref } from 'vue'
+      const emits = defineEmits(['test'])
+      const count = ref(0)
+
+      function update() {
+        emits('test', count)
+      }
+      </script>
+      `,
+      output: `
+      <script setup>
+      import { ref } from 'vue'
+      const emits = defineEmits(['test'])
+      const count = ref(0)
+
+      function update() {
+        emits('test', count.value)
+      }
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'Must use `.value` to read or write the value wrapped by `ref()`.',
+          line: 8,
+          endLine: 8,
+        },
+      ]
+    },
+    {
+      code: `
+      <script>
+      import { ref, defineComponent } from 'vue'
+
+      export default defineComponent({
+        emits: ['incremented'],
+        setup(_, ctx) {
+          const counter = ref(0)
+
+          ctx.emit('incremented', counter)
+
+          return {
+            counter
+          }
+        }
+      })
+      </script>
+      `,
+      output:`
+      <script>
+      import { ref, defineComponent } from 'vue'
+
+      export default defineComponent({
+        emits: ['incremented'],
+        setup(_, ctx) {
+          const counter = ref(0)
+
+          ctx.emit('incremented', counter.value)
+
+          return {
+            counter
+          }
+        }
+      })
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'Must use `.value` to read or write the value wrapped by `ref()`.',
+          line: 10,
+          endLine: 10,
+        },
+      ]
+    },
+    {
+      code: `
+      <script>
+      import { ref, defineComponent } from 'vue'
+
+      export default defineComponent({
+        emits: ['incremented'],
+        setup(_, { emit }) {
+          const counter = ref(0)
+
+          emit('incremented', counter)
+
+          return {
+            counter
+          }
+        }
+      })
+      </script>
+      `,
+      output:`
+      <script>
+      import { ref, defineComponent } from 'vue'
+
+      export default defineComponent({
+        emits: ['incremented'],
+        setup(_, { emit }) {
+          const counter = ref(0)
+
+          emit('incremented', counter.value)
+
+          return {
+            counter
+          }
+        }
+      })
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'Must use `.value` to read or write the value wrapped by `ref()`.',
+          line: 10,
+          endLine: 10,
+        },
       ]
     },
     // Auto-import

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -238,6 +238,60 @@ tester.run('no-ref-as-operand', rule, {
     })
     </script>
     `,
+    `
+    <script>
+    import { ref, defineComponent } from 'vue'
+
+    export default defineComponent({
+      emits: ['incremented'],
+      setup(_, { emit }) {
+        const counter = ref(0)
+
+        emit('incremented', counter.value, 'xxx')
+
+        return {
+          counter
+        }
+      }
+    })
+    </script>
+    `,
+    `
+    <script>
+    import { ref, defineComponent } from 'vue'
+
+    export default defineComponent({
+      emits: ['incremented'],
+      setup(_, { emit }) {
+        const counter = ref(0)
+
+        emit('incremented', 'xxx')
+
+        return {
+          counter
+        }
+      }
+    })
+    </script>
+    `,
+    `
+    <script>
+    import { ref, defineComponent } from 'vue'
+
+    export default defineComponent({
+      emits: ['incremented'],
+      setup(_, { emit }) {
+        const counter = ref(0)
+
+        emit('incremented')
+
+        return {
+          counter
+        }
+      }
+    })
+    </script>
+    `,
   ],
   invalid: [
     {
@@ -976,6 +1030,52 @@ tester.run('no-ref-as-operand', rule, {
           const counter = ref(0)
 
           emit('incremented', counter.value)
+
+          return {
+            counter
+          }
+        }
+      })
+      </script>
+      `,
+      errors: [
+        {
+          message:
+            'Must use `.value` to read or write the value wrapped by `ref()`.',
+          line: 10,
+          endLine: 10,
+        },
+      ]
+    },
+    {
+      code: `
+      <script>
+      import { ref, defineComponent } from 'vue'
+
+      export default defineComponent({
+        emits: ['incremented'],
+        setup(_, { emit }) {
+          const counter = ref(0)
+
+          emit('incremented', 'xxx', counter)
+
+          return {
+            counter
+          }
+        }
+      })
+      </script>
+      `,
+      output:`
+      <script>
+      import { ref, defineComponent } from 'vue'
+
+      export default defineComponent({
+        emits: ['incremented'],
+        setup(_, { emit }) {
+          const counter = ref(0)
+
+          emit('incremented', 'xxx', counter.value)
 
           return {
             counter

--- a/tests/lib/rules/no-ref-as-operand.js
+++ b/tests/lib/rules/no-ref-as-operand.js
@@ -291,7 +291,7 @@ tester.run('no-ref-as-operand', rule, {
       }
     })
     </script>
-    `,
+    `
   ],
   invalid: [
     {
@@ -951,8 +951,8 @@ tester.run('no-ref-as-operand', rule, {
           message:
             'Must use `.value` to read or write the value wrapped by `ref()`.',
           line: 8,
-          endLine: 8,
-        },
+          endLine: 8
+        }
       ]
     },
     {
@@ -974,7 +974,7 @@ tester.run('no-ref-as-operand', rule, {
       })
       </script>
       `,
-      output:`
+      output: `
       <script>
       import { ref, defineComponent } from 'vue'
 
@@ -997,8 +997,8 @@ tester.run('no-ref-as-operand', rule, {
           message:
             'Must use `.value` to read or write the value wrapped by `ref()`.',
           line: 10,
-          endLine: 10,
-        },
+          endLine: 10
+        }
       ]
     },
     {
@@ -1020,7 +1020,7 @@ tester.run('no-ref-as-operand', rule, {
       })
       </script>
       `,
-      output:`
+      output: `
       <script>
       import { ref, defineComponent } from 'vue'
 
@@ -1043,8 +1043,8 @@ tester.run('no-ref-as-operand', rule, {
           message:
             'Must use `.value` to read or write the value wrapped by `ref()`.',
           line: 10,
-          endLine: 10,
-        },
+          endLine: 10
+        }
       ]
     },
     {
@@ -1066,7 +1066,7 @@ tester.run('no-ref-as-operand', rule, {
       })
       </script>
       `,
-      output:`
+      output: `
       <script>
       import { ref, defineComponent } from 'vue'
 
@@ -1089,8 +1089,8 @@ tester.run('no-ref-as-operand', rule, {
           message:
             'Must use `.value` to read or write the value wrapped by `ref()`.',
           line: 10,
-          endLine: 10,
-        },
+          endLine: 10
+        }
       ]
     },
     // Auto-import


### PR DESCRIPTION
# Issue

close #2601 