### PR TITLE
docs: fix typo 'identifer' to 'identifier'

### DIFF
--- a/docs/rules/match-component-import-name.md
+++ b/docs/rules/match-component-import-name.md
@@ -12,7 +12,7 @@ since: v8.7.0
 
 ## :book: Rule Details
 
-By default, this rule will validate that the imported name matches the name of the components object property identifer. Note that "matches" means that the imported name matches either the PascalCase or kebab-case version of the components object property identifer. If you would like to enforce that it must match only one of PascalCase or kebab-case, use this rule in conjunction with the rule [vue/component-definition-name-casing](./component-definition-name-casing.md).
+By default, this rule will validate that the imported name matches the name of the components object property identifier. Note that "matches" means that the imported name matches either the PascalCase or kebab-case version of the components object property identifier. If you would like to enforce that it must match only one of PascalCase or kebab-case, use this rule in conjunction with the rule [vue/component-definition-name-casing](./component-definition-name-casing.md).
 
 <eslint-code-block :rules="{'vue/match-component-import-name': ['error']}">
 


### PR DESCRIPTION
Fix typo: change identifer to identifier in [the match-component-import-name rule documentation](https://eslint.vuejs.org/rules/match-component-import-name.html#rule-details).
- ~~Fix typo in match-component-import-name rule documentation~~
- ~~Change "identifer" to correct spelling "identifier" in rule description~~