### PR TITLE
test(html-button-has-type): make tests more strict

### DIFF
--- a/tests/lib/rules/html-button-has-type.js
+++ b/tests/lib/rules/html-button-has-type.js
@@ -58,7 +58,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'Missing an explicit type attribute for button.',
-          column: 11
+          column: 11,
+          line: 1,
+          endLine: 1,
+          endColumn: 19
         }
       ]
     },
@@ -68,7 +71,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'A value must be set for button type attribute.',
-          column: 24
+          column: 24,
+          line: 1,
+          endLine: 1,
+          endColumn: 26
         }
       ]
     },
@@ -78,7 +84,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'A value must be set for button type attribute.',
-          column: 19
+          column: 19,
+          line: 1,
+          endLine: 1,
+          endColumn: 23
         }
       ]
     },
@@ -88,7 +97,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'foo is an invalid value for button type attribute.',
-          column: 24
+          column: 24,
+          line: 1,
+          endLine: 1,
+          endColumn: 29
         }
       ]
     },
@@ -99,7 +111,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'button is a forbidden value for button type attribute.',
-          column: 24
+          column: 24,
+          line: 1,
+          endLine: 1,
+          endColumn: 32
         }
       ]
     },
@@ -110,7 +125,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'submit is a forbidden value for button type attribute.',
-          column: 24
+          column: 24,
+          line: 1,
+          endLine: 1,
+          endColumn: 32
         }
       ]
     },
@@ -121,7 +139,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'reset is a forbidden value for button type attribute.',
-          column: 24
+          column: 24,
+          line: 1,
+          endLine: 1,
+          endColumn: 31
         }
       ]
     },
@@ -137,17 +158,23 @@ ruleTester.run('html-button-has-type', rule, {
         {
           message: 'button is a forbidden value for button type attribute.',
           line: 2,
-          column: 30
+          column: 30,
+          endLine: 2,
+          endColumn: 38
         },
         {
           message: 'submit is a forbidden value for button type attribute.',
           line: 3,
-          column: 30
+          column: 30,
+          endLine: 3,
+          endColumn: 38
         },
         {
           message: 'reset is a forbidden value for button type attribute.',
           line: 4,
-          column: 30
+          column: 30,
+          endLine: 4,
+          endColumn: 37
         }
       ]
     },
@@ -165,17 +192,23 @@ ruleTester.run('html-button-has-type', rule, {
         {
           message: 'reset is a forbidden value for button type attribute.',
           line: 4,
-          column: 30
+          column: 30,
+          endLine: 4,
+          endColumn: 37
         },
         {
           message: 'A value must be set for button type attribute.',
           line: 5,
-          column: 30
+          column: 30,
+          endLine: 5,
+          endColumn: 32
         },
         {
           message: 'foo is an invalid value for button type attribute.',
           line: 6,
-          column: 30
+          column: 30,
+          endLine: 6,
+          endColumn: 35
         }
       ]
     },
@@ -185,11 +218,17 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'Missing an explicit type attribute for button.',
-          column: 11
+          column: 11,
+          line: 1,
+          endLine: 1,
+          endColumn: 19
         },
         {
           message: 'Missing an explicit type attribute for button.',
-          column: 39
+          column: 39,
+          line: 1,
+          endLine: 1,
+          endColumn: 47
         }
       ]
     },
@@ -199,7 +238,10 @@ ruleTester.run('html-button-has-type', rule, {
       errors: [
         {
           message: 'A value must be set for button type attribute.',
-          column: 25
+          column: 25,
+          line: 1,
+          endLine: 1,
+          endColumn: 27
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `html-button-has-type` to include both error message and full location checks.