### PR TITLE
feat(sort-keys): add allowLineSeparatedGroups option

### DIFF
--- a/.changeset/sort-keys-allow-line-separated-groups.md
+++ b/.changeset/sort-keys-allow-line-separated-groups.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Added `allowLineSeparatedGroups` option to [`vue/sort-keys`](https://eslint.vuejs.org/rules/sort-keys.html) rule.

--- a/.changeset/sort-keys-allow-line-separated-groups.md
+++ b/.changeset/sort-keys-allow-line-separated-groups.md
@@ -2,4 +2,4 @@
 "eslint-plugin-vue": minor
 ---
 
-Added `allowLineSeparatedGroups` option to [`vue/sort-keys`](https://eslint.vuejs.org/rules/sort-keys.html) rule.
+Added `allowLineSeparatedGroups` option to [`vue/sort-keys`](https://eslint.vuejs.org/rules/sort-keys.html) rule

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -80,7 +80,8 @@ export default {
         "ignoreChildrenOf": ["model"],
         "ignoreGrandchildrenOf": ["computed", "directives", "inject", "props", "watch"],
         "minKeys": 2,
-        "natural": false
+        "natural": false,
+        "allowLineSeparatedGroups": false
   }]
 }
 ```
@@ -90,13 +91,14 @@ The 1st option is `"asc"` or `"desc"`.
 - `"asc"` (default) - enforce properties to be in ascending order.
 - `"desc"` - enforce properties to be in descending order.
 
-The 2nd option is an object which has 5 properties.
+The 2nd option is an object which has 6 properties.
 
 - `caseSensitive` - if `true`, enforce properties to be in case-sensitive order. Default is `true`.
 - `ignoreChildrenOf` - an array of properties to ignore the children of.  Default is `["model"]`
 - `ignoreGrandchildrenOf` - an array of properties to ignore the grandchildren sort order. Default is `["computed", "directives", "inject", "props", "watch"]`
 - `minKeys` - Specifies the minimum number of keys that an object should have in order for the object's unsorted keys to produce an error. Default is `2`, which means by default all objects with unsorted keys will result in lint errors.
 - `natural` - if `true`, enforce properties to be in natural order. Default is `false`. Natural Order compares strings containing combination of letters and numbers in the way a human being would sort. It basically sorts numerically, instead of sorting alphabetically. So the number 10 comes after the number 3 in Natural Sorting.
+- `allowLineSeparatedGroups` - if `true`, the rule allows to group object keys through line breaks. In other words, a blank line after a property will reset the sorting of keys. Default is `false`.
 
 While using this rule, you may disable the normal `sort-keys` rule.  This rule will apply to plain js files as well as Vue component scripts.
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -256,7 +256,6 @@ module.exports = {
             node
           ]
 
-          // check blank line between tokens
           isBlankLineBetweenNodes ||= tokens.some((token, index) => {
             const previousToken = tokens.at(index - 1)
             return (

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -248,7 +248,6 @@ module.exports = {
         let isBlankLineBetweenNodes = objectStack.prevBlankLine
 
         if (prevNode) {
-          // Collect the previous node, the tokens between, and the current node
           const tokens = [
             prevNode,
             ...sourceCode.getTokensBetween(prevNode, node, {

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -249,9 +249,13 @@ module.exports = {
 
         if (prevNode) {
           // Get tokens between current node and previous node
-          const tokens = sourceCode.getTokensBetween(prevNode, node, {
-            includeComments: true
-          })
+          const tokens = [
+            prevNode,
+            ...sourceCode.getTokensBetween(prevNode, node, {
+              includeComments: true
+            }),
+            node
+          ]
 
           // check blank line between tokens
           let previousToken

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -257,11 +257,10 @@ module.exports = {
           ]
 
           isBlankLineBetweenNodes ||= tokens.some((token, index) => {
-            const previousToken = tokens.at(index - 1)
-            return (
-              previousToken &&
-              token.loc.start.line - previousToken.loc.end.line > 1
-            )
+            if (index === 0) {
+              return false
+            }
+            return token.loc.start.line - tokens[index - 1].loc.end.line > 1
           })
         }
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -277,6 +277,9 @@ module.exports = {
         }
 
         if (allowLineSeparatedGroups && isBlankLineBetweenNodes) {
+          // A computed key (e.g. `[a+b]`) has no name to compare, so it's skipped and doesn't
+          // reset the sort. Carry the blank line over; otherwise the next key would be compared
+          // against the previous group and wrongly reported as out of order.
           objectStack.prevBlankLine = thisName === null
           return
         }

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -96,6 +96,9 @@ module.exports = {
           },
           natural: {
             type: 'boolean'
+          },
+          allowLineSeparatedGroups: {
+            type: 'boolean'
           }
         },
         additionalProperties: false
@@ -132,13 +135,18 @@ module.exports = {
     const insensitive = options && options.caseSensitive === false
     const minKeys = options?.minKeys ?? 2
     const natural = options && options.natural
+    const allowLineSeparatedGroups =
+      (options && options.allowLineSeparatedGroups) || false
     const isValidOrder =
       isValidOrders[order + (insensitive ? 'I' : '') + (natural ? 'N' : '')]
+    const sourceCode = context.sourceCode
 
     /**
      * @typedef {object} ObjectStack
      * @property {ObjectStack | null} ObjectStack.upper
      * @property {string | null} ObjectStack.prevName
+     * @property {Property | null} ObjectStack.prevNode
+     * @property {boolean} ObjectStack.prevBlankLine
      * @property {number} ObjectStack.numKeys
      * @property {VueState} ObjectStack.vueState
      *
@@ -165,6 +173,8 @@ module.exports = {
         objectStack = {
           upper: objectStack,
           prevName: null,
+          prevNode: null,
+          prevBlankLine: false,
           numKeys: node.properties.length,
           vueState
         }
@@ -234,8 +244,56 @@ module.exports = {
         const numKeys = objectStack.numKeys
         const thisName = getPropertyName(node)
 
+        const prevNode = objectStack.prevNode
+        let isBlankLineBetweenNodes = objectStack.prevBlankLine
+
+        if (prevNode) {
+          // Get tokens between current node and previous node
+          const tokens = sourceCode.getTokensBetween(prevNode, node, {
+            includeComments: true
+          })
+
+          // check blank line between tokens
+          let previousToken
+          for (const token of tokens) {
+            if (
+              previousToken &&
+              token.loc.start.line - previousToken.loc.end.line > 1
+            ) {
+              isBlankLineBetweenNodes = true
+            }
+            previousToken = token
+          }
+
+          // check blank line between the current node and the last token
+          const lastToken = tokens.at(-1)
+          if (
+            !isBlankLineBetweenNodes &&
+            lastToken &&
+            node.loc.start.line - lastToken.loc.end.line > 1
+          ) {
+            isBlankLineBetweenNodes = true
+          }
+
+          // check blank line between the first token and the previous node
+          if (
+            !isBlankLineBetweenNodes &&
+            tokens[0] &&
+            tokens[0].loc.start.line - prevNode.loc.end.line > 1
+          ) {
+            isBlankLineBetweenNodes = true
+          }
+        }
+
+        objectStack.prevNode = node
+
         if (thisName !== null) {
           objectStack.prevName = thisName
+        }
+
+        if (allowLineSeparatedGroups && isBlankLineBetweenNodes) {
+          objectStack.prevBlankLine = thisName === null
+          return
         }
 
         if (prevName === null || thisName === null || numKeys < minKeys) {

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -248,7 +248,7 @@ module.exports = {
         let isBlankLineBetweenNodes = objectStack.prevBlankLine
 
         if (prevNode) {
-          // Get tokens between current node and previous node
+          // Collect the previous node, the tokens between, and the current node
           const tokens = [
             prevNode,
             ...sourceCode.getTokensBetween(prevNode, node, {
@@ -267,25 +267,6 @@ module.exports = {
               isBlankLineBetweenNodes = true
             }
             previousToken = token
-          }
-
-          // check blank line between the current node and the last token
-          const lastToken = tokens.at(-1)
-          if (
-            !isBlankLineBetweenNodes &&
-            lastToken &&
-            node.loc.start.line - lastToken.loc.end.line > 1
-          ) {
-            isBlankLineBetweenNodes = true
-          }
-
-          // check blank line between the first token and the previous node
-          if (
-            !isBlankLineBetweenNodes &&
-            tokens[0] &&
-            tokens[0].loc.start.line - prevNode.loc.end.line > 1
-          ) {
-            isBlankLineBetweenNodes = true
           }
         }
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -257,16 +257,13 @@ module.exports = {
           ]
 
           // check blank line between tokens
-          let previousToken
-          for (const token of tokens) {
-            if (
+          isBlankLineBetweenNodes ||= tokens.some((token, index) => {
+            const previousToken = tokens.at(index - 1)
+            return (
               previousToken &&
               token.loc.start.line - previousToken.loc.end.line > 1
-            ) {
-              isBlankLineBetweenNodes = true
-            }
-            previousToken = token
-          }
+            )
+          })
         }
 
         objectStack.prevNode = node

--- a/tests/lib/rules/sort-keys.test.ts
+++ b/tests/lib/rules/sort-keys.test.ts
@@ -509,6 +509,145 @@ ruleTester.run('sort-keys', rule, {
     {
       code: 'var obj = {a:1, _:2, b:3}',
       options: ['desc', { natural: true, caseSensitive: false, minKeys: 4 }]
+    },
+
+    // allowLineSeparatedGroups option
+    {
+      code: `
+        var obj = {
+          e: 1,
+          f: 2,
+          g: 3,
+
+          a: 4,
+          b: 5,
+          c: 6
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }]
+    },
+    {
+      code: `
+        var obj = {
+          b: 1,
+
+          // comment
+          a: 2,
+          c: 3
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }]
+    },
+    {
+      code: `
+        var obj = {
+          b: 1
+
+          ,
+
+          // comment
+          a: 2,
+          c: 3
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }]
+    },
+    {
+      code: `
+        var obj = {
+          c: 1,
+          d: 2,
+
+          b() {
+          },
+          e: 4
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: `
+        var obj = {
+          c: 1,
+          d: 2,
+          // comment
+
+          // comment
+          b() {
+          },
+          e: 4
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: `
+        var obj = {
+          b,
+
+          [a+b]: 1,
+          a
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 }
+    },
+    {
+      code: `
+        var obj = {
+          b: "/*",
+
+          a: "*/",
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }]
+    },
+    {
+      code: `
+        var obj = {
+          b,
+
+          a,
+          ...z,
+          c
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 2018 }
+    },
+    {
+      code: `
+        var obj = {
+          b,
+
+          [foo()]: [
+
+          ],
+          a
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 2018 }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        export default {
+          data () {
+            return {
+              e: 1,
+              f: 2,
+
+              a: 3,
+              b: 4
+            }
+          }
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions
     }
   ],
 
