### PR TITLE
Add vue-eslint-parser to Yarn install

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -11,7 +11,7 @@ npm install --save-dev eslint eslint-plugin-vue
 Via [yarn](https://yarnpkg.com/):
 
 ```bash
-yarn add -D eslint eslint-plugin-vue globals
+yarn add -D eslint eslint-plugin-vue vue-eslint-parser globals
 ```
 
 ::: tip Requirements


### PR DESCRIPTION
Since version 10.0.0 this has become a peer dependency which is not installed by Yarn.

See https://github.com/vuejs/eslint-plugin-vue/pull/2670