### PR TITLE
docs: improve editor interaction experience

### DIFF
--- a/docs/.vitepress/theme/components/eslint-code-block.vue
+++ b/docs/.vitepress/theme/components/eslint-code-block.vue
@@ -11,6 +11,7 @@
       dark
       :format="format"
       :fix="fix"
+      @keydown.stop
     />
   </div>
 </template>


### PR DESCRIPTION
Sometimes we want to type code directly in the documentation to quickly understand the details of the rules. However, typing “/” triggers the search input. It would be better if this behavior could be avoided.