### PR TITLE
test(no-loss-of-precision): make tests more strict

### DIFF
--- a/tests/lib/rules/no-loss-of-precision.js
+++ b/tests/lib/rules/no-loss-of-precision.js
@@ -53,11 +53,17 @@ tester.run('no-loss-of-precision', rule, {
             errors: [
               {
                 message: 'This number literal will lose precision at runtime.',
-                line: 3
+                line: 3,
+                column: 17,
+                endLine: 3,
+                endColumn: 37
               },
               {
                 message: 'This number literal will lose precision at runtime.',
-                line: 4
+                line: 4,
+                column: 17,
+                endLine: 4,
+                endColumn: 39
               }
             ]
           },
@@ -71,7 +77,10 @@ tester.run('no-loss-of-precision', rule, {
             errors: [
               {
                 message: 'This number literal will lose precision at runtime.',
-                line: 3
+                line: 3,
+                column: 34,
+                endLine: 3,
+                endColumn: 54
               }
             ]
           }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-loss-of-precision` to include both error message and full location checks.
