### PR TITLE
perf(no-child-content): bail out sooner for unrelated directives

### DIFF
--- a/.changeset/honest-tigers-crash.md
+++ b/.changeset/honest-tigers-crash.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Improve performance in `vue/no-child-content` rule

--- a/lib/rules/no-child-content.js
+++ b/lib/rules/no-child-content.js
@@ -120,7 +120,7 @@ module.exports = {
         const directiveName = directiveNode.key.name.name
         const elementNode = directiveNode.parent.parent
 
-        if (elementNode.endTag === null) {
+        if (elementNode.endTag === null || !directives.has(directiveName)) {
           return
         }
         const sourceCode = context.sourceCode
@@ -136,10 +136,7 @@ module.exports = {
 
         const childNodes = [...elementNode.children, ...elementComments]
 
-        if (
-          directives.has(directiveName) &&
-          childNodes.some((childNode) => !isWhiteSpaceTextNode(childNode))
-        ) {
+        if (childNodes.some((childNode) => !isWhiteSpaceTextNode(childNode))) {
           context.report({
             node: elementNode,
             loc: getLocationRange(childNodes),


### PR DESCRIPTION

Move the `directives.has(directiveName)` check higher up to avoid unnecessarily gathering the child nodes for `v-if`, `v-for` etc.
