### PR TITLE
test(html-quotes): make tests more strict

### DIFF
--- a/tests/lib/rules/html-quotes.js
+++ b/tests/lib/rules/html-quotes.js
@@ -82,101 +82,221 @@ tester.run('html-quotes', rule, {
       filename: 'test.vue',
       code: '<template><div class=foo></div></template>',
       output: '<template><div class="foo"></div></template>',
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: "<template><div class='foo'></div></template>",
       output: '<template><div class="foo"></div></template>',
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div :class=foo></div></template>',
       output: '<template><div :class="foo"></div></template>',
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: "<template><div :class='foo'></div></template>",
       output: '<template><div :class="foo"></div></template>',
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div :class=foo+"bar"></div></template>',
       output: '<template><div :class="foo+&quot;bar&quot;"></div></template>',
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div class=foo></div></template>',
       output: '<template><div class="foo"></div></template>',
       options: ['double'],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: "<template><div class='foo'></div></template>",
       output: '<template><div class="foo"></div></template>',
       options: ['double'],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div :class=foo></div></template>',
       output: '<template><div :class="foo"></div></template>',
       options: ['double'],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: "<template><div :class='foo'></div></template>",
       output: '<template><div :class="foo"></div></template>',
       options: ['double'],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div :class=foo+"bar"></div></template>',
       output: '<template><div :class="foo+&quot;bar&quot;"></div></template>',
       options: ['double'],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div class=foo></div></template>',
       output: "<template><div class='foo'></div></template>",
       options: ['single'],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 25
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div class="foo"></div></template>',
       output: "<template><div class='foo'></div></template>",
       options: ['single'],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 27
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div :class=foo></div></template>',
       output: "<template><div :class='foo'></div></template>",
       options: ['single'],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div :class="foo"></div></template>',
       output: "<template><div :class='foo'></div></template>",
       options: ['single'],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: "<template><div :class=foo+'bar'></div></template>",
       output: "<template><div :class='foo+&apos;bar&apos;'></div></template>",
       options: ['single'],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 23,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
     },
     // avoidEscape
     {
@@ -184,42 +304,90 @@ tester.run('html-quotes', rule, {
       code: "<template><div attr='foo'></div></template>",
       output: '<template><div attr="foo"></div></template>',
       options: ['double', { avoidEscape: true }],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div attr="bar"></div></template>',
       output: "<template><div attr='bar'></div></template>",
       options: ['single', { avoidEscape: true }],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 26
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div attr=foo"bar></div></template>',
       output: "<template><div attr='foo\"bar'></div></template>",
       options: ['double', { avoidEscape: true }],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: "<template><div attr=foo'bar></div></template>",
       output: '<template><div attr="foo\'bar"></div></template>',
       options: ['single', { avoidEscape: true }],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div attr=foo"bar\'baz></div></template>',
       output: '<template><div attr="foo&quot;bar\'baz"></div></template>',
       options: ['double', { avoidEscape: true }],
-      errors: ['Expected to be enclosed by double quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by double quotes.',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div attr=foo"bar\'baz></div></template>',
       output: "<template><div attr='foo\"bar&apos;baz'></div></template>",
       options: ['single', { avoidEscape: true }],
-      errors: ['Expected to be enclosed by single quotes.']
+      errors: [
+        {
+          message: 'Expected to be enclosed by single quotes.',
+          line: 1,
+          column: 21,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Continuation of #2793

- #2793

---

This PR converts all error assertions for `html-quotes` to include both error message and full location checks.
