### PR TITLE
test(jsx-uses-vars): make tests more strict

### DIFF
--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -124,7 +124,11 @@ describe('jsx-uses-vars', () => {
       `
                   }
                 ]
-              : null
+              : null,
+            line: 3,
+            column: 16,
+            endLine: 3,
+            endColumn: 29
           }
         ]
       },
@@ -162,7 +166,11 @@ describe('jsx-uses-vars', () => {
       `
                   }
                 ]
-              : null
+              : null,
+            line: 4,
+            column: 15,
+            endLine: 4,
+            endColumn: 22
           }
         ]
       }


### PR DESCRIPTION
Continuation of #2793

- #2793

---

This PR converts all error assertions for `jsx-uses-vars` to include both error message and full location checks.
