### PR TITLE
test(no-deprecated-functional-template): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-functional-template.js
+++ b/tests/lib/rules/no-deprecated-functional-template.js
@@ -48,7 +48,9 @@ ruleTester.run('no-deprecated-functional-template', rule, {
         {
           line: 1,
           column: 11,
-          messageId: 'unexpected'
+          messageId: 'unexpected',
+          endLine: 1,
+          endColumn: 21
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-functional-template` to include both error message and full location checks.
