### PR TITLE
fix: remove unnecessary conditional branch

### DIFF
--- a/lib/utils/ts-utils/ts-ast.js
+++ b/lib/utils/ts-utils/ts-ast.js
@@ -400,9 +400,6 @@ function inferRuntimeType(context, node, checked = new Set()) {
             return ['Number']
           }
         }
-        if (node.literal.value instanceof RegExp) {
-          return ['RegExp']
-        }
       }
       return inferRuntimeTypeFromTypeNode(
         context,


### PR DESCRIPTION
<img width="425" height="148" alt="image" src="https://github.com/user-attachments/assets/2fcfe2d0-73ac-4e4c-b23d-905ac1cc3d86" />

`TSLiteralType` could not be a `RegExpLiteral`, so that its value will never be a `RegExp`.

Examples in AST:
`TypeScript`: https://ast-explorer.dev/#eNo9zL0OQDAUhuFbOTmzxGBCDKx201mKRiocTf2ENL13pWJ9vjefxQkzHMUh1s4ovWGE2sN2aflD9wGUUADvcytNTkz8WuUtPuPcd4vvLDEA4SR42MUgG2lWtTBhBmkahS381or7hxNih+4GdnwrAw==
`@typescript-eslint/parser`: https://ast-explorer.dev/#eNotyDEKgCAUBuCrPP65aDdaOkTTW0TeYJiKShTi3TNq/SocFHZ96mySjQUDYodyR/lglOysf938TistNF3T3C10q+yJGGIOvUnKNniG6uB0kVwY7BvaA9bGIVY=

Related PR: https://github.com/typescript-eslint/typescript-eslint/pull/11624