### PR TITLE
test(no-deprecated-html-element-is): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-html-element-is.js
+++ b/tests/lib/rules/no-deprecated-html-element-is.js
@@ -58,7 +58,9 @@ ruleTester.run('no-deprecated-html-element-is', rule, {
         {
           line: 1,
           column: 16,
-          messageId: 'unexpected'
+          messageId: 'unexpected',
+          endLine: 1,
+          endColumn: 25
         }
       ]
     }

--- a/tests/lib/rules/no-deprecated-html-element-is.js
+++ b/tests/lib/rules/no-deprecated-html-element-is.js
@@ -43,9 +43,9 @@ ruleTester.run('no-deprecated-html-element-is', rule, {
       code: '<template><div is="foo" /></template>',
       errors: [
         {
+          messageId: 'unexpected',
           line: 1,
           column: 16,
-          messageId: 'unexpected',
           endLine: 1,
           endColumn: 24
         }
@@ -56,9 +56,9 @@ ruleTester.run('no-deprecated-html-element-is', rule, {
       code: '<template><div :is="foo" /></template>',
       errors: [
         {
+          messageId: 'unexpected',
           line: 1,
           column: 16,
-          messageId: 'unexpected',
           endLine: 1,
           endColumn: 25
         }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-html-element-is` to include both error message and full location checks.
