### PR TITLE
feat(no-literals-in-template): add support for ignored attributes in …

### DIFF
--- a/lib/rules/no-literals-in-template.js
+++ b/lib/rules/no-literals-in-template.js
@@ -25,7 +25,19 @@ module.exports = {
       url: 'https://eslint.vuejs.org/rules/no-literals-in-template.html'
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignored: {
+            type: 'array',
+            items: {
+              anyOf: [{ type: 'object' }, { type: 'string' }]
+            }
+          }
+        }
+      }
+    ],
     messages: {
       unexpected: 'Unexpected {{type}} literal in template.'
     }
@@ -67,12 +79,22 @@ module.exports = {
        */
       "VAttribute[directive=true][key.name.name='bind']"(node) {
         const expression = node.value?.expression
+        if (!expression) return
+
+        /** @type {(string | RegExp)[]} */
+        const ignoredNames = ['class', 'style']
+        if (context.options?.[0]?.ignored?.length > 0) {
+          ignoredNames.push(...context.options?.[0]?.ignored)
+        }
+
+        const argument = node.key.argument
         if (
-          !expression ||
-          (node.key.argument &&
-            node.key.argument.type === 'VIdentifier' &&
-            (node.key.argument.name === 'class' ||
-              node.key.argument.name === 'style'))
+          argument?.type === 'VIdentifier' &&
+          ignoredNames.some((ignored) => {
+            if (typeof ignored === 'string') return ignored === argument.name
+            if (ignored instanceof RegExp) return ignored.test(argument.name)
+            return false
+          })
         ) {
           return
         }

--- a/tests/lib/rules/no-literals-in-template.test.ts
+++ b/tests/lib/rules/no-literals-in-template.test.ts
@@ -156,6 +156,26 @@ tester.run('no-literals-in-template', rule, {
             </template>
           </Child>
         </template>`
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div :arr="[]"></div></template>',
+      options: [
+        {
+          ignored: ['arr']
+        }
+      ],
+      name: 'Skip ignored attributes'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div :test-arr="[]"></div></template>',
+      options: [
+        {
+          ignored: [/test-.*/]
+        }
+      ],
+      name: 'Regex ignored description'
     }
   ],
   invalid: [


### PR DESCRIPTION
Allow pass in an array of ignored attribute names. They could be `string` or `RegExp`.