### PR TITLE
test(eqeqeq): make tests more strict

### DIFF
--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -35,7 +35,11 @@ tester.run('eqeqeq', rule, {
                   output: `<template><div :attr="a === 1" /></template>`
                 }
               ]
-            : null
+            : null,
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 27
         }
       ]
     },
@@ -62,7 +66,11 @@ tester.run('eqeqeq', rule, {
       </style>`
                 }
               ]
-            : null
+            : null,
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 27
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `eqeqeq` to include both error message and full location checks.