@@ -2267,6 +2406,229 @@ ruleTester.run('sort-keys', rule, {
           column: 17,
           endLine: 7,
           endColumn: 18
+        }
+      ]
+    },
+
+    // allowLineSeparatedGroups option
+    {
+      code: `
+        var obj = {
+          b: 1,
+          c: 2,
+          a: 3
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: false }],
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'c'.",
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `
+        let obj = {
+          b
+
+          ,a
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: false }],
+      languageOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'b'.",
+          line: 5,
+          column: 12,
+          endLine: 5,
+          endColumn: 13
+        }
+      ]
+    },
+    {
+      code: `
+        let obj = {
+          b
+
+          ,a
+        }
+      `,
+      languageOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'b'.",
+          line: 5,
+          column: 12,
+          endLine: 5,
+          endColumn: 13
+        }
+      ]
+    },
+    {
+      code: `
+        var obj = {
+          b: 1,
+          c () {
+
+          },
+          a: 3
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'c'.",
+          line: 7,
+          column: 11,
+          endLine: 7,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `
+        var obj = {
+          a: 1,
+          b: 2,
+
+          z () {
+
+          },
+          y: 3
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'y' should be before 'z'.",
+          line: 9,
+          column: 11,
+          endLine: 9,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `
+        var obj = {
+          b: 1,
+          c () {
+          },
+          // comment
+          a: 3
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'c'.",
+          line: 7,
+          column: 11,
+          endLine: 7,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `
+        var obj = {
+          b,
+          [a+b]: 1,
+          a
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'b'.",
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `
+        var obj = {
+          c: 1,
+          d: 2,
+          // comment
+          // comment
+          b() {
+          },
+          e: 4
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'b' should be before 'd'.",
+          line: 7,
+          column: 11,
+          endLine: 7,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `
+        var obj = {
+          b: "/*",
+          a: "*/",
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'b'.",
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 12
+        }
+      ]
+    },
+    {
+      code: `
+        let obj = {
+          b,
+          [foo()]: [
+          // ↓ this blank is inside a property and therefore should not count
+
+          ],
+          a
+        }
+      `,
+      options: ['asc', { allowLineSeparatedGroups: true }],
+      languageOptions: { ecmaVersion: 2018 },
+      errors: [
+        {
+          message:
+            "Expected object keys to be in ascending order. 'a' should be before 'b'.",
+          line: 8,
+          column: 11,
+          endLine: 8,
+          endColumn: 12
         }
       ]
     }


### PR DESCRIPTION
Closes #2212

Adds an `allowLineSeparatedGroups` option to `vue/sort-keys`, mirroring the ESLint core option of the same name.
When enabled, a blank line between properties resets the sort order, so each group is sorted independently.
Default `false`, so existing behavior is unchanged.

Test cases are ported from ESLint core's suite.
