### PR TITLE
fix(no-export-in-script-setup): better report location

### DIFF
--- a/lib/rules/no-export-in-script-setup.js
+++ b/lib/rules/no-export-in-script-setup.js
@@ -20,7 +20,7 @@ module.exports = {
       categories: ['vue3-essential', 'vue2-essential'],
       url: 'https://eslint.vuejs.org/rules/no-export-in-script-setup.html'
     },
-    fixable: 'code',
+    fixable: null,
     schema: [],
     messages: {
       forbidden: '`<script setup>` cannot contain ES module exports.'
@@ -28,8 +28,11 @@ module.exports = {
   },
   /** @param {RuleContext} context */
   create(context) {
-    /** @param {ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration} node */
-    function verify(node) {
+    /**
+     * @param {ExportAllDeclaration | ExportDefaultDeclaration | ExportNamedDeclaration} node
+     * @param {SourceLocation} loc
+     */
+    function verify(node, loc) {
       const tsNode =
         /** @type {TSESTreeExportAllDeclaration | TSESTreeExportDefaultDeclaration | TSESTreeExportNamedDeclaration} */ (
           node
@@ -46,18 +49,24 @@ module.exports = {
       }
       context.report({
         node,
-        loc: node.loc,
-        messageId: 'forbidden',
-        fix(fixer) {
-          return fixer.remove(node)
-        }
+        loc,
+        messageId: 'forbidden'
       })
     }
 
     return utils.defineScriptSetupVisitor(context, {
-      ExportAllDeclaration: verify,
-      ExportDefaultDeclaration: verify,
-      ExportNamedDeclaration: verify
+      ExportAllDeclaration: (node) => verify(node, node.loc),
+      ExportDefaultDeclaration: (node) => verify(node, node.loc),
+      ExportNamedDeclaration: (node) => {
+        // export let foo = 'foo', export class Foo {}, export function foo() {}
+        if (node.declaration) {
+          verify(node, context.getSourceCode().getFirstToken(node).loc)
+        }
+        // export { foo }, export { foo } from 'bar'
+        else {
+          verify(node, node.loc)
+        }
+      }
     })
   }
 }

--- a/lib/rules/no-export-in-script-setup.js
+++ b/lib/rules/no-export-in-script-setup.js
@@ -20,7 +20,7 @@ module.exports = {
       categories: ['vue3-essential', 'vue2-essential'],
       url: 'https://eslint.vuejs.org/rules/no-export-in-script-setup.html'
     },
-    fixable: [],
+    fixable: 'code',
     schema: [],
     messages: {
       forbidden: '`<script setup>` cannot contain ES module exports.'

--- a/lib/rules/no-export-in-script-setup.js
+++ b/lib/rules/no-export-in-script-setup.js
@@ -20,7 +20,7 @@ module.exports = {
       categories: ['vue3-essential', 'vue2-essential'],
       url: 'https://eslint.vuejs.org/rules/no-export-in-script-setup.html'
     },
-    fixable: null,
+    fixable: [],
     schema: [],
     messages: {
       forbidden: '`<script setup>` cannot contain ES module exports.'
@@ -46,7 +46,11 @@ module.exports = {
       }
       context.report({
         node,
-        messageId: 'forbidden'
+        loc: node.loc,
+        messageId: 'forbidden',
+        fix(fixer) {
+          return fixer.remove(node)
+        }
       })
     }
 

--- a/tests/lib/rules/no-export-in-script-setup.js
+++ b/tests/lib/rules/no-export-in-script-setup.js
@@ -94,6 +94,13 @@ ruleTester.run('no-export-in-script-setup', rule, {
       export class A {}
       </script>
       `,
+      output: `
+      <script setup>
+      
+      
+      
+      </script>
+      `,
       errors: [
         {
           message: '`<script setup>` cannot contain ES module exports.',
@@ -121,6 +128,16 @@ ruleTester.run('no-export-in-script-setup', rule, {
       export class A {}
       </script>
       `,
+      output: `
+      <script>
+      let foo;
+      </script>
+      <script setup>
+      
+      
+      
+      </script>
+      `,
       errors: [
         {
           message: '`<script setup>` cannot contain ES module exports.',
@@ -143,6 +160,13 @@ ruleTester.run('no-export-in-script-setup', rule, {
       export const Foo = {}
       export enum Bar {}
       export {}
+      </script>
+      `,
+      output: `
+      <script setup lang="ts">
+      
+      
+      
       </script>
       `,
       languageOptions: {

--- a/tests/lib/rules/no-export-in-script-setup.js
+++ b/tests/lib/rules/no-export-in-script-setup.js
@@ -92,27 +92,62 @@ ruleTester.run('no-export-in-script-setup', rule, {
       export * from 'foo'
       export default {}
       export class A {}
-      </script>
-      `,
-      output: `
-      <script setup>
-      
-      
-      
+      export const test = '123'
+      export function foo() {}
+      const a = 1
+      export { a }
+      export { fao } from 'bar'
       </script>
       `,
       errors: [
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 3
+          line: 3,
+          endLine: 3,
+          column: 7,
+          endColumn: 26
         },
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 4
+          line: 4,
+          endLine: 4,
+          column: 7,
+          endColumn: 24
         },
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 5
+          line: 5,
+          endLine: 5,
+          column: 7,
+          endColumn: 13
+        },
+        {
+          message: '`<script setup>` cannot contain ES module exports.',
+          line: 6,
+          endLine: 6,
+          column: 7,
+          endColumn: 13
+        },
+        {
+          message: '`<script setup>` cannot contain ES module exports.',
+          line: 7,
+          endLine: 7,
+          column: 7,
+          endColumn: 13
+        },
+        {
+          message: '`<script setup>` cannot contain ES module exports.',
+          line: 9,
+          endLine: 9,
+          column: 7,
+          endColumn: 19
+        },
+        {
+          message: '`<script setup>` cannot contain ES module exports.',
+          line: 10,
+          endLine: 10,
+          column: 7,
+          endColumn: 32
         }
       ]
     },
@@ -128,28 +163,27 @@ ruleTester.run('no-export-in-script-setup', rule, {
       export class A {}
       </script>
       `,
-      output: `
-      <script>
-      let foo;
-      </script>
-      <script setup>
-      
-      
-      
-      </script>
-      `,
       errors: [
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 6
+          line: 6,
+          endLine: 6,
+          column: 7,
+          endColumn: 26
         },
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 7
+          line: 7,
+          endLine: 7,
+          column: 7,
+          endColumn: 24
         },
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 8
+          line: 8,
+          endLine: 8,
+          column: 7,
+          endColumn: 13
         }
       ]
     },
@@ -162,13 +196,6 @@ ruleTester.run('no-export-in-script-setup', rule, {
       export {}
       </script>
       `,
-      output: `
-      <script setup lang="ts">
-      
-      
-      
-      </script>
-      `,
       languageOptions: {
         parser: require('vue-eslint-parser'),
         parserOptions: {
@@ -178,15 +205,24 @@ ruleTester.run('no-export-in-script-setup', rule, {
       errors: [
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 3
+          line: 3,
+          endLine: 3,
+          column: 7,
+          endColumn: 13
         },
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 4
+          line: 4,
+          endLine: 4,
+          column: 7,
+          endColumn: 13
         },
         {
           message: '`<script setup>` cannot contain ES module exports.',
-          line: 5
+          line: 5,
+          endLine: 5,
+          column: 7,
+          endColumn: 16
         }
       ]
     }


### PR DESCRIPTION
support autofix for no-export-in-script-setup rule. 

relates to #2690