### PR TITLE
fix(prefer-import-from-vue): don't report names not exported by vue

### DIFF
--- a/.changeset/prefer-import-from-vue-non-exports.md
+++ b/.changeset/prefer-import-from-vue-non-exports.md
@@ -2,4 +2,4 @@
 "eslint-plugin-vue": patch
 ---
 
-Fixed `vue/prefer-import-from-vue` to not report imports/exports of names from `@vue/reactivity` and `@vue/shared` that are not re-exported by `vue`.
+Fixed `vue/prefer-import-from-vue` to not report imports/exports of names that are not re-exported by `vue`.

--- a/.changeset/prefer-import-from-vue-non-exports.md
+++ b/.changeset/prefer-import-from-vue-non-exports.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/prefer-import-from-vue` to not report imports/exports of names from `@vue/reactivity` and `@vue/shared` that are not re-exported by `vue`.

--- a/docs/rules/prefer-import-from-vue.md
+++ b/docs/rules/prefer-import-from-vue.md
@@ -30,6 +30,8 @@ Imports from the following modules are almost always wrong. You should import fr
 - `@vue/reactivity`
 - `@vue/shared`
 
+For `@vue/reactivity` and `@vue/shared`, only named imports/exports that `vue` actually re-exports are reported.
+
 <eslint-code-block fix :rules="{'vue/prefer-import-from-vue': ['error']}" filename="example.js" language="javascript">
 
 ```js

--- a/docs/rules/prefer-import-from-vue.md
+++ b/docs/rules/prefer-import-from-vue.md
@@ -30,7 +30,7 @@ Imports from the following modules are almost always wrong. You should import fr
 - `@vue/reactivity`
 - `@vue/shared`
 
-For `@vue/reactivity` and `@vue/shared`, only named imports/exports that `vue` actually re-exports are reported.
+Only named imports/exports of bindings that `vue` actually re-exports are reported.
 
 <eslint-code-block fix :rules="{'vue/prefer-import-from-vue': ['error']}" filename="example.js" language="javascript">
 

