### PR TITLE
test(no-deprecated-dollar-scopedslots-api): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-dollar-scopedslots-api.js
+++ b/tests/lib/rules/no-deprecated-dollar-scopedslots-api.js
@@ -239,7 +239,9 @@ ruleTester.run('no-deprecated-dollar-scopedslots-api', rule, {
         {
           line: 6,
           column: 23,
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          endLine: 6,
+          endColumn: 35
         }
       ]
     },
@@ -275,7 +277,9 @@ ruleTester.run('no-deprecated-dollar-scopedslots-api', rule, {
         {
           line: 7,
           column: 25,
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          endLine: 7,
+          endColumn: 37
         }
       ]
     },
@@ -307,10 +311,18 @@ ruleTester.run('no-deprecated-dollar-scopedslots-api', rule, {
       `,
       errors: [
         {
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          line: 6,
+          column: 27,
+          endLine: 6,
+          endColumn: 39
         },
         {
-          messageId: 'deprecated'
+          messageId: 'deprecated',
+          line: 7,
+          column: 29,
+          endLine: 7,
+          endColumn: 41
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-dollar-scopedslots-api` to include both error message and full location checks.
