### PR TITLE
test(brace-style): make tests more strict

### DIFF
--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -40,7 +40,10 @@ tester.run('brace-style', rule, {
         {
           message:
             'Opening curly brace does not appear on the same line as controlling statement.',
-          line: 4
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 12
         }
       ]
     },
@@ -58,12 +61,18 @@ tester.run('brace-style', rule, {
       errors: [
         {
           message: 'Statement inside of curly braces should be on next line.',
-          line: 3
+          line: 3,
+          column: 38,
+          endLine: 3,
+          endColumn: 39
         },
         {
           message:
             'Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.',
-          line: 3
+          line: 3,
+          column: 53,
+          endLine: 3,
+          endColumn: 54
         }
       ]
     },
@@ -74,11 +83,19 @@ return(1)
 })()" /></template>`,
       errors: [
         {
-          message: 'Statement inside of curly braces should be on next line.'
+          message: 'Statement inside of curly braces should be on next line.',
+          line: 1,
+          column: 57,
+          endLine: 1,
+          endColumn: 58
         },
         {
           message:
-            'Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.'
+            'Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.',
+          line: 1,
+          column: 67,
+          endLine: 1,
+          endColumn: 68
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793

- #2793 

---

This PR converts all error assertions for `brace-style` to include both error message and full location checks.