### PR TITLE
Update dependencies

### DIFF
--- a/.changeset/three-loud-plums-jog.md
+++ b/.changeset/three-loud-plums-jog.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-vue': patch
+---
+
+Updated `@eslint-community/eslint-utils`, `semver` and `xml-name-validator` dependencies

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     }
   },
   "dependencies": {
-    "@eslint-community/eslint-utils": "^4.4.0",
+    "@eslint-community/eslint-utils": "^4.9.1",
     "natural-compare": "^1.4.0",
     "nth-check": "^2.1.1",
     "postcss-selector-parser": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "natural-compare": "^1.4.0",
     "nth-check": "^2.1.1",
     "postcss-selector-parser": "^7.1.4",
-    "semver": "^7.6.3",
+    "semver": "^7.8.5",
     "xml-name-validator": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "nth-check": "^2.1.1",
     "postcss-selector-parser": "^7.1.4",
     "semver": "^7.8.5",
-    "xml-name-validator": "^4.0.0"
+    "xml-name-validator": "^5.0.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@eslint-community/eslint-utils": "^4.4.0",
     "natural-compare": "^1.4.0",
     "nth-check": "^2.1.1",
-    "postcss-selector-parser": "^7.1.0",
+    "postcss-selector-parser": "^7.1.4",
     "semver": "^7.6.3",
     "xml-name-validator": "^4.0.0"
   },


### PR DESCRIPTION
- `postcss-selector-parser`: only patch updates (including security updates), see https://github.com/postcss/postcss-selector-parser/blob/7.1.4/CHANGELOG.md
- `@eslint-community/eslint-utils`: only minor updates, see https://github.com/eslint-community/eslint-utils/releases
- `semver`: only minor updates, see https://github.com/npm/node-semver/blob/v7.8.5/CHANGELOG.md
- `xml-name-validator`: major update (but Node.js v18 is still in our supported range), see https://github.com/jsdom/xml-name-validator/releases/tag/v5.0.0
- `nth-check`: intentionally not updated because v3 would be ESM-only and require Node.js v20.19+, see https://github.com/fb55/nth-check/releases/tag/v3.0.0