### PR TITLE
fix: remove useless polyfill

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -64,6 +64,7 @@ const VUE3_BUILTIN_COMPONENT_NAMES = new Set(
   require('./vue3-builtin-components')
 )
 const VUE_BUILTIN_ELEMENT_NAMES = new Set(require('./vue-builtin-elements'))
+const { createRequire } = require('module')
 const path = require('path')
 const vueEslintParser = require('vue-eslint-parser')
 const { traverseNodes, getFallbackKeys, NS } = vueEslintParser.AST
@@ -2250,36 +2251,6 @@ function flatten(v) {
  */
 function isIterable(v) {
   return v && Symbol.iterator in v
-}
-
-// ------------------------------------------------------------------------------
-// Nodejs Helpers
-// ------------------------------------------------------------------------------
-/**
- * @param {String} filename
- */
-function createRequire(filename) {
-  const Module = require('module')
-  const moduleCreateRequire =
-    // Added in v12.2.0
-    Module.createRequire ||
-    // Added in v10.12.0, but deprecated in v12.2.0.
-    Module.createRequireFromPath ||
-    // Polyfill - This is not executed on the tests on node@>=10.
-    /**
-     * @param {string} filename
-     */
-    function (filename) {
-      const mod = new Module(filename)
-
-      mod.filename = filename
-      // @ts-ignore
-      mod.paths = Module._nodeModulePaths(path.dirname(filename))
-      // @ts-ignore
-      mod._compile('module.exports = require;', filename)
-      return mod.exports
-    }
-  return moduleCreateRequire(filename)
 }
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
Since our [`package.json`](https://github.com/vuejs/eslint-plugin-vue/blob/1d59e53b2d4b1a9eec02844f96397e34e1c11951/package.json#L58) explicitly defines the Node version requirement, I think this polyfill is now redundant and can be safely deleted without side effects.