### PR TITLE
fix(one-component-per-file): Ignore members imported from elsewhere

### DIFF
--- a/.changeset/whole-readers-film.md
+++ b/.changeset/whole-readers-film.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-vue': patch
+---
+
+Ignore members imported from elsewhere in `vue/one-component-per-file`

--- a/.changeset/whole-readers-film.md
+++ b/.changeset/whole-readers-film.md
@@ -2,4 +2,4 @@
 'eslint-plugin-vue': patch
 ---
 
-Ignore members imported from elsewhere in `vue/one-component-per-file`
+Ignore functions not imported from Vue in `vue/one-component-per-file`

--- a/lib/rules/one-component-per-file.js
+++ b/lib/rules/one-component-per-file.js
@@ -17,7 +17,7 @@ module.exports = {
     fixable: null,
     schema: [],
     messages: {
-      toManyComponents: 'There is more than one component in this file.'
+      tooManyComponents: 'There is more than one component in this file.'
     }
   },
   /** @param {RuleContext} context */
@@ -29,7 +29,7 @@ module.exports = {
       {},
       utils.executeOnVueComponent(context, (node, type) => {
         if (type === 'definition') {
-          const defType = getVueComponentDefinitionType(node)
+          const defType = getVueComponentDefinitionType(context, node)
           if (defType === 'mixin') {
             return
           }
@@ -42,7 +42,7 @@ module.exports = {
             for (const node of components) {
               context.report({
                 node,
-                messageId: 'toManyComponents'
+                messageId: 'tooManyComponents'
               })
             }
           }

--- a/lib/rules/require-expose.js
+++ b/lib/rules/require-expose.js
@@ -274,7 +274,7 @@ module.exports = {
           return
         }
         if (type === 'definition') {
-          const defType = getVueComponentDefinitionType(component)
+          const defType = getVueComponentDefinitionType(context, component)
           if (defType === 'mixin') {
             return
           }

--- a/lib/rules/require-name-property.js
+++ b/lib/rules/require-name-property.js
@@ -64,7 +64,7 @@ module.exports = {
     }
     return utils.executeOnVue(context, (component, type) => {
       if (type === 'definition') {
-        const defType = getVueComponentDefinitionType(component)
+        const defType = getVueComponentDefinitionType(context, component)
         if (defType === 'mixin') {
           return
         }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2772,21 +2772,53 @@ function isGlobalOrImportedFromVue(callee, context) {
   if (variable !== null && variable.defs.length === 1) {
     const def = variable.defs[0]
 
+    // import { name } from 'not-vue'
     if (
       def.type === 'ImportBinding' &&
       def.node.type === 'ImportSpecifier' &&
       def.node.imported.type === 'Identifier' &&
-      def.node.parent.type === 'ImportDeclaration' &&
-      def.node.parent.source.value !== 'vue' &&
-      def.node.parent.source.value !== '@vue/composition-api'
+      def.node.parent.type === 'ImportDeclaration'
     ) {
-      return false
+      return (
+        def.node.parent.source.value === 'vue' ||
+        def.node.parent.source.value === '@vue/composition-api'
+      )
     }
 
-    // ignore `function name() {}`
-    if (def.type === 'FunctionName') {
-      return false
+    // const { name } = ...
+    if (
+      def.type === 'Variable' &&
+      def.node.id.type === 'ObjectPattern' &&
+      def.node.init !== null
+    ) {
+      const init = def.node.init
+
+      // const { name } = require('something')
+      if (init.type === 'CallExpression') {
+        const firstArg = init.arguments[0]
+
+        if (
+          init.callee.type === 'Identifier' &&
+          init.callee.name === 'require'
+        ) {
+          const source =
+            firstArg.type === 'Literal' || firstArg.type === 'TemplateLiteral'
+              ? getStringLiteralValue(firstArg)
+              : null
+
+          if (source === 'vue' || source === '@vue/composition-api') {
+            return true
+          }
+        }
+      }
+
+      // const { name } = something
+      else if (init.type === 'Identifier' && init.name === 'Vue') {
+        return true
+      }
     }
+
+    return false
   }
 
   return true

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2806,21 +2806,26 @@ function isGlobalOrImportedFromVue(callee, context) {
               ? getStringLiteralValue(firstArg)
               : null
 
-          if (source === 'vue' || source === '@vue/composition-api') {
-            return true
-          }
+          return source === 'vue' || source === '@vue/composition-api'
         }
-      }
-
-      // const { name } = something
-      else if (init.type === 'Identifier' && init.name === 'Vue') {
-        return true
       }
     }
 
-    return false
+    // try {} catch (name) {}
+    // class name {}
+    // function name() {}
+    // name(); let name = ...
+    if (
+      def.type === 'CatchClause' ||
+      def.type === 'ClassName' ||
+      def.type === 'FunctionName' ||
+      def.type === 'TDZ'
+    ) {
+      return false
+    }
   }
 
+  // Can't determine the source, default to true.
   return true
 }
 
@@ -2874,27 +2879,19 @@ function getVueComponentDefinitionType(context, node) {
         return isDestructedVueComponent ? 'defineNuxtComponent' : null
       }
 
-      if (!isGlobalOrImportedFromVue(callee, context)) {
-        return null
-      }
-
-      if (callee.name === 'component') {
+      if (
         // for Vue.js 2.x
         // component('xxx', {})
-        const isDestructedVueComponent = isObjectArgument(parent)
-        return isDestructedVueComponent ? 'component' : null
-      }
-      if (callee.name === 'createApp') {
-        // for Vue.js 3.x
-        // createApp({})
-        const isAppVueComponent = isObjectArgument(parent)
-        return isAppVueComponent ? 'createApp' : null
-      }
-      if (callee.name === 'defineComponent') {
-        // for Vue.js 3.x
-        // defineComponent({})
-        const isDestructedVueComponent = isObjectArgument(parent)
-        return isDestructedVueComponent ? 'defineComponent' : null
+        (callee.name === 'component' ||
+          // for Vue.js 3.x
+          // createApp({})
+          callee.name === 'createApp' ||
+          // for Vue.js 3.x
+          // defineComponent({})
+          callee.name === 'defineComponent') &&
+        isGlobalOrImportedFromVue(callee, context)
+      ) {
+        return isObjectArgument(parent) ? callee.name : null
       }
     }
   }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2186,11 +2186,7 @@ module.exports = {
    * Wraps composition API trace map in both 'vue' and '@vue/composition-api' imports, or '#imports' from unimport
    * @param {import('@eslint-community/eslint-utils').TYPES.TraceMap} map
    */
-  createCompositionApiTraceMap: (map) => ({
-    vue: map,
-    '@vue/composition-api': map,
-    '#imports': map
-  }),
+  createCompositionApiTraceMap,
 
   /**
    * Iterates all references in the given trace map.
@@ -2728,12 +2724,84 @@ function isVueComponentFile(node, path) {
 }
 
 /**
+ * Whether the given callee refers to a symbol exported by Vue.
+ * @param {Identifier} callee Node to check.
+ * @param {RuleContext} context The rule context to use parser services.
+ * @returns {boolean}
+ */
+function isGlobalOrImportedFromVue(callee, context) {
+  const globalScope = context.sourceCode.scopeManager.globalScope
+
+  if (globalScope === null) {
+    return true
+  }
+
+  const tracker = new ReferenceTracker(globalScope)
+
+  const globalTraceMap = {
+    [callee.name]: {
+      [ReferenceTracker.CALL]: true
+    }
+  }
+  const cjsTraceMap = createCompositionApiTraceMap(globalTraceMap)
+  const esmTraceMap = createCompositionApiTraceMap({
+    [ReferenceTracker.ESM]: true,
+    [callee.name]: {
+      [ReferenceTracker.CALL]: true
+    }
+  })
+
+  function* allReferences() {
+    yield* tracker.iterateGlobalReferences(globalTraceMap)
+    yield* tracker.iterateEsmReferences(esmTraceMap)
+    yield* tracker.iterateCjsReferences(cjsTraceMap)
+  }
+
+  for (const { node } of allReferences()) {
+    if (node === callee.parent) {
+      return true
+    }
+  }
+
+  // No references found
+  // The callee is either from a different source, or it is injected
+  // (e.g., <script>defineComponent({})</script>).
+
+  const variable = findVariable(getScope(context, callee), callee)
+
+  // console.log('foobarr', context.sourceCode.text, variable?.defs[0])
+
+  if (variable !== null && variable.defs.length === 1) {
+    const def = variable.defs[0]
+
+    if (
+      def.type === 'ImportBinding' &&
+      def.node.type === 'ImportSpecifier' &&
+      def.node.imported.type === 'Identifier' &&
+      def.node.parent.type === 'ImportDeclaration' &&
+      def.node.parent.source.value !== 'vue' &&
+      def.node.parent.source.value !== '@vue/composition-api'
+    ) {
+      return false
+    }
+
+    // ignore `function name() {}`
+    if (def.type === 'FunctionName') {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
  * Get the Vue component definition type from given node
  * Vue.component('xxx', {}) || component('xxx', {})
+ * @param {RuleContext} context The rule context to use parser services.
  * @param {ObjectExpression} node Node to check
  * @returns {'component' | 'mixin' | 'extend' | 'createApp' | 'defineComponent' | 'defineNuxtComponent' | null}
  */
-function getVueComponentDefinitionType(node) {
+function getVueComponentDefinitionType(context, node) {
   const parent = getParent(node)
   if (parent.type === 'CallExpression') {
     const callee = parent.callee
@@ -2769,6 +2837,17 @@ function getVueComponentDefinitionType(node) {
     }
 
     if (callee.type === 'Identifier') {
+      if (callee.name === 'defineNuxtComponent') {
+        // for Nuxt 3.x
+        // defineNuxtComponent({})
+        const isDestructedVueComponent = isObjectArgument(parent)
+        return isDestructedVueComponent ? 'defineNuxtComponent' : null
+      }
+
+      if (!isGlobalOrImportedFromVue(callee, context)) {
+        return null
+      }
+
       if (callee.name === 'component') {
         // for Vue.js 2.x
         // component('xxx', {})
@@ -2786,12 +2865,6 @@ function getVueComponentDefinitionType(node) {
         // defineComponent({})
         const isDestructedVueComponent = isObjectArgument(parent)
         return isDestructedVueComponent ? 'defineComponent' : null
-      }
-      if (callee.name === 'defineNuxtComponent') {
-        // for Nuxt 3.x
-        // defineNuxtComponent({})
-        const isDestructedVueComponent = isObjectArgument(parent)
-        return isDestructedVueComponent ? 'defineNuxtComponent' : null
       }
     }
   }
@@ -2860,7 +2933,7 @@ function getVueObjectType(context, node) {
     case 'CallExpression': {
       // Vue.component('xxx', {}) || component('xxx', {})
       if (
-        getVueComponentDefinitionType(node) != null &&
+        getVueComponentDefinitionType(context, node) != null &&
         skipTSAsExpression(parent.arguments.at(-1)) === node
       ) {
         return 'definition'
@@ -3007,6 +3080,18 @@ function* iterateWatchHandlerValues(property) {
     }
   } else {
     yield value
+  }
+}
+
+/**
+ * Wraps composition API trace map in both 'vue' and '@vue/composition-api' imports, or '#imports' from unimport
+ * @param {import('@eslint-community/eslint-utils').TYPES.TraceMap} map
+ */
+function createCompositionApiTraceMap(map) {
+  return {
+    vue: map,
+    '@vue/composition-api': map,
+    '#imports': map
   }
 }
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2769,8 +2769,6 @@ function isGlobalOrImportedFromVue(callee, context) {
 
   const variable = findVariable(getScope(context, callee), callee)
 
-  // console.log('foobarr', context.sourceCode.text, variable?.defs[0])
-
   if (variable !== null && variable.defs.length === 1) {
     const def = variable.defs[0]
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1569,12 +1569,7 @@ module.exports = {
   getPropsDestructure,
 
   getVueObjectType,
-  /**
-   * Get the Vue component definition type from given node
-   * Vue.component('xxx', {}) || component('xxx', {})
-   * @param {ObjectExpression} node Node to check
-   * @returns {'component' | 'mixin' | 'extend' | 'createApp' | 'defineComponent' | 'defineNuxtComponent' | null}
-   */
+
   getVueComponentDefinitionType,
   /**
    * Checks whether the given object is an SFC definition.

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -929,16 +929,7 @@ module.exports = {
     }
   },
 
-  /**
-   * @param {ASTNode} node
-   * @returns {node is Literal | TemplateLiteral}
-   */
-  isStringLiteral(node) {
-    return (
-      (node.type === 'Literal' && typeof node.value === 'string') ||
-      (node.type === 'TemplateLiteral' && node.expressions.length === 0)
-    )
-  },
+  isStringLiteral,
 
   /**
    * Check whether the given node is a custom component or not.
@@ -2801,10 +2792,9 @@ function isGlobalOrImportedFromVue(callee, context) {
           init.callee.type === 'Identifier' &&
           init.callee.name === 'require'
         ) {
-          const source =
-            firstArg.type === 'Literal' || firstArg.type === 'TemplateLiteral'
-              ? getStringLiteralValue(firstArg)
-              : null
+          const source = isStringLiteral(firstArg)
+            ? getStringLiteralValue(firstArg)
+            : null
 
           return source === 'vue' || source === '@vue/composition-api'
         }
@@ -3221,6 +3211,17 @@ function isVBindSameNameShorthand(node) {
     node.value?.expression?.type === 'Identifier' &&
     node.key.range[0] <= node.value.range[0] &&
     node.value.range[1] <= node.key.range[1]
+  )
+}
+
+/**
+ * @param {ASTNode} node
+ * @returns {node is Literal | TemplateLiteral}
+ */
+function isStringLiteral(node) {
+  return (
+    (node.type === 'Literal' && typeof node.value === 'string') ||
+    (node.type === 'TemplateLiteral' && node.expressions.length === 0)
   )
 }
 

--- a/tests/lib/rules/one-component-per-file.test.ts
+++ b/tests/lib/rules/one-component-per-file.test.ts
@@ -192,6 +192,18 @@ ruleTester.run('one-component-per-file', rule, {
     {
       filename: 'test.vue',
       code: `
+        const { component } = Vue
+        component('', {})
+        component('', {})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
         import { component } from '@vue/composition-api'
         component('', {})
         component('', {})
@@ -229,6 +241,18 @@ ruleTester.run('one-component-per-file', rule, {
       filename: 'test.js',
       code: `
         const { createApp } = Vue
+        createApp({})
+        createApp({})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const createApp = Vue.createApp
         createApp({})
         createApp({})
       `,

--- a/tests/lib/rules/one-component-per-file.test.ts
+++ b/tests/lib/rules/one-component-per-file.test.ts
@@ -52,6 +52,45 @@ ruleTester.run('one-component-per-file', rule, {
         Vue.mixin({})
         Vue.component('name', {})
       `
+    },
+    {
+      filename: 'test.js',
+      code: `
+        import { createApp } from 'vue'
+        createApp({})
+      `
+    },
+    {
+      filename: 'test.js',
+      code: `
+        import { component } from 'other.js'
+        component({})
+        component({})
+      `
+    },
+    {
+      filename: 'test.js',
+      code: `
+        import { createApp } from 'other.js'
+        createApp({})
+        createApp({})
+      `
+    },
+    {
+      filename: 'test.js',
+      code: `
+        import { defineComponent } from 'other.js'
+        defineComponent({})
+        defineComponent({})
+      `
+    },
+    {
+      filename: 'test.js',
+      code: `
+        function createApp() {}
+        createApp({})
+        createApp({})
+      `
     }
   ],
   invalid: [
@@ -128,6 +167,101 @@ ruleTester.run('one-component-per-file', rule, {
           endLine: 3,
           endColumn: 26
         }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        import { component } from 'vue'
+        component('', {})
+        component('', {})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        import { component } from '@vue/composition-api'
+        component('', {})
+        component('', {})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        import { createApp } from 'vue'
+        createApp({})
+        createApp({})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        import { createApp } from '@vue/composition-api'
+        createApp({})
+        createApp({})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        import { defineComponent } from 'vue'
+        defineComponent({})
+        defineComponent({})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        import { defineComponent } from '@vue/composition-api'
+        defineComponent('', {})
+        defineComponent('', {})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        defineComponent({})
+        defineComponent({})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        const { defineComponent } = require('vue')
+        defineComponent({})
+        defineComponent({})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
       ]
     }
   ]

--- a/tests/lib/rules/one-component-per-file.test.ts
+++ b/tests/lib/rules/one-component-per-file.test.ts
@@ -185,8 +185,20 @@ ruleTester.run('one-component-per-file', rule, {
         component('', {})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 23,
+          endLine: 3,
+          endColumn: 25
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 23,
+          endLine: 4,
+          endColumn: 25
+        }
       ]
     },
     {
@@ -197,8 +209,20 @@ ruleTester.run('one-component-per-file', rule, {
         component('', {})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 23,
+          endLine: 3,
+          endColumn: 25
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 23,
+          endLine: 4,
+          endColumn: 25
+        }
       ]
     },
     {
@@ -209,8 +233,20 @@ ruleTester.run('one-component-per-file', rule, {
         component('', {})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 23,
+          endLine: 3,
+          endColumn: 25
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 23,
+          endLine: 4,
+          endColumn: 25
+        }
       ]
     },
     {
@@ -221,8 +257,20 @@ ruleTester.run('one-component-per-file', rule, {
         createApp({})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 19,
+          endLine: 3,
+          endColumn: 21
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 21
+        }
       ]
     },
     {
@@ -233,8 +281,20 @@ ruleTester.run('one-component-per-file', rule, {
         createApp({})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 19,
+          endLine: 3,
+          endColumn: 21
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 21
+        }
       ]
     },
     {
@@ -245,8 +305,20 @@ ruleTester.run('one-component-per-file', rule, {
         createApp({})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 19,
+          endLine: 3,
+          endColumn: 21
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 21
+        }
       ]
     },
     {
@@ -257,8 +329,20 @@ ruleTester.run('one-component-per-file', rule, {
         createApp({})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 19,
+          endLine: 3,
+          endColumn: 21
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 19,
+          endLine: 4,
+          endColumn: 21
+        }
       ]
     },
     {
@@ -269,8 +353,20 @@ ruleTester.run('one-component-per-file', rule, {
         defineComponent({})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 25,
+          endLine: 3,
+          endColumn: 27
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 27
+        }
       ]
     },
     {
@@ -281,8 +377,20 @@ ruleTester.run('one-component-per-file', rule, {
         defineComponent('', {})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 29,
+          endLine: 3,
+          endColumn: 31
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 29,
+          endLine: 4,
+          endColumn: 31
+        }
       ]
     },
     {
@@ -292,8 +400,20 @@ ruleTester.run('one-component-per-file', rule, {
         defineComponent({})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 2,
+          column: 25,
+          endLine: 2,
+          endColumn: 27
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 25,
+          endLine: 3,
+          endColumn: 27
+        }
       ]
     },
     {
@@ -304,8 +424,20 @@ ruleTester.run('one-component-per-file', rule, {
         defineComponent({})
       `,
       errors: [
-        'There is more than one component in this file.',
-        'There is more than one component in this file.'
+        {
+          message: 'There is more than one component in this file.',
+          line: 3,
+          column: 25,
+          endLine: 3,
+          endColumn: 27
+        },
+        {
+          message: 'There is more than one component in this file.',
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 27
+        }
       ]
     }
   ]

--- a/tests/lib/rules/one-component-per-file.test.ts
+++ b/tests/lib/rules/one-component-per-file.test.ts
@@ -91,6 +91,14 @@ ruleTester.run('one-component-per-file', rule, {
         createApp({})
         createApp({})
       `
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { createApp } = require('other.js')
+        createApp({})
+        createApp({})
+      `
     }
   ],
   invalid: [
@@ -209,6 +217,18 @@ ruleTester.run('one-component-per-file', rule, {
       filename: 'test.vue',
       code: `
         import { createApp } from '@vue/composition-api'
+        createApp({})
+        createApp({})
+      `,
+      errors: [
+        'There is more than one component in this file.',
+        'There is more than one component in this file.'
+      ]
+    },
+    {
+      filename: 'test.js',
+      code: `
+        const { createApp } = Vue
         createApp({})
         createApp({})
       `,


### PR DESCRIPTION
Resolves #2201, supersedes/closes #2203. Based on #2203 and [this review comment](https://github.com/vuejs/eslint-plugin-vue/pull/2203/changes#r1249325595).

`getVueComponentDefinitionType()` now also checks the source of the callee. It does this in two passes: One using `ReferencesTracker` and one using `findVariable()`. This is because no methods of `ReferencesTracker` return any results when the callee is injected, like this test in `require-explicit-slots.test.ts`:

```vue
<!-- ... -->
<script lang="ts">
// ...
defineComponent({/* ... */})
</script>
```

Co-authored-by: candy-Tong <563378816@qq.com>
Co-authored-by: ota-meshi <16508807+ota-meshi@users.noreply.github.com>