### PR TITLE
test(no-duplicate-attributes): make tests more strict

### DIFF
--- a/tests/lib/rules/no-duplicate-attributes.js
+++ b/tests/lib/rules/no-duplicate-attributes.js
@@ -62,36 +62,84 @@ tester.run('no-duplicate-attributes', rule, {
     {
       filename: 'test.vue',
       code: '<template><div><div foo v-bind:foo></div></div></template>',
-      errors: ["Duplicate attribute 'foo'."]
+      errors: [
+        {
+          message: "Duplicate attribute 'foo'.",
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 35
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div foo :foo></div></div></template>',
-      errors: ["Duplicate attribute 'foo'."]
+      errors: [
+        {
+          message: "Duplicate attribute 'foo'.",
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 29
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div style :style></div></div></template>',
       options: [{ allowCoexistStyle: false }],
-      errors: ["Duplicate attribute 'style'."]
+      errors: [
+        {
+          message: "Duplicate attribute 'style'.",
+          line: 1,
+          column: 27,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div class :class></div></div></template>',
       options: [{ allowCoexistClass: false }],
-      errors: ["Duplicate attribute 'class'."]
+      errors: [
+        {
+          message: "Duplicate attribute 'class'.",
+          line: 1,
+          column: 27,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div :style style></div></div></template>',
       options: [{ allowCoexistStyle: false }],
-      errors: ["Duplicate attribute 'style'."]
+      errors: [
+        {
+          message: "Duplicate attribute 'style'.",
+          line: 1,
+          column: 28,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
     },
     {
       filename: 'test.vue',
       code: '<template><div><div :class class></div></div></template>',
       options: [{ allowCoexistClass: false }],
-      errors: ["Duplicate attribute 'class'."]
+      errors: [
+        {
+          message: "Duplicate attribute 'class'.",
+          line: 1,
+          column: 28,
+          endLine: 1,
+          endColumn: 33
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-duplicate-attributes` to include both error message and full location checks.
