### PR TITLE
fix(custom-event-name-casing): check segments of colon-separated names

### DIFF
--- a/.changeset/quiet-events-split.md
+++ b/.changeset/quiet-events-split.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/custom-event-name-casing` to check segments of colon-separated event names like `update:*`

--- a/.changeset/quiet-events-split.md
+++ b/.changeset/quiet-events-split.md
@@ -2,4 +2,4 @@
 "eslint-plugin-vue": patch
 ---
 
-Fixed `vue/custom-event-name-casing` to check segments of colon-separated event names like `update:*`
+Fixed `vue/custom-event-name-casing` to check segments of colon-separated event names like `update:foo-bar`

--- a/docs/rules/custom-event-name-casing.md
+++ b/docs/rules/custom-event-name-casing.md
@@ -30,6 +30,8 @@ See [Guide - Custom Events] for more details.
 
 This rule enforces camelCase by default.
 
+For namespaced event names like `update:myProp`, each segment between `:` is checked against the configured casing.
+
 <eslint-code-block :rules="{'vue/custom-event-name-casing': ['error']}">
 
 ```vue
@@ -140,7 +142,7 @@ export default {
 ```vue
 <template>
   <!-- ✓ GOOD -->
-  <button @click="$emit('click:row')" />
+  <button @click="$emit('click:my-row')" />
   <button @click="$emit('foo-bar')" />
 
   <!-- ✗ BAD -->
@@ -151,7 +153,7 @@ export default {
   methods: {
     onClick() {
       /* ✓ GOOD */
-      this.$emit('click:row')
+      this.$emit('click:my-row')
       this.$emit('foo-bar')
 
       /* ✗ BAD */

--- a/lib/rules/custom-event-name-casing.ts
+++ b/lib/rules/custom-event-name-casing.ts
@@ -94,7 +94,7 @@ export default {
      * Check whether the given event name is valid.
      */
     function isValidEventName(name: string): boolean {
-      return caseChecker(name) || name.startsWith('update:')
+      return name.split(':').every(caseChecker)
     }
 
     function verify(nameWithLoc: NameWithLoc) {

--- a/tests/lib/rules/custom-event-name-casing.test.ts
+++ b/tests/lib/rules/custom-event-name-casing.test.ts
@@ -28,7 +28,7 @@ tester.run('custom-event-name-casing', rule, {
         setup(props, context) {
           return {
             onInput(value) {
-              context.emit('update:fooBar', value)
+              context.emit('update:foo-bar', value)
               context.emit('foo-bar')
             }
           }
@@ -48,21 +48,21 @@ tester.run('custom-event-name-casing', rule, {
       code: `
       <template>
         <input
-          @click="$emit('update:fooBar', value)">
+          @click="$emit('update:foo-bar', value)">
       </template>
       <script>
       export default {
         setup(props, {emit}) {
           return {
             onInput(value) {
-              emit('update:fooBar', value)
+              emit('update:foo-bar', value)
               emit('foo-bar')
             }
           }
         },
         methods: {
           onClick() {
-            this.$emit('update:fooBar', value)
+            this.$emit('update:foo-bar', value)
           }
         }
       }
@@ -332,6 +332,16 @@ tester.run('custom-event-name-casing', rule, {
       </template>
       `,
       options: ['kebab-case']
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/2439
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <button @click="$emit('fooBar:barBaz')" />
+      </template>
+      `,
+      options: ['camelCase']
     }
   ],
   invalid: [
@@ -758,6 +768,45 @@ tester.run('custom-event-name-casing', rule, {
           column: 29,
           endLine: 9,
           endColumn: 38
+        }
+      ]
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/2439
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <input
+          @click="$emit('update:fooBar')">
+      </template>
+      `,
+      options: ['kebab-case'],
+      errors: [
+        {
+          message: "Custom event name 'update:fooBar' must be kebab-case.",
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 40
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <input
+          @click="$emit('update:my-prop')">
+      </template>
+      `,
+      options: ['camelCase'],
+      errors: [
+        {
+          message: "Custom event name 'update:my-prop' must be camelCase.",
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 41
         }
       ]
     }


### PR DESCRIPTION
fix #2439

Each segment of colon-separated event names is now checked against the configured casing, instead of skipping any name starting with `update:`.
This also applies to non-`update:` namespaced names like `fooBar:barBaz`.

Updated two existing valid tests that pinned the old shortcut behaviour.