### PR TITLE
feat: add `-error` configs to types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,21 +8,29 @@ declare const vue: {
 
     'vue2-essential': Linter.LegacyConfig
     'vue2-strongly-recommended': Linter.LegacyConfig
+    'vue2-strongly-recommended-error': Linter.LegacyConfig
     'vue2-recommended': Linter.LegacyConfig
+    'vue2-recommended-error': Linter.LegacyConfig
 
     essential: Linter.LegacyConfig
     'strongly-recommended': Linter.LegacyConfig
+    'strongly-recommended-error': Linter.LegacyConfig
     recommended: Linter.LegacyConfig
+    'recommended-error': Linter.LegacyConfig
 
     'flat/base': Linter.FlatConfig[]
 
     'flat/vue2-essential': Linter.FlatConfig[]
     'flat/vue2-strongly-recommended': Linter.FlatConfig[]
+    'flat/vue2-strongly-recommended-error': Linter.FlatConfig[]
     'flat/vue2-recommended': Linter.FlatConfig[]
+    'flat/vue2-recommended-error': Linter.FlatConfig[]
 
     'flat/essential': Linter.FlatConfig[]
     'flat/strongly-recommended': Linter.FlatConfig[]
+    'flat/strongly-recommended-error': Linter.FlatConfig[]
     'flat/recommended': Linter.FlatConfig[]
+    'flat/recommended-error': Linter.FlatConfig[]
 
     'no-layout-rules': Linter.LegacyConfig
   }


### PR DESCRIPTION
Follow-up to #2796, where we forgot to update the type definitions.