### PR TITLE
fix(require-default-prop): avoid requiring defaults for optional props not included in destructuring

### DIFF
--- a/.changeset/wise-bugs-peel.md
+++ b/.changeset/wise-bugs-peel.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-vue': patch
+---
+
+[vue/require-default-prop](https://eslint.vuejs.org/rules/require-default-prop.html) now ignores optional props that are not included in Vue 3.5 props destructuring pattern.

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -207,6 +207,19 @@ module.exports = {
               if (defaultsByWithDefaults[prop.propName]) {
                 return true
               }
+              // If using props destructure and this is an optional prop that is NOT included
+              // in the destructure pattern, exclude it from the report
+              if (
+                isUsingPropsDestructure &&
+                !prop.required &&
+                prop.propName != null
+              ) {
+                const destructuredProps = utils.getPropsDestructure(node)
+                if (!destructuredProps[prop.propName]) {
+                  // Optional prop is not destructured, so no default value is needed
+                  return true
+                }
+              }
             }
             if (!isUsingPropsDestructure) {
               return false

--- a/tests/lib/rules/require-default-prop.js
+++ b/tests/lib/rules/require-default-prop.js
@@ -413,6 +413,40 @@ ruleTester.run('require-default-prop', rule, {
         ...languageOptions,
         parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
       }
+    },
+    // Optional props that are not destructured should not require default values
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const { bar } = defineProps<{
+        foo?: string;
+        bar: string;
+      }>()
+      </script>
+      `,
+      languageOptions: {
+        parser: require('vue-eslint-parser'),
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const { bar } = defineProps<{
+        foo?: string;
+        bar: string;
+        baz?: number;
+      }>()
+      </script>
+      `,
+      languageOptions: {
+        parser: require('vue-eslint-parser'),
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
     }
   ],
 
@@ -728,6 +762,7 @@ ruleTester.run('require-default-prop', rule, {
     },
     {
       // https://github.com/vuejs/eslint-plugin-vue/issues/2725
+      // Optional props that ARE destructured should still require default values
       filename: 'type-with-props-destructure.vue',
       code: `
       <script setup lang="ts">
@@ -742,6 +777,30 @@ ruleTester.run('require-default-prop', rule, {
       errors: [
         {
           message: "Prop 'foo' requires default value to be set.",
+          line: 3
+        }
+      ]
+    },
+    {
+      // Optional props that are NOT destructured should still cause errors if they are used in destructuring without defaults
+      filename: 'mixed-optional-destructure.vue',
+      code: `
+      <script setup lang="ts">
+      const {foo, bar, baz} = defineProps<{foo?: number; bar: number; baz?: string}>()
+      </script>
+      `,
+      languageOptions: {
+        parser: require('vue-eslint-parser'),
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      },
+      errors: [
+        {
+          message: "Prop 'foo' requires default value to be set.",
+          line: 3
+        },
+        {
+          message: "Prop 'baz' requires default value to be set.",
           line: 3
         }
       ]


### PR DESCRIPTION
Fixes https://github.com/vuejs/eslint-plugin-vue/issues/2767

If this approach doesn't align with the project's direction, please don't hesitate to reject this proposal. In that case, you may also close the corresponding issue.



## What type of PR is this?

bug fix / enhancement

## What does this PR do? / Why do we need it?

This PR fixes a regression in the `vue/require-default-prop` rule introduced in v10.1.0. The rule was requiring default values for ALL optional props when using props destructuring, even if those props were not included in the destructuring pattern.

### Before this fix
```typescript
// Was forced to destructure all optional props, even unused ones
const { used, unused = undefined } = defineProps<{
  used?: string;
  unused?: string; // Only used in template, forced to assign undefined
}>()
```

### After this fix
```typescript
// Only need to provide defaults for actually destructured optional props
const { used = 'default' } = defineProps<{
  used?: string;    // Destructured, so needs default
  unused?: string;  // Not destructured, no default needed
}>()
```

## What changes did you make? (Give an overview)

1. **Modified `lib/rules/require-default-prop.js`**:
   - Added logic to check if an optional prop is actually included in the destructuring pattern
   - Only requires default values for optional props that are explicitly destructured
   - Uses `utils.getPropsDestructure(node)` to get destructured props and check if optional prop exists

2. **Updated test cases in `tests/lib/rules/require-default-prop.js`**:
   - Added valid test cases for optional props not included in destructuring
   - Updated invalid test cases to properly test mixed scenarios
   - Added comprehensive test coverage for the new behavior

## Which issue(s) does this PR fix?

Fixes #2767
Related to #2725 and #2741

## Additional context

This change maintains backward compatibility and only reduces false positive warnings. The rule continues to work as expected for:
- Required props (still checked)
- Optional props with explicit destructuring (still requires defaults)  
- Boolean props (still exempt)
- Props using `withDefaults()` (still works)

The fix specifically addresses the user feedback that the previous fix was too aggressive and made Vue 3.5's props destructuring unnecessarily verbose.