### PR TITLE
test(no-side-effects-in-computed-properties): make tests more strict

### DIFF
--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -296,50 +296,50 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       })`,
       errors: [
         {
-          line: 4,
           message: 'Unexpected side effect in "test1" computed property.',
+          line: 4,
           column: 13,
           endLine: 4,
           endColumn: 37
         },
         {
-          line: 9,
           message: 'Unexpected side effect in "test2" computed property.',
+          line: 9,
           column: 13,
           endLine: 9,
           endColumn: 28
         },
         {
-          line: 10,
           message: 'Unexpected side effect in "test2" computed property.',
+          line: 10,
           column: 13,
           endLine: 10,
           endColumn: 25
         },
         {
-          line: 14,
           message: 'Unexpected side effect in "test3" computed property.',
+          line: 14,
           column: 20,
           endLine: 14,
           endColumn: 44
         },
         {
-          line: 17,
           message: 'Unexpected side effect in "test4" computed property.',
+          line: 17,
           column: 26,
           endLine: 17,
           endColumn: 64
         },
         {
-          line: 21,
           message: 'Unexpected side effect in "test5" computed property.',
+          line: 21,
           column: 13,
           endLine: 21,
           endColumn: 49
         },
         {
-          line: 25,
           message: 'Unexpected side effect in "test6" computed property.',
+          line: 25,
           column: 20,
           endLine: 25,
           endColumn: 46
@@ -380,36 +380,36 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       })`,
       errors: [
         {
-          line: 5,
           message: 'Unexpected side effect in "test1" computed property.',
+          line: 5,
           column: 15,
           endLine: 5,
           endColumn: 39
         },
         {
-          line: 11,
           message: 'Unexpected side effect in "test2" computed property.',
+          line: 11,
           column: 15,
           endLine: 11,
           endColumn: 30
         },
         {
-          line: 12,
           message: 'Unexpected side effect in "test2" computed property.',
+          line: 12,
           column: 15,
           endLine: 12,
           endColumn: 27
         },
         {
-          line: 18,
           message: 'Unexpected side effect in "test3" computed property.',
+          line: 18,
           column: 22,
           endLine: 18,
           endColumn: 46
         },
         {
-          line: 23,
           message: 'Unexpected side effect in "test4" computed property.',
+          line: 23,
           column: 28,
           endLine: 23,
           endColumn: 66
@@ -430,8 +430,8 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       languageOptions: { parser: require('@typescript-eslint/parser') },
       errors: [
         {
-          line: 5,
           message: 'Unexpected side effect in "test1" computed property.',
+          line: 5,
           column: 22,
           endLine: 5,
           endColumn: 46
@@ -451,8 +451,8 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       })`,
       errors: [
         {
-          line: 4,
           message: 'Unexpected side effect in "test1" computed property.',
+          line: 4,
           column: 13,
           endLine: 4,
           endColumn: 37
@@ -475,22 +475,22 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       })`,
       errors: [
         {
-          line: 4,
           message: 'Unexpected side effect in "test1" computed property.',
+          line: 4,
           column: 20,
           endLine: 4,
           endColumn: 48
         },
         {
-          line: 7,
           message: 'Unexpected side effect in "test2" computed property.',
+          line: 7,
           column: 20,
           endLine: 7,
           endColumn: 50
         },
         {
-          line: 10,
           message: 'Unexpected side effect in "test3" computed property.',
+          line: 10,
           column: 20,
           endLine: 10,
           endColumn: 50
@@ -510,15 +510,15 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       })`,
       errors: [
         {
-          line: 4,
           message: 'Unexpected side effect in "fooBar" computed property.',
+          line: 4,
           column: 18,
           endLine: 4,
           endColumn: 22
         },
         {
-          line: 5,
           message: 'Unexpected side effect in "fooBar" computed property.',
+          line: 5,
           column: 17,
           endLine: 5,
           endColumn: 20
@@ -580,85 +580,85 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       `,
       errors: [
         {
-          line: 12,
           message: 'Unexpected side effect in computed function.',
+          line: 12,
           column: 13,
           endLine: 12,
           endColumn: 36
         },
         {
-          line: 13,
           message: 'Unexpected side effect in computed function.',
+          line: 13,
           column: 13,
           endLine: 13,
           endColumn: 34
         },
         {
-          line: 17,
           message: 'Unexpected side effect in computed function.',
+          line: 17,
           column: 13,
           endLine: 17,
           endColumn: 27
         },
         {
-          line: 18,
           message: 'Unexpected side effect in computed function.',
+          line: 18,
           column: 13,
           endLine: 18,
           endColumn: 24
         },
         {
-          line: 21,
           message: 'Unexpected side effect in computed function.',
+          line: 21,
           column: 40,
           endLine: 21,
           endColumn: 63
         },
         {
-          line: 23,
           message: 'Unexpected side effect in computed function.',
+          line: 23,
           column: 26,
           endLine: 23,
           endColumn: 63
         },
         {
-          line: 27,
           message: 'Unexpected side effect in computed function.',
+          line: 27,
           column: 13,
           endLine: 27,
           endColumn: 52
         },
         {
-          line: 30,
           message: 'Unexpected side effect in computed function.',
+          line: 30,
           column: 40,
           endLine: 30,
           endColumn: 65
         },
         {
-          line: 33,
           message: 'Unexpected side effect in computed function.',
+          line: 33,
           column: 22,
           endLine: 33,
           endColumn: 45
         },
         {
-          line: 37,
           message: 'Unexpected side effect in computed function.',
+          line: 37,
           column: 13,
           endLine: 37,
           endColumn: 24
         },
         {
-          line: 40,
           message: 'Unexpected side effect in computed function.',
+          line: 40,
           column: 13,
           endLine: 40,
           endColumn: 24
         },
         {
-          line: 42,
           message: 'Unexpected side effect in computed function.',
+          line: 42,
           column: 42,
           endLine: 42,
           endColumn: 52
@@ -681,8 +681,8 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       `,
       errors: [
         {
-          line: 8,
           message: 'Unexpected side effect in computed function.',
+          line: 8,
           column: 40,
           endLine: 8,
           endColumn: 53
@@ -705,8 +705,8 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       `,
       errors: [
         {
-          line: 8,
           message: 'Unexpected side effect in computed function.',
+          line: 8,
           column: 40,
           endLine: 8,
           endColumn: 63
@@ -765,88 +765,88 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       `,
       errors: [
         {
+          message: 'Unexpected side effect in computed function.',
           line: 10,
           column: 9,
           endLine: 10,
-          endColumn: 32,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 32
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 11,
           column: 9,
           endLine: 11,
-          endColumn: 30,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 30
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 15,
           column: 9,
           endLine: 15,
-          endColumn: 23,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 23
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 16,
           column: 9,
           endLine: 16,
-          endColumn: 20,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 20
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 19,
           column: 36,
           endLine: 19,
-          endColumn: 59,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 59
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 21,
           column: 22,
           endLine: 21,
-          endColumn: 59,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 59
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 25,
           column: 9,
           endLine: 25,
-          endColumn: 48,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 48
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 28,
           column: 36,
           endLine: 28,
-          endColumn: 61,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 61
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 31,
           column: 18,
           endLine: 31,
-          endColumn: 41,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 41
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 35,
           column: 9,
           endLine: 35,
-          endColumn: 20,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 20
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 38,
           column: 9,
           endLine: 38,
-          endColumn: 20,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 20
         },
         {
+          message: 'Unexpected side effect in computed function.',
           line: 40,
           column: 38,
           endLine: 40,
-          endColumn: 48,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 48
         }
       ]
     },
@@ -862,11 +862,11 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       `,
       errors: [
         {
+          message: 'Unexpected side effect in computed function.',
           line: 6,
           column: 36,
           endLine: 6,
-          endColumn: 49,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 49
         }
       ]
     },
@@ -882,11 +882,11 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       `,
       errors: [
         {
+          message: 'Unexpected side effect in computed function.',
           line: 6,
           column: 36,
           endLine: 6,
-          endColumn: 59,
-          message: 'Unexpected side effect in computed function.'
+          endColumn: 59
         }
       ]
     }

--- a/tests/lib/rules/no-side-effects-in-computed-properties.js
+++ b/tests/lib/rules/no-side-effects-in-computed-properties.js
@@ -297,31 +297,52 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 4,
-          message: 'Unexpected side effect in "test1" computed property.'
+          message: 'Unexpected side effect in "test1" computed property.',
+          column: 13,
+          endLine: 4,
+          endColumn: 37
         },
         {
           line: 9,
-          message: 'Unexpected side effect in "test2" computed property.'
+          message: 'Unexpected side effect in "test2" computed property.',
+          column: 13,
+          endLine: 9,
+          endColumn: 28
         },
         {
           line: 10,
-          message: 'Unexpected side effect in "test2" computed property.'
+          message: 'Unexpected side effect in "test2" computed property.',
+          column: 13,
+          endLine: 10,
+          endColumn: 25
         },
         {
           line: 14,
-          message: 'Unexpected side effect in "test3" computed property.'
+          message: 'Unexpected side effect in "test3" computed property.',
+          column: 20,
+          endLine: 14,
+          endColumn: 44
         },
         {
           line: 17,
-          message: 'Unexpected side effect in "test4" computed property.'
+          message: 'Unexpected side effect in "test4" computed property.',
+          column: 26,
+          endLine: 17,
+          endColumn: 64
         },
         {
           line: 21,
-          message: 'Unexpected side effect in "test5" computed property.'
+          message: 'Unexpected side effect in "test5" computed property.',
+          column: 13,
+          endLine: 21,
+          endColumn: 49
         },
         {
           line: 25,
-          message: 'Unexpected side effect in "test6" computed property.'
+          message: 'Unexpected side effect in "test6" computed property.',
+          column: 20,
+          endLine: 25,
+          endColumn: 46
         }
       ]
     },
@@ -360,23 +381,38 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 5,
-          message: 'Unexpected side effect in "test1" computed property.'
+          message: 'Unexpected side effect in "test1" computed property.',
+          column: 15,
+          endLine: 5,
+          endColumn: 39
         },
         {
           line: 11,
-          message: 'Unexpected side effect in "test2" computed property.'
+          message: 'Unexpected side effect in "test2" computed property.',
+          column: 15,
+          endLine: 11,
+          endColumn: 30
         },
         {
           line: 12,
-          message: 'Unexpected side effect in "test2" computed property.'
+          message: 'Unexpected side effect in "test2" computed property.',
+          column: 15,
+          endLine: 12,
+          endColumn: 27
         },
         {
           line: 18,
-          message: 'Unexpected side effect in "test3" computed property.'
+          message: 'Unexpected side effect in "test3" computed property.',
+          column: 22,
+          endLine: 18,
+          endColumn: 46
         },
         {
           line: 23,
-          message: 'Unexpected side effect in "test4" computed property.'
+          message: 'Unexpected side effect in "test4" computed property.',
+          column: 28,
+          endLine: 23,
+          endColumn: 66
         }
       ]
     },
@@ -395,7 +431,10 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 5,
-          message: 'Unexpected side effect in "test1" computed property.'
+          message: 'Unexpected side effect in "test1" computed property.',
+          column: 22,
+          endLine: 5,
+          endColumn: 46
         }
       ]
     },
@@ -413,7 +452,10 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 4,
-          message: 'Unexpected side effect in "test1" computed property.'
+          message: 'Unexpected side effect in "test1" computed property.',
+          column: 13,
+          endLine: 4,
+          endColumn: 37
         }
       ]
     },
@@ -432,9 +474,27 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
         }
       })`,
       errors: [
-        'Unexpected side effect in "test1" computed property.',
-        'Unexpected side effect in "test2" computed property.',
-        'Unexpected side effect in "test3" computed property.'
+        {
+          line: 4,
+          message: 'Unexpected side effect in "test1" computed property.',
+          column: 20,
+          endLine: 4,
+          endColumn: 48
+        },
+        {
+          line: 7,
+          message: 'Unexpected side effect in "test2" computed property.',
+          column: 20,
+          endLine: 7,
+          endColumn: 50
+        },
+        {
+          line: 10,
+          message: 'Unexpected side effect in "test3" computed property.',
+          column: 20,
+          endLine: 10,
+          endColumn: 50
+        }
       ]
     },
     {
@@ -451,11 +511,17 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 4,
-          message: 'Unexpected side effect in "fooBar" computed property.'
+          message: 'Unexpected side effect in "fooBar" computed property.',
+          column: 18,
+          endLine: 4,
+          endColumn: 22
         },
         {
           line: 5,
-          message: 'Unexpected side effect in "fooBar" computed property.'
+          message: 'Unexpected side effect in "fooBar" computed property.',
+          column: 17,
+          endLine: 5,
+          endColumn: 20
         }
       ]
     },
@@ -515,51 +581,87 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 12,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 13,
+          endLine: 12,
+          endColumn: 36
         },
         {
           line: 13,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 13,
+          endLine: 13,
+          endColumn: 34
         },
         {
           line: 17,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 13,
+          endLine: 17,
+          endColumn: 27
         },
         {
           line: 18,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 13,
+          endLine: 18,
+          endColumn: 24
         },
         {
           line: 21,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 40,
+          endLine: 21,
+          endColumn: 63
         },
         {
           line: 23,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 26,
+          endLine: 23,
+          endColumn: 63
         },
         {
           line: 27,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 13,
+          endLine: 27,
+          endColumn: 52
         },
         {
           line: 30,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 40,
+          endLine: 30,
+          endColumn: 65
         },
         {
           line: 33,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 22,
+          endLine: 33,
+          endColumn: 45
         },
         {
           line: 37,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 13,
+          endLine: 37,
+          endColumn: 24
         },
         {
           line: 40,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 13,
+          endLine: 40,
+          endColumn: 24
         },
         {
           line: 42,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 42,
+          endLine: 42,
+          endColumn: 52
         }
       ]
     },
