### PR TITLE
test(no-deprecated-v-is): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-v-is.js
+++ b/tests/lib/rules/no-deprecated-v-is.js
@@ -25,7 +25,10 @@ tester.run('no-deprecated-v-is', rule, {
       errors: [
         {
           message: '`v-is` directive is deprecated.',
-          line: 3
+          line: 3,
+          column: 14,
+          endLine: 3,
+          endColumn: 18
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-v-is` to include both error message and full location checks.
