### PR TITLE
fix(block-lang): use consistent quotation marks in error messages

### DIFF
--- a/.changeset/strong-masks-fetch.md
+++ b/.changeset/strong-masks-fetch.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-vue': patch
+---
+
+Fixed inconsistent quotes in [`vue/block-lang`](https://eslint.vuejs.org/rules/block-lang.html) error messages

--- a/lib/rules/block-lang.js
+++ b/lib/rules/block-lang.js
@@ -40,7 +40,7 @@ const DEFAULT_LANGUAGES = {
  * @param {NonNullable<BlockOptions['lang']>} lang
  */
 function getAllowsLangPhrase(lang) {
-  const langs = [...lang].map((s) => `"${s}"`)
+  const langs = [...lang].map((s) => `'${s}'`)
   switch (langs.length) {
     case 1: {
       return langs[0]
@@ -157,7 +157,7 @@ module.exports = {
       missing: "The 'lang' attribute of '<{{tag}}>' is missing.",
       unexpected: "Do not specify the 'lang' attribute of '<{{tag}}>'.",
       useOrNot:
-        "Only {{allows}} can be used for the 'lang' attribute of '<{{tag}}>'. Or, not specifying the `lang` attribute is allowed.",
+        "Only {{allows}} can be used for the 'lang' attribute of '<{{tag}}>'. Or, not specifying the 'lang' attribute is allowed.",
       unexpectedDefault:
         "Do not explicitly specify the default language for the 'lang' attribute of '<{{tag}}>'."
     }

--- a/tests/lib/rules/block-lang.js
+++ b/tests/lib/rules/block-lang.js
@@ -44,7 +44,9 @@ tester.run('block-lang', rule, {
         {
           message: `Only "ts" can be used for the 'lang' attribute of '<script>'.`,
           line: 2,
-          column: 15
+          column: 15,
+          endLine: 2,
+          endColumn: 24
         }
       ]
     },
@@ -56,7 +58,9 @@ tester.run('block-lang', rule, {
         {
           message: `Only "ts" can be used for the 'lang' attribute of '<script>'.`,
           line: 2,
-          column: 15
+          column: 15,
+          endLine: 2,
+          endColumn: 24
         }
       ]
     },
@@ -68,7 +72,9 @@ tester.run('block-lang', rule, {
         {
           message: "The 'lang' attribute of '<script>' is missing.",
           line: 2,
-          column: 7
+          column: 7,
+          endLine: 2,
+          endColumn: 15
         }
       ]
     },
@@ -80,7 +86,9 @@ tester.run('block-lang', rule, {
         {
           message: `Only "ts" can be used for the 'lang' attribute of '<script>'.`,
           line: 2,
-          column: 15
+          column: 15,
+          endLine: 2,
+          endColumn: 22
         }
       ]
     },
@@ -91,7 +99,9 @@ tester.run('block-lang', rule, {
         {
           message: "Do not specify the 'lang' attribute of '<script>'.",
           line: 1,
-          column: 30
+          column: 30,
+          endLine: 1,
+          endColumn: 39
         }
       ]
     },
@@ -103,7 +113,9 @@ tester.run('block-lang', rule, {
           message:
             "Do not explicitly specify the default language for the 'lang' attribute of '<script>'.",
           line: 1,
-          column: 30
+          column: 30,
+          endLine: 1,
+          endColumn: 39
         }
       ]
     },
@@ -114,7 +126,9 @@ tester.run('block-lang', rule, {
         {
           message: "Do not specify the 'lang' attribute of '<script>'.",
           line: 1,
-          column: 30
+          column: 30,
+          endLine: 1,
+          endColumn: 39
         }
       ]
     },
@@ -126,7 +140,9 @@ tester.run('block-lang', rule, {
         {
           message: "The 'lang' attribute of '<i18n>' is missing.",
           line: 1,
-          column: 1
+          column: 1,
+          endLine: 1,
+          endColumn: 7
         }
       ]
     },
@@ -139,7 +155,9 @@ tester.run('block-lang', rule, {
           message:
             "Only \"json\" can be used for the 'lang' attribute of '<i18n>'. Or, not specifying the `lang` attribute is allowed.",
           line: 2,
-          column: 13
+          column: 13,
+          endLine: 2,
+          endColumn: 24
         }
       ]
     },
@@ -152,7 +170,9 @@ tester.run('block-lang', rule, {
           message:
             'Only "json", and "yaml" can be used for the \'lang\' attribute of \'<i18n>\'. Or, not specifying the `lang` attribute is allowed.',
           line: 2,
-          column: 13
+          column: 13,
+          endLine: 2,
+          endColumn: 24
         }
       ]
     },
@@ -165,17 +185,23 @@ tester.run('block-lang', rule, {
         {
           message: "Do not specify the 'lang' attribute of '<template>'.",
           line: 1,
-          column: 11
+          column: 11,
+          endLine: 1,
+          endColumn: 21
         },
         {
           message: "Do not specify the 'lang' attribute of '<script>'.",
           line: 2,
-          column: 15
+          column: 15,
+          endLine: 2,
+          endColumn: 24
         },
         {
           message: "Do not specify the 'lang' attribute of '<style>'.",
           line: 3,
-          column: 14
+          column: 14,
+          endLine: 3,
+          endColumn: 27
         }
       ]
     }

--- a/tests/lib/rules/block-lang.js
+++ b/tests/lib/rules/block-lang.js
@@ -42,7 +42,8 @@ tester.run('block-lang', rule, {
       options: [{ script: { lang: 'ts' } }],
       errors: [
         {
-          message: `Only "ts" can be used for the 'lang' attribute of '<script>'.`,
+          message:
+            "Only 'ts' can be used for the 'lang' attribute of '<script>'.",
           line: 2,
           column: 15,
           endLine: 2,
@@ -56,7 +57,8 @@ tester.run('block-lang', rule, {
       options: [{ script: { lang: ['ts'] } }],
       errors: [
         {
-          message: `Only "ts" can be used for the 'lang' attribute of '<script>'.`,
+          message:
+            "Only 'ts' can be used for the 'lang' attribute of '<script>'.",
           line: 2,
           column: 15,
           endLine: 2,
@@ -84,7 +86,8 @@ tester.run('block-lang', rule, {
       options: [{ script: { lang: 'ts' } }],
       errors: [
         {
-          message: `Only "ts" can be used for the 'lang' attribute of '<script>'.`,
+          message:
+            "Only 'ts' can be used for the 'lang' attribute of '<script>'.",
           line: 2,
           column: 15,
           endLine: 2,
@@ -153,7 +156,7 @@ tester.run('block-lang', rule, {
       errors: [
         {
           message:
-            "Only \"json\" can be used for the 'lang' attribute of '<i18n>'. Or, not specifying the `lang` attribute is allowed.",
+            "Only 'json' can be used for the 'lang' attribute of '<i18n>'. Or, not specifying the `lang` attribute is allowed.",
           line: 2,
           column: 13,
           endLine: 2,
@@ -168,7 +171,7 @@ tester.run('block-lang', rule, {
       errors: [
         {
           message:
-            'Only "json", and "yaml" can be used for the \'lang\' attribute of \'<i18n>\'. Or, not specifying the `lang` attribute is allowed.',
+            "Only 'json', and 'yaml' can be used for the 'lang' attribute of '<i18n>'. Or, not specifying the `lang` attribute is allowed.",
           line: 2,
           column: 13,
           endLine: 2,


### PR DESCRIPTION
Follow-Up on #2804

- #2804

---

While updating the tests, I noticed that the error messages use `"`, `'` and <code>`</code> for quoting/highlighting things.
This PR changes this to only use <code>'</code>.

Do I need to create an issue for this one?

---

Blocked by #2804