### PR TITLE
ci: run lint on Node.js LTS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Install Node.js
         uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
       - name: Install Packages
         run: npm install --legacy-peer-deps
       - name: Lint


### PR DESCRIPTION
Fix the CI/Lint error on `master` (see https://github.com/vuejs/eslint-plugin-vue/pull/3048#issuecomment-3992429560)