### PR TITLE
test(no-multiple-objects-in-class): make tests more strict

### DIFF
--- a/tests/lib/rules/no-multiple-objects-in-class.js
+++ b/tests/lib/rules/no-multiple-objects-in-class.js
@@ -26,7 +26,11 @@ ruleTester.run('no-multiple-objects-in-class', rule, {
       errors: [
         {
           message: 'Unexpected multiple objects. Merge objects.',
-          type: 'VAttribute'
+          type: 'VAttribute',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 63
         }
       ]
     },
@@ -35,7 +39,11 @@ ruleTester.run('no-multiple-objects-in-class', rule, {
       errors: [
         {
           message: 'Unexpected multiple objects. Merge objects.',
-          type: 'VAttribute'
+          type: 'VAttribute',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 57
         }
       ]
     },
@@ -46,7 +54,11 @@ ruleTester.run('no-multiple-objects-in-class', rule, {
       errors: [
         {
           message: 'Unexpected multiple objects. Merge objects.',
-          type: 'VAttribute'
+          type: 'VAttribute',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 64
         }
       ]
     }


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-multiple-objects-in-class` to include both error message and full location checks.
