### PR TITLE
test(html-end-tags): make tests more strict

### DIFF
--- a/tests/lib/rules/html-end-tags.js
+++ b/tests/lib/rules/html-end-tags.js
@@ -80,13 +80,29 @@ tester.run('html-end-tags', rule, {
       filename: 'test.vue',
       code: '<template><div><div></div></template>',
       output: '<template><div><div></div></div></template>',
-      errors: ["'<div>' should have end tag."]
+      errors: [
+        {
+          message: "'<div>' should have end tag.",
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 16
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div><p></div></template>',
       output: '<template><div><p></p></div></template>',
-      errors: ["'<p>' should have end tag."]
+      errors: [
+        {
+          message: "'<p>' should have end tag.",
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 19
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Continuation of #2793
	- #2793
	---
	This PR converts all error assertions for `html-end-tags` to include both error message and full location checks.