### PR TITLE
test(no-deprecated-dollar-listeners-api): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-dollar-listeners-api.js
+++ b/tests/lib/rules/no-deprecated-dollar-listeners-api.js
@@ -207,7 +207,9 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
         {
           line: 7,
           column: 25,
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          endLine: 7,
+          endColumn: 35
         }
       ]
     },
@@ -232,7 +234,9 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
         {
           line: 8,
           column: 27,
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          endLine: 8,
+          endColumn: 37
         }
       ]
     },
@@ -253,10 +257,18 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
       `,
       errors: [
         {
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          line: 7,
+          column: 29,
+          endLine: 7,
+          endColumn: 39
         },
         {
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          line: 8,
+          column: 31,
+          endLine: 8,
+          endColumn: 41
         }
       ]
     }

--- a/tests/lib/rules/no-deprecated-dollar-listeners-api.js
+++ b/tests/lib/rules/no-deprecated-dollar-listeners-api.js
@@ -132,16 +132,16 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
       `,
       errors: [
         {
+          messageId: 'deprecated',
           line: 3,
           column: 22,
-          messageId: 'deprecated',
           endLine: 3,
           endColumn: 32
         },
         {
+          messageId: 'deprecated',
           line: 9,
           column: 27,
-          messageId: 'deprecated',
           endLine: 9,
           endColumn: 37
         }
@@ -167,23 +167,23 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
       `,
       errors: [
         {
+          messageId: 'deprecated',
           line: 3,
           column: 35,
-          messageId: 'deprecated',
           endLine: 3,
           endColumn: 45
         },
         {
+          messageId: 'deprecated',
           line: 4,
           column: 22,
-          messageId: 'deprecated',
           endLine: 4,
           endColumn: 32
         },
         {
+          messageId: 'deprecated',
           line: 10,
           column: 23,
-          messageId: 'deprecated',
           endLine: 10,
           endColumn: 33
         }
@@ -205,9 +205,9 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
       `,
       errors: [
         {
+          messageId: 'deprecated',
           line: 7,
           column: 25,
-          messageId: 'deprecated',
           endLine: 7,
           endColumn: 35
         }
@@ -232,9 +232,9 @@ ruleTester.run('no-deprecated-dollar-listeners-api', rule, {
       `,
       errors: [
         {
+          messageId: 'deprecated',
           line: 8,
           column: 27,
-          messageId: 'deprecated',
           endLine: 8,
           endColumn: 37
         }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-dollar-listeners-api` to include both error message and full location checks.
