### PR TITLE
fix: require correct peerDep version for `vue-eslint-parser`

### DIFF
--- a/.changeset/unlucky-bugs-mix.md
+++ b/.changeset/unlucky-bugs-mix.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Updated peer dependency version for `vue-eslint-parser` to fix parsing errors in Vue SFCs

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
     "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-    "vue-eslint-parser": "^10.0.0"
+    "vue-eslint-parser": "^10.3.0"
   },
   "peerDependenciesMeta": {
     "@stylistic/eslint-plugin": {


### PR DESCRIPTION
currently wrong specified may require manual intervention from consumer repo maintainers
