### PR TITLE
test(match-component-import-name): make tests more strict

### DIFF
--- a/tests/lib/rules/match-component-import-name.js
+++ b/tests/lib/rules/match-component-import-name.js
@@ -65,7 +65,9 @@ tester.run('match-component-import-name', rule, {
           message:
             'Component alias InvalidExport should be one of: SomeRandomName, some-random-name.',
           line: 2,
-          column: 47
+          column: 47,
+          endLine: 2,
+          endColumn: 76
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793

- #2793

---

This PR converts all error assertions for `match-component-import-name` to include both error message and full location checks.
