### PR TITLE
test(no-computed-properties-in-data): make tests more strict

### DIFF
--- a/tests/lib/rules/no-computed-properties-in-data.js
+++ b/tests/lib/rules/no-computed-properties-in-data.js
@@ -97,7 +97,9 @@ tester.run('no-computed-properties-in-data', rule, {
           message:
             'The computed property cannot be used in `data()` because it is before initialization.',
           line: 5,
-          column: 23
+          column: 23,
+          endLine: 5,
+          endColumn: 31
         }
       ]
     },
@@ -122,7 +124,9 @@ tester.run('no-computed-properties-in-data', rule, {
           message:
             'The computed property cannot be used in `data()` because it is before initialization.',
           line: 6,
-          column: 23
+          column: 23,
+          endLine: 6,
+          endColumn: 29
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-computed-properties-in-data` to include both error message and full location checks.
