### PR TITLE
test(required-typed-ref): remove invalid `}` outside `<script>`

### DIFF
--- a/tests/lib/rules/require-typed-ref.js
+++ b/tests/lib/rules/require-typed-ref.js
@@ -242,7 +242,6 @@ tester.run('require-typed-ref', rule, {
             }
           }
         </script>
-      }
       `,
       languageOptions: { parser: require('vue-eslint-parser') },
       errors: [


### PR DESCRIPTION
found here:
https://github.com/oxc-project/oxc/pull/13857#discussion_r2355378236