### PR TITLE
test(max-lines-per-block): make tests more strict

### DIFF
--- a/tests/lib/rules/max-lines-per-block.js
+++ b/tests/lib/rules/max-lines-per-block.js
@@ -59,7 +59,9 @@ tester.run('max-lines-per-block', rule, {
         {
           message: 'Block has too many lines (2). Maximum allowed is 1.',
           line: 2,
-          column: 7
+          column: 7,
+          endLine: 5,
+          endColumn: 18
         }
       ]
     },
@@ -76,7 +78,9 @@ tester.run('max-lines-per-block', rule, {
         {
           message: 'Block has too many lines (2). Maximum allowed is 1.',
           line: 2,
-          column: 7
+          column: 7,
+          endLine: 6,
+          endColumn: 16
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793

- #2793

---

This PR converts all error assertions for `max-lines-per-block` to include both error message and full location checks.
