### PR TITLE
chore: use LTS version of Node.js in `check-for-resources-update.yml` workflow

### DIFF
--- a/.github/workflows/check-for-resources-update.yml
+++ b/.github/workflows/check-for-resources-update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: lts/*
       - name: Install Packages
         run: npm install
       - name: Update


### PR DESCRIPTION
This PR changes the `check-for-resources-update.yml` workflow to use the LTS version of Node.js.

This allows the use of `require(esm)` and I believe fixes the following failure:
https://github.com/vuejs/eslint-plugin-vue/actions/runs/22267049617/job/64415095458