### PR TITLE
refactor: use regexp-groups to simplify ignores (POC)

### DIFF
--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -16,8 +16,7 @@ module.exports = {
     /** @type {{ ignore: string[] }} */
     const options = context.options[0] || {}
     const { ignore = [] } = options
-    /** @type {RegExp[]} */
-    const ignorePatterns = ignore.map(regexp.toRegExp)
+    const ignoreGroupMatcher = regexp.toRegExpGroupMatcher(ignore)
 
     const sourceCode = context.getSourceCode()
     const tokenStore =
@@ -125,15 +124,12 @@ module.exports = {
      */
     function reportSlot(slotAttr) {
       const componentName = slotAttr.parent.parent.rawName
-      const componentNamePascalCase = casing.pascalCase(componentName)
-      const componentNameKebabCase = casing.kebabCase(componentName)
 
       if (
-        ignorePatterns.some(
-          (pattern) =>
-            pattern.test(componentName) ||
-            pattern.test(componentNamePascalCase) ||
-            pattern.test(componentNameKebabCase)
+        ignoreGroupMatcher(
+          componentName,
+          casing.pascalCase(componentName),
+          casing.kebabCase(componentName)
         )
       ) {
         return

--- a/lib/utils/regexp.js
+++ b/lib/utils/regexp.js
@@ -41,8 +41,32 @@ function isRegExp(string) {
   return RE_REGEXP_STR.test(string)
 }
 
+/**
+ * Converts an array of strings to a singular function to match any of them.
+ * This function converts each string to a `RegExp` and returns a function that checks all of them.
+ *
+ * @param {string[]} [patterns] The strings or regular expression strings to match.
+ * @returns {(...toCheck: string[]) => boolean} Returns a function that checks if any string matches any of the given patterns.
+ */
+function toRegExpGroupMatcher(patterns = []) {
+  if (patterns.length === 0) {
+    return () => false
+  }
+
+  // In the future, we could optimize this by joining expressions with identical flags.
+  const regexps = patterns.map(toRegExp)
+
+  if (regexps.length === 1) {
+    return (...toCheck) => toCheck.some((str) => regexps[0].test(str))
+  }
+
+  return (...toCheck) =>
+    regexps.some((regexp) => toCheck.some((str) => regexp.test(str)))
+}
+
 module.exports = {
   escape,
   toRegExp,
-  isRegExp
+  isRegExp,
+  toRegExpGroupMatcher
 }


### PR DESCRIPTION
Implement idea suggested here: https://github.com/vuejs/eslint-plugin-vue/pull/2773#discussion_r2176903520

- https://github.com/vuejs/eslint-plugin-vue/pull/2773#discussion_r2176903520

---

Excluding/Ignoring things is a common task in rules. This PR creates a helper that hides all the string[] -> regexp[] -> boolean logic in a simple helper function.

````js
onst options = context.options[0] || {}
const { ignore = [] } = options
const ignoreGroupMatcher = regexp.toRegExpGroupMatcher(ignore)

...

 if (
  ignoreGroupMatcher(
    componentName,
    casing.pascalCase(componentName),
    casing.kebabCase(componentName)
  )
) {
  // skip
  return
}
````

The current project contains at least 9 instances of `.map(toRegExp)` + a few more using more verbose syntax.

If the general design of this feature is accepted, I will convert the other locations to the new feature and mark this PR as ~~POC~~.

I'm not super happy with the method name and jsdocs, so any input would be appreciated.