### PR TITLE
refactor(no-import-compiler-macros): check only in `<script setup>`

### DIFF
--- a/lib/rules/no-import-compiler-macros.js
+++ b/lib/rules/no-import-compiler-macros.js
@@ -4,6 +4,8 @@
  */
 'use strict'
 
+const utils = require('../utils')
+
 const COMPILER_MACROS = new Set([
   'defineProps',
   'defineEmits',
@@ -43,9 +45,13 @@ module.exports = {
    * @returns {RuleListener}
    */
   create(context) {
+    const scriptSetup = utils.getScriptSetupElement(context)
+    if (!scriptSetup) {
+      return {}
+    }
     const sourceCode = context.getSourceCode()
 
-    return {
+    return utils.defineScriptSetupVisitor(context, {
       ImportDeclaration(node) {
         if (node.specifiers.length === 0 || !VUE_MODULES.has(node.source.value))
           return
@@ -96,6 +102,6 @@ module.exports = {
           })
         }
       }
-    }
+    })
   }
 }


### PR DESCRIPTION
After reading https://github.com/vuejs/eslint-plugin-vue/issues/2437, I found out that the compiler warnings are only reported at `<script setup>`:
https://github.com/vuejs/core/blob/c16f8a94c7eda79f51f44b7b3c64c72343df0d38/packages/compiler-sfc/src/compileScript.ts#L321-L355

Changed the rule to only look inside `<script setup>` and not other files like `someMacro.ts`.

Copied the logic from https://github.com/vuejs/eslint-plugin-vue/blob/553abe61c4d7a8964fb154069ea6a82d14b2b3b6/lib/rules/valid-define-emits.js#L31-L46