### PR TITLE
test(no-deprecated-inline-template): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-inline-template.js
+++ b/tests/lib/rules/no-deprecated-inline-template.js
@@ -48,12 +48,28 @@ ruleTester.run('no-deprecated-inline-template', rule, {
     {
       filename: 'test.vue',
       code: '<template><my-component inline-template=""><div /></my-component></template>',
-      errors: [{ messageId: 'unexpected' }]
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><my-component inline-template="foo"><div /></my-component></template>',
-      errors: [{ messageId: 'unexpected' }]
+      errors: [
+        {
+          messageId: 'unexpected',
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-inline-template` to include both error message and full location checks.
