### PR TITLE
test(no-deprecated-router-link-tag-prop): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-router-link-tag-prop.js
+++ b/tests/lib/rules/no-deprecated-router-link-tag-prop.js
@@ -103,7 +103,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'RouterLink' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 21
+          column: 21,
+          endLine: 3,
+          endColumn: 24
         }
       ]
     },
@@ -119,7 +121,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'router-link' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 22
+          column: 22,
+          endLine: 3,
+          endColumn: 25
         }
       ]
     },
@@ -136,7 +140,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'RouterLink' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 21
+          column: 21,
+          endLine: 3,
+          endColumn: 24
         }
       ]
     },
@@ -153,7 +159,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'RouterLink' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 21
+          column: 21,
+          endLine: 3,
+          endColumn: 24
         }
       ]
     },
@@ -170,7 +178,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'router-link' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 22
+          column: 22,
+          endLine: 3,
+          endColumn: 25
         }
       ]
     },
@@ -186,7 +196,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'RouterLink' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 22
+          column: 22,
+          endLine: 3,
+          endColumn: 25
         }
       ]
     },
@@ -202,7 +214,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'router-link' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 23
+          column: 23,
+          endLine: 3,
+          endColumn: 26
         }
       ]
     },
@@ -219,7 +233,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'RouterLink' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 22
+          column: 22,
+          endLine: 3,
+          endColumn: 25
         }
       ]
     },
@@ -236,7 +252,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'router-link' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 23
+          column: 23,
+          endLine: 3,
+          endColumn: 26
         }
       ]
     },
@@ -253,7 +271,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'NuxtLink' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 19
+          column: 19,
+          endLine: 3,
+          endColumn: 22
         }
       ]
     },
@@ -270,7 +290,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'nuxt-link' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 20
+          column: 20,
+          endLine: 3,
+          endColumn: 23
         }
       ]
     },
@@ -287,7 +309,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'NuxtLink' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 20
+          column: 20,
+          endLine: 3,
+          endColumn: 23
         }
       ]
     },
@@ -304,7 +328,9 @@ tester.run('no-deprecated-router-link-tag-prop', rule, {
           message:
             "'tag' property on 'nuxt-link' component is deprecated. Use scoped slots instead.",
           line: 3,
-          column: 21
+          column: 21,
+          endLine: 3,
+          endColumn: 24
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-router-link-tag-prop` to include both error message and full location checks.
