### PR TITLE
feat: add TypeScript IntelliSense support with eslint-typegen

### DIFF
--- a/.changeset/neat-swans-argue.md
+++ b/.changeset/neat-swans-argue.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Add TypeScript IntelliSense support with eslint-typegen

--- a/.changeset/neat-swans-argue.md
+++ b/.changeset/neat-swans-argue.md
@@ -2,4 +2,4 @@
 "eslint-plugin-vue": minor
 ---
 
-Add TypeScript IntelliSense support with eslint-typegen
+Add TypeScript IntelliSense support via [eslint-typegen](https://github.com/antfu/eslint-typegen)

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log
 /docs/.vitepress/.temp
 /docs/.vitepress/cache
 typings/eslint/lib/rules
+eslint-typegen.d.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,19 @@
-'use strict'
+import globals from 'globals'
+import eslintPluginEslintPlugin from 'eslint-plugin-eslint-plugin/configs/all'
+import eslintPluginJsonc from 'eslint-plugin-jsonc'
+import eslintPluginNodeDependencies from 'eslint-plugin-node-dependencies'
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
+import eslintPluginUnicorn from 'eslint-plugin-unicorn'
+import vueEslintParser from 'vue-eslint-parser'
+import noInvalidMeta from './eslint-internal-rules/no-invalid-meta.js'
+import noInvalidMetaDocsCategories from './eslint-internal-rules/no-invalid-meta-docs-categories.js'
+import requireEslintCommunity from './eslint-internal-rules/require-eslint-community.js'
 
-const globals = require('globals')
-const eslintPluginEslintPlugin = require('eslint-plugin-eslint-plugin/configs/all')
-const eslintPluginJsonc = require('eslint-plugin-jsonc')
-const eslintPluginNodeDependencies = require('eslint-plugin-node-dependencies')
-const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended')
-const eslintPluginUnicorn = require('eslint-plugin-unicorn')
+// @ts-check
+/// <reference path="./eslint-typegen.d.ts" />
+import typegen from 'eslint-typegen'
 
-module.exports = [
+export default typegen([
   {
     ignores: [
       '.nyc_output',
@@ -33,9 +39,9 @@ module.exports = [
     plugins: {
       internal: {
         rules: {
-          'no-invalid-meta': require('./eslint-internal-rules/no-invalid-meta'),
-          'no-invalid-meta-docs-categories': require('./eslint-internal-rules/no-invalid-meta-docs-categories'),
-          'require-eslint-community': require('./eslint-internal-rules/require-eslint-community')
+          'no-invalid-meta': noInvalidMeta,
+          'no-invalid-meta-docs-categories': noInvalidMetaDocsCategories,
+          'require-eslint-community': requireEslintCommunity
         }
       }
     }
@@ -213,7 +219,7 @@ module.exports = [
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
-      parser: require('vue-eslint-parser')
+      parser: vueEslintParser
     }
   },
   {
@@ -241,4 +247,4 @@ module.exports = [
       'prettier/prettier': 'off'
     }
   }
-]
+])

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="./eslint-typegen.d.ts" />
 import type { Linter } from 'eslint'
 
 declare const vue: {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "docs:build": "vitepress build docs",
     "generate:version": "env-cmd -e version npm run update && npm run lint -- --fix",
     "changeset:version": "changeset version && npm run generate:version && git add --all",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "npm run typegen && changeset publish"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-unicorn": "^56.0.0",
     "eslint-plugin-vue": "file:.",
+    "eslint-typegen": "^2.2.0",
     "eslint-visitor-keys": "^4.2.0",
     "espree": "^10.4.0",
     "events": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "version": "npm run generate:version && git add .",
     "update": "node ./tools/update.js",
     "update-resources": "node ./tools/update-resources.js",
+    "typegen": "node ./tools/generate-typegen.mjs",
     "docs:watch": "vitepress dev docs",
     "predocs:build": "npm run update",
     "docs:build": "vitepress build docs",

--- a/tools/generate-typegen.mjs
+++ b/tools/generate-typegen.mjs
@@ -1,0 +1,9 @@
+import fs from 'node:fs/promises'
+import { pluginsToRulesDTS } from 'eslint-typegen/core'
+import plugin from '../lib/index.js'
+
+const dts = await pluginsToRulesDTS({
+  vue: plugin
+})
+
+await fs.writeFile('lib/eslint-typegen.d.ts', dts)


### PR DESCRIPTION
## Summary

Add TypeScript IntelliSense support via `eslint-typegen` with ESM migration for ESLint v9.0+ compatibility.

## Changes

- Integrate `eslint-typegen` for TypeScript definitions
- Convert `eslint.config.js` to `eslint.config.mjs` (required for eslint-typegen)
- Install with `--legacy-peer-deps` due to ESLint version requirements
- Update all imports to ESM format

## Benefits

- TypeScript IntelliSense for ESLint configurations
- Modern ESLint v9.0+ compatibility
- Improved developer experience with type safety

## Screenshot

| Before(No TypeScript Support) | After(TypeScript IntelliSense Active) |
|--------|--------|
| <img width="554" alt="No TypeScript Support" src="https://github.com/user-attachments/assets/52133b31-eba9-41e3-b1bb-e0be8643e3ad" /> | <img width="562" alt="TypeScript IntelliSense Active" src="https://github.com/user-attachments/assets/e8dfbcd4-077e-4235-805f-0ecd61072374" />|

close  #2757