### PR TITLE
Avoid require-valid-default-prop false positives for unresolved unions

### DIFF
--- a/lib/rules/require-valid-default-prop.ts
+++ b/lib/rules/require-valid-default-prop.ts
@@ -271,6 +271,12 @@ export default {
 
         if (defaultList.length === 0) continue
 
+        // When a union type contains a member the rule cannot resolve to a
+        // native type (e.g. an imported type reference), `null` is used as a
+        // placeholder. In that case the set of allowed default types is
+        // unknown, so we cannot reliably report a type mismatch.
+        if (typeList.includes('null')) continue
+
         const typeNames = new Set(
           typeList.filter((item) => NATIVE_TYPES.has(item))
         )

--- a/tests/lib/rules/require-valid-default-prop.test.ts
+++ b/tests/lib/rules/require-valid-default-prop.test.ts
@@ -266,6 +266,26 @@ ruleTester.run('require-valid-default-prop', rule, {
       }
     },
     {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2279
+      filename: 'test.vue',
+      code: `<script setup lang="ts">
+      import type { Foo } from './foo'
+      withDefaults(defineProps<{
+        msg?: Foo | 'foo'
+      }>(), {
+        msg: false,
+      })
+      </script>`,
+      languageOptions: {
+        parser: vueEslintParser,
+        ecmaVersion: 6,
+        sourceType: 'module',
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
       code: `
       <script setup lang="ts">
       import {Props2 as Props} from './test01'


### PR DESCRIPTION
Problem I saw:
`vue/require-valid-default-prop` could report a valid default when a prop type mixed an imported type with a native literal type.
For example, if a union includes an imported type that resolves to boolean in user code, the rule may not be able to see that without type services. It then keeps only the known native part and can require the wrong default type.
What I changed:
I changed the rule to skip reporting when the inferred type list still contains the unresolved type placeholder.
That keeps this path aligned with the rule's existing behavior for native types it cannot know for sure, instead of guessing from the remaining resolved pieces.
How I checked it:
The new issue-repro valid case failed before the guard.
After the fix, the focused rule suite passed with 73 tests. The full lib suite passed with 11,495 tests after build, and changed-file ESLint, the changed-file TypeScript check, `git diff --check`, and branch hygiene were clean.
Closes #2279
