### PR TITLE
fix: fix walking program AST when multiple script blocks

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1380,7 +1380,7 @@ module.exports = {
      * @param {any[]} args
      */
     function callVisitor(key, node, ...args) {
-      if (visitor[key] && inScriptSetup(node)) {
+      if (visitor[key] && (node.type === 'Program' || inScriptSetup(node))) {
         // @ts-expect-error
         visitor[key](node, ...args)
       }

--- a/tests/lib/rules/prefer-use-template-ref.js
+++ b/tests/lib/rules/prefer-use-template-ref.js
@@ -263,6 +263,23 @@ tester.run('prefer-use-template-ref', rule, {
           })
         </script>
       `
+    },
+    {
+      filename: 'multiple-scripts.vue',
+      code: `
+      <template>
+        <div ref="root" :data-a="A" />
+      </template>
+
+      <script>
+      const A = 'foo'
+      </script>
+
+      <script setup>
+      import { useTemplateRef } from 'vue'
+      const root = useTemplateRef('root')
+      </script>
+      `
     }
   ],
   invalid: [
@@ -418,6 +435,33 @@ tester.run('prefer-use-template-ref', rule, {
           },
           line: 9,
           column: 28
+        }
+      ]
+    },
+    {
+      filename: 'multiple-scripts.vue',
+      code: `
+      <template>
+        <div ref="root" :data-a="A" />
+      </template>
+
+      <script>
+      const A = 'foo'
+      </script>
+
+      <script setup>
+      import { ref } from 'vue'
+      const root = ref()
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'preferUseTemplateRef',
+          data: {
+            name: 'ref'
+          },
+          line: 12,
+          column: 20
         }
       ]
     }

--- a/tests/lib/rules/prefer-use-template-ref.js
+++ b/tests/lib/rules/prefer-use-template-ref.js
@@ -265,7 +265,24 @@ tester.run('prefer-use-template-ref', rule, {
       `
     },
     {
-      filename: 'multiple-scripts.vue',
+      filename: 'multiple-scripts-setup-first.vue',
+      code: `
+      <template>
+        <div ref="root" :data-a="A" />
+      </template>
+
+      <script setup>
+      import { useTemplateRef } from 'vue'
+      const root = useTemplateRef('root')
+      </script>
+
+      <script>
+      const A = 'foo'
+      </script>
+      `
+    },
+    {
+      filename: 'multiple-scripts-setup-last.vue',
       code: `
       <template>
         <div ref="root" :data-a="A" />
@@ -439,7 +456,34 @@ tester.run('prefer-use-template-ref', rule, {
       ]
     },
     {
-      filename: 'multiple-scripts.vue',
+      filename: 'multiple-scripts-setup-first.vue',
+      code: `
+      <template>
+        <div ref="root" :data-a="A" />
+      </template>
+
+      <script setup>
+      import { ref } from 'vue'
+      const root = ref()
+      </script>
+
+      <script>
+      const A = 'foo'
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'preferUseTemplateRef',
+          data: {
+            name: 'ref'
+          },
+          line: 8,
+          column: 20
+        }
+      ]
+    },
+    {
+      filename: 'multiple-scripts-setup-last.vue',
       code: `
       <template>
         <div ref="root" :data-a="A" />


### PR DESCRIPTION
This PR fixes #2696 and adds test cases for it.

When multiple script blocks exist and walk AST of node `Program`, `inScriptSetup(node)` will return false.

The range of node Program contains the range of script setup block.