### PR TITLE
test(no-empty-pattern): make tests more strict

### DIFF
--- a/tests/lib/rules/no-empty-pattern.js
+++ b/tests/lib/rules/no-empty-pattern.js
@@ -62,19 +62,31 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty object pattern.',
-          line: 5
+          line: 5,
+          column: 17,
+          endLine: 5,
+          endColumn: 19
         },
         {
           message: 'Unexpected empty array pattern.',
-          line: 6
+          line: 6,
+          column: 17,
+          endLine: 6,
+          endColumn: 19
         },
         {
           message: 'Unexpected empty object pattern.',
-          line: 7
+          line: 7,
+          column: 21,
+          endLine: 7,
+          endColumn: 23
         },
         {
           message: 'Unexpected empty array pattern.',
-          line: 8
+          line: 8,
+          column: 21,
+          endLine: 8,
+          endColumn: 23
         }
       ]
     },
@@ -88,7 +100,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty object pattern.',
-          line: 4
+          line: 4,
+          column: 33,
+          endLine: 4,
+          endColumn: 35
         }
       ]
     },
@@ -102,7 +117,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty array pattern.',
-          line: 4
+          line: 4,
+          column: 33,
+          endLine: 4,
+          endColumn: 35
         }
       ]
     },
@@ -116,7 +134,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty object pattern.',
-          line: 4
+          line: 4,
+          column: 37,
+          endLine: 4,
+          endColumn: 39
         }
       ]
     },
@@ -130,7 +151,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty array pattern.',
-          line: 4
+          line: 4,
+          column: 37,
+          endLine: 4,
+          endColumn: 39
         }
       ]
     },
@@ -144,7 +168,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty object pattern.',
-          line: 4
+          line: 4,
+          column: 21,
+          endLine: 4,
+          endColumn: 23
         }
       ]
     },
@@ -158,7 +185,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty array pattern.',
-          line: 4
+          line: 4,
+          column: 21,
+          endLine: 4,
+          endColumn: 23
         }
       ]
     },
@@ -172,7 +202,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty object pattern.',
-          line: 4
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 27
         }
       ]
     },
@@ -186,7 +219,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty array pattern.',
-          line: 4
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 27
         }
       ]
     },
@@ -200,7 +236,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty object pattern.',
-          line: 4
+          line: 4,
+          column: 23,
+          endLine: 4,
+          endColumn: 25
         }
       ]
     },
@@ -214,7 +253,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty array pattern.',
-          line: 4
+          line: 4,
+          column: 23,
+          endLine: 4,
+          endColumn: 25
         }
       ]
     },
@@ -228,7 +270,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty object pattern.',
-          line: 4
+          line: 4,
+          column: 27,
+          endLine: 4,
+          endColumn: 29
         }
       ]
     },
@@ -242,7 +287,10 @@ tester.run('no-empty-pattern', rule, {
       errors: [
         {
           message: 'Unexpected empty array pattern.',
-          line: 4
+          line: 4,
+          column: 27,
+          endLine: 4,
+          endColumn: 29
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-empty-pattern` to include both error message and full location checks.
