### PR TITLE
Chore: fix build site script

### DIFF
--- a/docs/.vitepress/build-system/build.mts
+++ b/docs/.vitepress/build-system/build.mts
@@ -23,6 +23,7 @@ build(
     'node:fs',
     'semver',
     'fast-glob',
+    'tinyglobby',
     'debug'
   ]
 )

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -162,6 +162,7 @@ export default async () => {
           tslib: path.join(dirname, '../../node_modules/tslib/tslib.es6.js'),
           globby: path.join(dirname, './build-system/shim/empty.mjs'),
           'fast-glob': path.join(dirname, './build-system/shim/empty.mjs'),
+          tinyglobby: path.join(dirname, './build-system/shim/empty.mjs'),
           module: path.join(dirname, './build-system/shim/empty.mjs')
         }
       },


### PR DESCRIPTION
It seems that an update to typescript-eslint caused our site to break when it built.
This PR fixes that issue.