### PR TITLE
test(no-deprecated-scope-attribute): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-scope-attribute.js
+++ b/tests/lib/rules/no-deprecated-scope-attribute.js
@@ -66,7 +66,10 @@ tester.run('no-deprecated-scope-attribute', rule, {
       errors: [
         {
           message: '`scope` attributes are deprecated.',
-          line: 4
+          line: 4,
+          column: 21,
+          endLine: 4,
+          endColumn: 26
         }
       ]
     },
@@ -90,7 +93,10 @@ tester.run('no-deprecated-scope-attribute', rule, {
       errors: [
         {
           message: '`scope` attributes are deprecated.',
-          line: 4
+          line: 4,
+          column: 33,
+          endLine: 4,
+          endColumn: 38
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-scope-attribute` to include both error message and full location checks.
