### PR TITLE
test: remove `errors` and `output` from valid test cases

### DIFF
--- a/tests/lib/rules/html-self-closing.js
+++ b/tests/lib/rules/html-self-closing.js
@@ -56,7 +56,6 @@ tester.run('html-self-closing', rule, {
     // Don't error if there are comments in their content.
     {
       code: '<template><div><!-- comment --></div></template>',
-      output: null,
       options: [{ html: { normal: 'always' } }]
     },
 

--- a/tests/lib/rules/no-deprecated-props-default-this.js
+++ b/tests/lib/rules/no-deprecated-props-default-this.js
@@ -71,8 +71,7 @@ ruleTester.run('no-deprecated-props-default-this', rule, {
           }
         }
         </script>
-      `,
-      errors: [{}, {}]
+      `
     },
     {
       filename: 'test.vue',

--- a/tests/lib/rules/no-parsing-error.js
+++ b/tests/lib/rules/no-parsing-error.js
@@ -80,13 +80,11 @@ tester.run('no-parsing-error', rule, {
     },
     {
       code: '<template><svg><![CDATA[cdata',
-      options: [{ 'eof-in-cdata': false }],
-      errors: ['Parsing error: eof-in-cdata.']
+      options: [{ 'eof-in-cdata': false }]
     },
     {
       code: '<template><!--comment',
-      options: [{ 'eof-in-comment': false }],
-      errors: ['Parsing error: eof-in-comment.']
+      options: [{ 'eof-in-comment': false }]
     },
     {
       code: '<template><div class=""',
@@ -192,8 +190,7 @@ tester.run('no-parsing-error', rule, {
     },
     {
       code: '<template></div></template>',
-      options: [{ 'x-invalid-end-tag': false }],
-      errors: ['Parsing error: x-invalid-end-tag.']
+      options: [{ 'x-invalid-end-tag': false }]
     },
     {
       code: '<template><div xmlns=""></template>',

--- a/tests/lib/rules/no-setup-props-reactivity-loss.js
+++ b/tests/lib/rules/no-setup-props-reactivity-loss.js
@@ -203,13 +203,7 @@ tester.run('no-setup-props-reactivity-loss', rule, {
         const count = props.count
       })
       </script>
-      `,
-      errors: [
-        {
-          messageId: 'getProperty',
-          line: 4
-        }
-      ]
+      `
     },
     {
       filename: 'test.vue',
@@ -223,13 +217,7 @@ tester.run('no-setup-props-reactivity-loss', rule, {
         count = props.count
       })
       </script>
-      `,
-      errors: [
-        {
-          messageId: 'getProperty',
-          line: 4
-        }
-      ]
+      `
     },
     {
       filename: 'test.vue',


### PR DESCRIPTION
Found by #2962.