--- a/lib/rules/prefer-import-from-vue.js
+++ b/lib/rules/prefer-import-from-vue.js
@@ -85,6 +85,17 @@ module.exports = {
         // Skip imports without specifiers in `.d.ts` files
         if (node.specifiers.length === 0 && context.filename.endsWith('.d.ts'))
           return
+        // Don't report imports where no name is re-exported by 'vue'.
+        if (
+          !SUBSET_AT_VUE_MODULES.has(node.source.value) &&
+          node.specifiers.length > 0 &&
+          node.specifiers.every(
+            (s) =>
+              s.type === 'ImportSpecifier' &&
+              !vue3ExportNames.has(s.imported.name)
+          )
+        )
+          return
 
         verifySource(node.source, () => {
           if (SUBSET_AT_VUE_MODULES.has(node.source.value)) {
@@ -105,6 +116,14 @@ module.exports = {
       },
       ExportNamedDeclaration(node) {
         if (node.source) {
+          // Don't report exports where no name is re-exported by 'vue'.
+          if (
+            !SUBSET_AT_VUE_MODULES.has(node.source.value) &&
+            node.specifiers.length > 0 &&
+            node.specifiers.every((s) => !vue3ExportNames.has(s.local.name))
+          )
+            return
+
           verifySource(node.source, () => {
             for (const specifier of node.specifiers) {
               if (!vue3ExportNames.has(specifier.local.name)) {

--- a/lib/rules/prefer-import-from-vue.js
+++ b/lib/rules/prefer-import-from-vue.js
@@ -12,8 +12,6 @@ const TARGET_AT_VUE_MODULES = new Set([
   '@vue/reactivity',
   '@vue/shared'
 ])
-// Modules with the names of a subset of vue.
-const SUBSET_AT_VUE_MODULES = new Set(['@vue/runtime-dom', '@vue/runtime-core'])
 
 /**
  * @param {ImportDeclaration} node
@@ -95,24 +93,18 @@ module.exports = {
           return
 
         const hasOnlyNamedSpecifiers = node.specifiers.every(
-          (s) => s.type === 'ImportSpecifier'
+          (specifier) => specifier.type === 'ImportSpecifier'
         )
         const importedNames = hasOnlyNamedSpecifiers
           ? node.specifiers.map(
-              (s) => /** @type {ImportSpecifier} */ (s).imported.name
+              (specifier) =>
+                /** @type {ImportSpecifier} */ (specifier).imported.name
             )
           : []
 
         verifySource(
           node.source,
           () => {
-            if (
-              !hasOnlyNamedSpecifiers &&
-              SUBSET_AT_VUE_MODULES.has(node.source.value)
-            ) {
-              // Namespace/default import from a subset of 'vue' can safely be retargeted.
-              return true
-            }
             for (const name of extractImportNames(node)) {
               if (name == null) {
                 return false // import all
@@ -140,7 +132,7 @@ module.exports = {
               }
               return true
             },
-            node.specifiers.map((s) => s.local.name)
+            node.specifiers.map((specifier) => specifier.local.name)
           )
         }
       },

--- a/lib/rules/prefer-import-from-vue.js
+++ b/lib/rules/prefer-import-from-vue.js
@@ -60,9 +60,17 @@ module.exports = {
      *
      * @param {Literal & { value: string }} source
      * @param { () => boolean } fixable
+     * @param {string[]} names Named bindings imported or exported from the source.
      */
-    function verifySource(source, fixable) {
+    function verifySource(source, fixable, names) {
       if (!TARGET_AT_VUE_MODULES.has(source.value)) {
+        return
+      }
+      // Don't report when none of the named bindings are re-exported by 'vue'.
+      if (
+        names.length > 0 &&
+        names.every((name) => !vue3ExportNames.has(name))
+      ) {
         return
       }
 
@@ -85,61 +93,63 @@ module.exports = {
         // Skip imports without specifiers in `.d.ts` files
         if (node.specifiers.length === 0 && context.filename.endsWith('.d.ts'))
           return
-        // Don't report imports where no name is re-exported by 'vue'.
-        if (
-          !SUBSET_AT_VUE_MODULES.has(node.source.value) &&
-          node.specifiers.length > 0 &&
-          node.specifiers.every(
-            (s) =>
-              s.type === 'ImportSpecifier' &&
-              !vue3ExportNames.has(s.imported.name)
-          )
+
+        const hasOnlyNamedSpecifiers = node.specifiers.every(
+          (s) => s.type === 'ImportSpecifier'
         )
-          return
+        const importedNames = hasOnlyNamedSpecifiers
+          ? node.specifiers.map(
+              (s) => /** @type {ImportSpecifier} */ (s).imported.name
+            )
+          : []
 
-        verifySource(node.source, () => {
-          if (SUBSET_AT_VUE_MODULES.has(node.source.value)) {
-            // If the module is a subset of 'vue', we can safely change it to 'vue'.
-            return true
-          }
-          for (const name of extractImportNames(node)) {
-            if (name == null) {
-              return false // import all
+        verifySource(
+          node.source,
+          () => {
+            if (
+              !hasOnlyNamedSpecifiers &&
+              SUBSET_AT_VUE_MODULES.has(node.source.value)
+            ) {
+              // Namespace/default import from a subset of 'vue' can safely be retargeted.
+              return true
             }
-            if (!vue3ExportNames.has(name)) {
-              // If there is a name that is not exported from 'vue', it will not be auto-fixed.
-              return false
-            }
-          }
-          return true
-        })
-      },
-      ExportNamedDeclaration(node) {
-        if (node.source) {
-          // Don't report exports where no name is re-exported by 'vue'.
-          if (
-            !SUBSET_AT_VUE_MODULES.has(node.source.value) &&
-            node.specifiers.length > 0 &&
-            node.specifiers.every((s) => !vue3ExportNames.has(s.local.name))
-          )
-            return
-
-          verifySource(node.source, () => {
-            for (const specifier of node.specifiers) {
-              if (!vue3ExportNames.has(specifier.local.name)) {
+            for (const name of extractImportNames(node)) {
+              if (name == null) {
+                return false // import all
+              }
+              if (!vue3ExportNames.has(name)) {
                 // If there is a name that is not exported from 'vue', it will not be auto-fixed.
                 return false
               }
             }
             return true
-          })
+          },
+          importedNames
+        )
+      },
+      ExportNamedDeclaration(node) {
+        if (node.source) {
+          verifySource(
+            node.source,
+            () => {
+              for (const specifier of node.specifiers) {
+                if (!vue3ExportNames.has(specifier.local.name)) {
+                  // If there is a name that is not exported from 'vue', it will not be auto-fixed.
+                  return false
+                }
+              }
+              return true
+            },
+            node.specifiers.map((s) => s.local.name)
+          )
         }
       },
       ExportAllDeclaration(node) {
         verifySource(
           node.source,
           // If we change it to `from 'vue'`, it will export more, so it will not be auto-fixed.
-          () => false
+          () => false,
+          []
         )
       }
     }

--- a/tests/lib/rules/prefer-import-from-vue.test.ts
+++ b/tests/lib/rules/prefer-import-from-vue.test.ts
@@ -24,7 +24,11 @@ tester.run('prefer-import-from-vue', rule, {
     {
       filename: 'test.d.ts',
       code: `import '@vue/runtime-dom'`
-    }
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/2354
+    `import { unknown } from '@vue/reactivity'`,
+    `import { unknown } from '@vue/shared'`,
+    `export { unknown } from '@vue/reactivity'`
   ],
   invalid: [
     {
@@ -76,19 +80,6 @@ tester.run('prefer-import-from-vue', rule, {
           column: 32,
           endLine: 1,
           endColumn: 45
-        }
-      ]
-    },
-    {
-      code: `import { unknown } from '@vue/reactivity'`,
-      output: null,
-      errors: [
-        {
-          message: "Import from 'vue' instead of '@vue/reactivity'.",
-          line: 1,
-          column: 25,
-          endLine: 1,
-          endColumn: 42
         }
       ]
     },
@@ -184,19 +175,6 @@ tester.run('prefer-import-from-vue', rule, {
       ]
     },
     {
-      code: `export { unknown } from '@vue/reactivity'`,
-      output: null,
-      errors: [
-        {
-          message: "Import from 'vue' instead of '@vue/reactivity'.",
-          line: 1,
-          column: 25,
-          endLine: 1,
-          endColumn: 42
-        }
-      ]
-    },
-    {
       code: `export { unknown } from '@vue/runtime-dom'`,
       output: null,
       errors: [
@@ -232,6 +210,20 @@ tester.run('prefer-import-from-vue', rule, {
           column: 21,
           endLine: 1,
           endColumn: 39
+        }
+      ]
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/2354
+    {
+      code: `import { computed, unknown } from '@vue/reactivity'`,
+      output: null,
+      errors: [
+        {
+          message: "Import from 'vue' instead of '@vue/reactivity'.",
+          line: 1,
+          column: 35,
+          endLine: 1,
+          endColumn: 52
         }
       ]
     }

--- a/tests/lib/rules/prefer-import-from-vue.test.ts
+++ b/tests/lib/rules/prefer-import-from-vue.test.ts
@@ -28,7 +28,9 @@ tester.run('prefer-import-from-vue', rule, {
     // https://github.com/vuejs/eslint-plugin-vue/issues/2354
     `import { unknown } from '@vue/reactivity'`,
     `import { unknown } from '@vue/shared'`,
-    `export { unknown } from '@vue/reactivity'`
+    `import { unknown } from '@vue/runtime-dom'`,
+    `export { unknown } from '@vue/reactivity'`,
+    `export { unknown } from '@vue/runtime-dom'`
   ],
   invalid: [
     {
@@ -80,19 +82,6 @@ tester.run('prefer-import-from-vue', rule, {
           column: 32,
           endLine: 1,
           endColumn: 45
-        }
-      ]
-    },
-    {
-      code: `import { unknown } from '@vue/runtime-dom'`,
-      output: `import { unknown } from 'vue'`,
-      errors: [
-        {
-          message: "Import from 'vue' instead of '@vue/runtime-dom'.",
-          line: 1,
-          column: 25,
-          endLine: 1,
-          endColumn: 43
         }
       ]
     },
@@ -171,19 +160,6 @@ tester.run('prefer-import-from-vue', rule, {
           column: 26,
           endLine: 1,
           endColumn: 44
-        }
-      ]
-    },
-    {
-      code: `export { unknown } from '@vue/runtime-dom'`,
-      output: null,
-      errors: [
-        {
-          message: "Import from 'vue' instead of '@vue/runtime-dom'.",
-          line: 1,
-          column: 25,
-          endLine: 1,
-          endColumn: 43
         }
       ]
     },

--- a/tests/lib/rules/prefer-import-from-vue.test.ts
+++ b/tests/lib/rules/prefer-import-from-vue.test.ts
@@ -100,7 +100,7 @@ tester.run('prefer-import-from-vue', rule, {
     },
     {
       code: `import * as Foo from '@vue/runtime-dom'`,
-      output: `import * as Foo from 'vue'`,
+      output: null,
       errors: [
         {
           message: "Import from 'vue' instead of '@vue/runtime-dom'.",
@@ -178,7 +178,7 @@ tester.run('prefer-import-from-vue', rule, {
     },
     {
       code: `import unknown from '@vue/runtime-dom'`,
-      output: `import unknown from 'vue'`,
+      output: null,
       errors: [
         {
           message: "Import from 'vue' instead of '@vue/runtime-dom'.",


### PR DESCRIPTION
fix #2354

For `@vue/reactivity` and `@vue/shared`, named imports/exports of bindings not re-exported by `vue` (e.g. `pauseTracking` from `@vue/reactivity`) are no longer reported. ~`@vue/runtime-dom` and `@vue/runtime-core` are unchanged — `vue` re-exports everything from them.~

Two existing tests that pinned the false-positive behaviour moved from `invalid` to `valid`. Added one `invalid` case for mixed-named imports (at least one name in `vue`, no autofix possible).