### PR TITLE
test(no-deprecated-slot-attribute): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-slot-attribute.js
+++ b/tests/lib/rules/no-deprecated-slot-attribute.js
@@ -686,8 +686,20 @@ tester.run('no-deprecated-slot-attribute', rule, {
         </my-component>
       </template>`,
       errors: [
-        '`slot` attributes are deprecated.',
-        '`slot` attributes are deprecated.'
+        {
+          message: '`slot` attributes are deprecated.',
+          line: 4,
+          column: 30,
+          endLine: 4,
+          endColumn: 34
+        },
+        {
+          message: '`slot` attributes are deprecated.',
+          line: 7,
+          column: 28,
+          endLine: 7,
+          endColumn: 32
+        }
       ]
     },
     {


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-slot-attribute` to include both error message and full location checks.
