### PR TITLE
test: add valid example for empty `defineEmits`

### DIFF
--- a/tests/lib/rules/valid-define-emits.js
+++ b/tests/lib/rules/valid-define-emits.js
@@ -62,6 +62,17 @@ tester.run('valid-define-emits', rule, {
     {
       filename: 'test.vue',
       code: `
+      <script>
+        export default { emits: [] }
+      </script>
+      <script setup>
+        defineEmits();
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
       <script setup>
         defineEmits({
           notify (payload) {


### PR DESCRIPTION
Covering this part of the code: 

https://github.com/vuejs/eslint-plugin-vue/blob/a198b52b0ac26c8b8069fef1e295758ef7e5d932/lib/rules/valid-define-emits.js#L121-L128

Found in https://github.com/oxc-project/oxc/pull/12545