@@ -580,7 +682,10 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 8,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 40,
+          endLine: 8,
+          endColumn: 53
         }
       ]
     },
@@ -601,7 +706,10 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 8,
-          message: 'Unexpected side effect in computed function.'
+          message: 'Unexpected side effect in computed function.',
+          column: 40,
+          endLine: 8,
+          endColumn: 63
         }
       ]
     },
@@ -658,50 +766,86 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 10,
+          column: 9,
+          endLine: 10,
+          endColumn: 32,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 11,
+          column: 9,
+          endLine: 11,
+          endColumn: 30,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 15,
+          column: 9,
+          endLine: 15,
+          endColumn: 23,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 16,
+          column: 9,
+          endLine: 16,
+          endColumn: 20,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 19,
+          column: 36,
+          endLine: 19,
+          endColumn: 59,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 21,
+          column: 22,
+          endLine: 21,
+          endColumn: 59,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 25,
+          column: 9,
+          endLine: 25,
+          endColumn: 48,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 28,
+          column: 36,
+          endLine: 28,
+          endColumn: 61,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 31,
+          column: 18,
+          endLine: 31,
+          endColumn: 41,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 35,
+          column: 9,
+          endLine: 35,
+          endColumn: 20,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 38,
+          column: 9,
+          endLine: 38,
+          endColumn: 20,
           message: 'Unexpected side effect in computed function.'
         },
         {
           line: 40,
+          column: 38,
+          endLine: 40,
+          endColumn: 48,
           message: 'Unexpected side effect in computed function.'
         }
       ]
@@ -719,6 +863,9 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 6,
+          column: 36,
+          endLine: 6,
+          endColumn: 49,
           message: 'Unexpected side effect in computed function.'
         }
       ]
@@ -736,6 +883,9 @@ ruleTester.run('no-side-effects-in-computed-properties', rule, {
       errors: [
         {
           line: 6,
+          column: 36,
+          endLine: 6,
+          endColumn: 59,
           message: 'Unexpected side effect in computed function.'
         }
       ]


### PR DESCRIPTION
Continuation of #2793
- #2793
---
This PR converts all error assertions for `no-side-effects-in-computed-properties` to include both error message and full location checks.
