### PR TITLE
feat(no-deprecated-slot-attribute): add ignoreParents option

### DIFF
--- a/.changeset/beige-teams-camp.md
+++ b/.changeset/beige-teams-camp.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-vue': minor
+---
+
+Added `ignoreParents` option to `no-deprecated-slot-attribute`

--- a/.changeset/beige-teams-camp.md
+++ b/.changeset/beige-teams-camp.md
@@ -2,4 +2,4 @@
 'eslint-plugin-vue': minor
 ---
 
-Added `ignoreParents` option to `no-deprecated-slot-attribute`
+Added `ignoreParents` option to [`vue/no-deprecated-slot-attribute`](https://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html)

--- a/docs/rules/no-deprecated-slot-attribute.md
+++ b/docs/rules/no-deprecated-slot-attribute.md
@@ -50,7 +50,7 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
 ```
 
 - `"ignore"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) that ignore these rules. This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
-- `"ignoreParents"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) for parents that ignore these rules. This option is especially useful for Web-Components. This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
+- `"ignoreParents"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) for parents that ignore these rules. This option is especially useful for [Web-Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
 
 ### `"ignore": ["my-component"]`
 
@@ -117,6 +117,7 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
 ## :books: Further Reading
 
 - [API - slot](https://v2.vuejs.org/v2/api/#slot-deprecated)
+- [Web - slot](https://developer.mozilla.org/en-US/docs/Web/API/Element/slot)
 
 ## :rocket: Version
 

--- a/docs/rules/no-deprecated-slot-attribute.md
+++ b/docs/rules/no-deprecated-slot-attribute.md
@@ -89,19 +89,19 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
 
 ```vue
 <template>
-  <my-web-component'>
+  <my-web-component>
     <!-- ✓ GOOD -->
     <template v-slot:name>
       {{ props.title }}
     </template>
-  </my-web-component'>
+  </my-web-component>
 
-  <my-web-component'>
+  <my-web-component>
     <!-- ✓ GOOD -->
     <my-component slot="name">
       {{ props.title }}
     </my-component>
-  </my-web-component'>
+  </my-web-component>
 
   <other-component>
     <!-- ✗ BAD -->

--- a/docs/rules/no-deprecated-slot-attribute.md
+++ b/docs/rules/no-deprecated-slot-attribute.md
@@ -43,16 +43,18 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
 ```json
 {
   "vue/no-deprecated-slot-attribute": ["error", {
-    "ignore": ["my-component"]
+    "ignore": ["my-component"],
+    "ignoreParents": ["my-web-component"],
   }]
 }
 ```
 
 - `"ignore"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) that ignore these rules. This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
+- `"ignoreParents"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) for parents that ignore these rules. This option is especially useful for Web-Components. This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
 
 ### `"ignore": ["my-component"]`
 
-<eslint-code-block fix :rules="{'vue/no-dupe-keys': ['error', {ignore: ['my-component']}]}">
+<eslint-code-block fix :rules="{'vue/no-deprecated-slot-attribute': ['error', {ignore: ['my-component']}]}">
 
 ```vue
 <template>
@@ -76,6 +78,37 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
       {{ props.title }}
     </other-component>
   </ListComponent>
+</template>
+```
+
+</eslint-code-block>
+
+### `"ignoreParents": ["my-web-component"]`
+
+<eslint-code-block fix :rules="{'vue/no-deprecated-slot-attribute': ['error', {ignoreParents: ['my-web-component']}]}">
+
+```vue
+<template>
+  <my-web-component'>
+    <!-- ✓ GOOD -->
+    <template v-slot:name>
+      {{ props.title }}
+    </template>
+  </my-web-component'>
+
+  <my-web-component'>
+    <!-- ✓ GOOD -->
+    <my-component slot="name">
+      {{ props.title }}
+    </my-component>
+  </my-web-component'>
+
+  <other-component>
+    <!-- ✗ BAD -->
+    <my-component slot="name">
+      {{ props.title }}
+    </my-component>
+  </other-component>
 </template>
 ```
 

--- a/docs/rules/no-deprecated-slot-attribute.md
+++ b/docs/rules/no-deprecated-slot-attribute.md
@@ -50,7 +50,7 @@ This rule reports deprecated `slot` attribute in Vue.js v2.6.0+.
 ```
 
 - `"ignore"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) that ignore these rules. This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
-- `"ignoreParents"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) for parents that ignore these rules. This option is especially useful for [Web-Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). This option will check both kebab-case and PascalCase versions of the given tag names. Default is empty.
+- `"ignoreParents"` (`string[]`) An array of tags or regular expression patterns (e.g. `/^custom-/`) for parents that ignore these rules. This option is especially useful for [Web-Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). Default is empty.
 
 ### `"ignore": ["my-component"]`
 

--- a/lib/rules/no-deprecated-slot-attribute.js
+++ b/lib/rules/no-deprecated-slot-attribute.js
@@ -25,6 +25,11 @@ module.exports = {
             type: 'array',
             items: { type: 'string' },
             uniqueItems: true
+          },
+          ignoreParents: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -18,7 +18,7 @@ module.exports = {
     const options = context.options[0] || {}
     const { ignore = [], ignoreParents = [] } = options
     const isAnyIgnored = regexp.toRegExpGroupMatcher(ignore)
-    const isAnyParentIgnored = regexp.toRegExpGroupMatcher(ignoreParents)
+    const isParentIgnored = regexp.toRegExpGroupMatcher(ignoreParents)
 
     const sourceCode = context.getSourceCode()
     const tokenStore =
@@ -140,7 +140,7 @@ module.exports = {
 
       const parent = component.parent
       const parentName = isVElement(parent) ? parent.rawName : null
-      if (parentName && isAnyParentIgnored(parentName)) {
+      if (parentName && isParentIgnored(parentName)) {
         return
       }
 

--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -140,14 +140,7 @@ module.exports = {
 
       const parent = component.parent
       const parentName = isVElement(parent) ? parent.rawName : null
-      if (
-        parentName &&
-        isAnyParentIgnored(
-          parentName,
-          casing.pascalCase(parentName),
-          casing.kebabCase(parentName)
-        )
-      ) {
+      if (parentName && isAnyParentIgnored(parentName)) {
         return
       }
 

--- a/lib/rules/syntaxes/slot-attribute.js
+++ b/lib/rules/syntaxes/slot-attribute.js
@@ -7,16 +7,18 @@
 const canConvertToVSlot = require('./utils/can-convert-to-v-slot')
 const regexp = require('../../utils/regexp')
 const casing = require('../../utils/casing')
+const { isVElement } = require('../../utils')
 
 module.exports = {
   deprecated: '2.6.0',
   supported: '<3.0.0',
   /** @param {RuleContext} context @returns {TemplateListener} */
   createTemplateBodyVisitor(context) {
-    /** @type {{ ignore: string[] }} */
+    /** @type {{ ignore: string[], ignoreParents: string[] }} */
     const options = context.options[0] || {}
-    const { ignore = [] } = options
+    const { ignore = [], ignoreParents = [] } = options
     const isAnyIgnored = regexp.toRegExpGroupMatcher(ignore)
+    const isAnyParentIgnored = regexp.toRegExpGroupMatcher(ignoreParents)
 
     const sourceCode = context.getSourceCode()
     const tokenStore =
@@ -123,13 +125,27 @@ module.exports = {
      * @returns {void}
      */
     function reportSlot(slotAttr) {
-      const componentName = slotAttr.parent.parent.rawName
+      const component = slotAttr.parent.parent
+      const componentName = component.rawName
 
       if (
         isAnyIgnored(
           componentName,
           casing.pascalCase(componentName),
           casing.kebabCase(componentName)
+        )
+      ) {
+        return
+      }
+
+      const parent = component.parent
+      const parentName = isVElement(parent) ? parent.rawName : null
+      if (
+        parentName &&
+        isAnyParentIgnored(
+          parentName,
+          casing.pascalCase(parentName),
+          casing.kebabCase(parentName)
         )
       ) {
         return

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2462,7 +2462,7 @@ function isAssignmentProperty(node) {
 }
 /**
  * Checks whether the given node is VElement.
- * @param {VElement | VExpressionContainer | VText} node
+ * @param {VElement | VExpressionContainer | VText | VDocumentFragment} node
  * @returns {node is VElement}
  */
 function isVElement(node) {

--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -67,6 +67,30 @@ tester.run('no-deprecated-slot-attribute', rule, {
       </LinkList>
     </template>`,
       options: [{ ignore: ['/one/', '/^Two$/i', '/^my-.*/i'] }]
+    },
+    {
+      code: `<template>
+      <LinkList>
+        <one slot="one" />
+        <two slot="two" />
+        <my-component slot="my-component-slot" />
+        <myComponent slot="myComponent-slot" />
+        <MyComponent slot="MyComponent-slot" />
+      </LinkList>
+    </template>`,
+      options: [{ ignoreParents: ['LinkList'] }]
+    },
+    {
+      code: `<template>
+      <LinkList>
+        <one slot="one" />
+        <two slot="two" />
+        <my-component slot="my-component-slot" />
+        <myComponent slot="myComponent-slot" />
+        <MyComponent slot="MyComponent-slot" />
+      </LinkList>
+    </template>`,
+      options: [{ ignoreParents: ['/^Link/'] }]
     }
   ],
   invalid: [
@@ -728,6 +752,90 @@ tester.run('no-deprecated-slot-attribute', rule, {
           line: 7,
           endLine: 7,
           column: 16,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <my-component>
+          <one slot="one">
+            A
+          </one>
+        </my-component>
+        <my-component2>
+          <two slot="two">
+            B
+          </two>
+        </my-component2>
+      </template>`,
+      output: `
+      <template>
+        <my-component>
+          <one slot="one">
+            A
+          </one>
+        </my-component>
+        <my-component2>
+          <template v-slot:two>\n<two >
+            B
+          </two>\n</template>
+        </my-component2>
+      </template>`,
+      options: [
+        {
+          ignoreParents: ['my-component']
+        }
+      ],
+      errors: [
+        {
+          message: '`slot` attributes are deprecated.',
+          line: 9,
+          column: 16,
+          endLine: 9,
+          endColumn: 20
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <my-component>
+          <one slot="one">
+            A
+          </one>
+        </my-component>
+        <my-component2>
+          <two slot="two">
+            B
+          </two>
+        </my-component2>
+      </template>`,
+      output: `
+      <template>
+        <my-component>
+          <one slot="one">
+            A
+          </one>
+        </my-component>
+        <my-component2>
+          <template v-slot:two>\n<two >
+            B
+          </two>\n</template>
+        </my-component2>
+      </template>`,
+      options: [
+        {
+          ignoreParents: ['/component$/']
+        }
+      ],
+      errors: [
+        {
+          message: '`slot` attributes are deprecated.',
+          line: 9,
+          column: 16,
+          endLine: 9,
           endColumn: 20
         }
       ]


### PR DESCRIPTION
Adds #2710

- #2710

---

Adds an `ignoreParents: string[]` option to `no-deprecated-slot-attribute` to allow ignoring web-component usecases:

````vue
<template>
	<web-component>
 		<Entry slot="entry" />
	</web-component>
</template>
````

Preview:

- [`rules/no-deprecated-slot-attribute` (new)](https://deploy-preview-2784--eslint-plugin-vue.netlify.app/rules/no-deprecated-slot-attribute.html)
- [`rules/no-deprecated-slot-attribute` (current)](https://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html)

---

Note to self: Next PR(s):

- Increase the specificity of the rule test case assertions https://github.com/vuejs/eslint-plugin-vue/pull/2773#discussion_r2176359714