### PR TITLE
test(dot-location): make tests more strict

### DIFF
--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -48,7 +48,10 @@ tester.run('dot-location', rule, {
       errors: [
         {
           message: 'Expected dot to be on same line as object.',
-          line: 5
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 14
         }
       ]
     },
@@ -71,7 +74,10 @@ tester.run('dot-location', rule, {
       errors: [
         {
           message: 'Expected dot to be on same line as property.',
-          line: 4
+          line: 4,
+          column: 21,
+          endLine: 4,
+          endColumn: 22
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793

- #2793

---

This PR converts all error assertions for `dot-location` to include both error message and full location checks.