### PR TITLE
docs(no-async-in-computed-properties): suggest `computedAsync` instead of `vue-async-computed`

### DIFF
--- a/docs/rules/no-async-in-computed-properties.md
+++ b/docs/rules/no-async-in-computed-properties.md
@@ -13,7 +13,7 @@ since: v3.8.0
 - :gear: This rule is included in all of `"plugin:vue/essential"`, `*.configs["flat/essential"]`, `"plugin:vue/vue2-essential"`, `*.configs["flat/vue2-essential"]`, `"plugin:vue/strongly-recommended"`, `*.configs["flat/strongly-recommended"]`, `"plugin:vue/vue2-strongly-recommended"`, `*.configs["flat/vue2-strongly-recommended"]`, `"plugin:vue/recommended"`, `*.configs["flat/recommended"]`, `"plugin:vue/vue2-recommended"` and `*.configs["flat/vue2-recommended"]`.
 
 Computed properties and functions should be synchronous. Asynchronous actions inside them may not work as expected and can lead to unexpected behaviour; that's why you should avoid them.
-If you need async computed properties, you might want to consider using an additional plugin such as [vue-async-computed]
+If you need async computed properties, consider using the [`computedAsync`] composable from VueUse.
 
 ## :book: Rule Details
 
@@ -147,9 +147,9 @@ const fetchData = computed(() => {
 
 ## :books: Further Reading
 
-- [vue-async-computed]
+- [`computedAsync`]
 
-[vue-async-computed]: https://github.com/foxbenjaminfox/vue-async-computed
+[`computedAsync`]: https://vueuse.org/core/computedAsync
 
 ## :rocket: Version
 


### PR DESCRIPTION
I accidentally stumbled upon the documentation page for [no-async-in-computed-properties](https://eslint.vuejs.org/rules/no-async-in-computed-properties) rule, and noticed that it suggests using [vue-async-computed](https://github.com/foxbenjaminfox/vue-async-computed) package in case we need async code in `computed`. This package hasn't been maintained for over 2 years, so I believe [`computedAsync`](https://vueuse.org/core/computedAsync) from VueUse is a much better, well-maintained alternative. Besides, there's a good chance that developers already use some other composable from VueUse, which means they won't need to install yet another random NPM package to solve a simple issue.