### PR TITLE
fix: resolve TypeScript compatibility issues with eslint-typegen

### DIFF
--- a/.changeset/eight-camels-refuse.md
+++ b/.changeset/eight-camels-refuse.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Resolved TypeScript compatibility issues introduced by eslint-typegen

--- a/tools/generate-typegen.mjs
+++ b/tools/generate-typegen.mjs
@@ -2,8 +2,13 @@ import fs from 'node:fs/promises'
 import { pluginsToRulesDTS } from 'eslint-typegen/core'
 import plugin from '../lib/index.js'
 
-const dts = await pluginsToRulesDTS({
-  vue: plugin
-})
+const dts = await pluginsToRulesDTS(
+  {
+    vue: plugin
+  },
+  {
+    includeAugmentation: false
+  }
+)
 
 await fs.writeFile('lib/eslint-typegen.d.ts', dts)


### PR DESCRIPTION
## Summary
Fixes TypeScript compatibility issues between eslint-plugin-vue and ESLint types by setting `includeAugmentation: false` in the eslint-typegen configuration.

## Solution
Set `includeAugmentation: false` to generate standalone type definitions instead of augmenting ESLint's built-in types. This approach is also used by [@antfu/eslint-config](https://github.com/antfu/eslint-config/blob/95963ac345d27cd06a4eeb5ebc16e1848cb2fd81/scripts/typegen.ts#L29-L33).

Closes  #2788