### PR TITLE
test(match-component-file-name): make tests more strict

### DIFF
--- a/tests/lib/rules/match-component-file-name.js
+++ b/tests/lib/rules/match-component-file-name.js
@@ -596,7 +596,11 @@ ruleTester.run('match-component-file-name', rule, {
         }
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -624,7 +628,11 @@ ruleTester.run('match-component-file-name', rule, {
         }
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -652,7 +660,11 @@ ruleTester.run('match-component-file-name', rule, {
         }
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -680,7 +692,11 @@ ruleTester.run('match-component-file-name', rule, {
         }
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -717,7 +733,11 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `
             }
-          ]
+          ],
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 31
         }
       ]
     },
@@ -752,7 +772,11 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `
             }
-          ]
+          ],
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 31
         }
       ]
     },
@@ -787,7 +811,11 @@ ruleTester.run('match-component-file-name', rule, {
         </script>
       `
             }
-          ]
+          ],
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 31
         }
       ]
     },
@@ -817,7 +845,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -845,7 +877,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -873,7 +909,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -899,7 +939,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -925,7 +969,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -951,7 +999,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 29
         }
       ]
     },
@@ -977,7 +1029,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 2,
+          column: 23,
+          endLine: 2,
+          endColumn: 35
         }
       ]
     },
@@ -1003,7 +1059,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 2,
+          column: 23,
+          endLine: 2,
+          endColumn: 35
         }
       ]
     },
@@ -1029,7 +1089,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 2,
+          column: 23,
+          endLine: 2,
+          endColumn: 35
         }
       ]
     },
@@ -1055,7 +1119,11 @@ ruleTester.run('match-component-file-name', rule, {
         })
       `
             }
-          ]
+          ],
+          line: 2,
+          column: 23,
+          endLine: 2,
+          endColumn: 35
         }
       ]
     },
@@ -1085,7 +1153,11 @@ ruleTester.run('match-component-file-name', rule, {
         }
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 31
         }
       ]
     },
@@ -1113,7 +1185,11 @@ ruleTester.run('match-component-file-name', rule, {
         }
       `
             }
-          ]
+          ],
+          line: 3,
+          column: 17,
+          endLine: 3,
+          endColumn: 30
         }
       ]
     },
@@ -1134,7 +1210,11 @@ ruleTester.run('match-component-file-name', rule, {
               desc: 'Rename component to match file name.',
               output: `<script setup> defineOptions({name: 'MyComponent'}) </script>`
             }
-          ]
+          ],
+          line: 1,
+          column: 37,
+          endLine: 1,
+          endColumn: 52
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793

- #2793

---

This PR converts all error assertions for `match-component-file-name` to include both error message and full location checks.
