### PR TITLE
chore: use Trusted Publisher

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write # to create release (changesets/action)
       pull-requests: write # to create pull request (changesets/action)
+      id-token: write # OpenID Connect token needed for Trusted Publisher
     name: Release
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Install Dependencies
         run: npm install
 
@@ -32,4 +35,3 @@ jobs:
           publish: npm run changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR will change it to npm publish using Trusted Publisher.

I've already configured npm, so I think this change is all we need to do to use Trusted Publisher.

https://docs.npmjs.com/trusted-publishers