### PR TITLE
test(no-deprecated-vue-config-keycodes): make tests more strict

### DIFF
--- a/tests/lib/rules/no-deprecated-vue-config-keycodes.js
+++ b/tests/lib/rules/no-deprecated-vue-config-keycodes.js
@@ -46,12 +46,28 @@ ruleTester.run('no-deprecated-vue-config-keycodes', rule, {
     {
       filename: 'test.js',
       code: 'Vue?.config?.keyCodes',
-      errors: ['`Vue.config.keyCodes` are deprecated.']
+      errors: [
+        {
+          message: '`Vue.config.keyCodes` are deprecated.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 22
+        }
+      ]
     },
     {
       filename: 'test.js',
       code: '(Vue?.config)?.keyCodes',
-      errors: ['`Vue.config.keyCodes` are deprecated.']
+      errors: [
+        {
+          message: '`Vue.config.keyCodes` are deprecated.',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 24
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-deprecated-vue-config-keycodes` to include both error message and full location checks.
