### PR TITLE
Fix prefer-separate-static-class for template literals

### DIFF
--- a/.changeset/prefer-static-class-template-literal.md
+++ b/.changeset/prefer-static-class-template-literal.md
@@ -2,4 +2,4 @@
 "eslint-plugin-vue": patch
 ---
 
-Fixed `vue/prefer-separate-static-class` to report static class text inside template literal class bindings.
+Fixed `vue/prefer-separate-static-class` to report static text inside template literals

--- a/.changeset/prefer-static-class-template-literal.md
+++ b/.changeset/prefer-static-class-template-literal.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/prefer-separate-static-class` to report static class text inside template literal class bindings.

--- a/.changeset/prefer-static-class-template-literal.md
+++ b/.changeset/prefer-static-class-template-literal.md
@@ -1,5 +1,5 @@
 ---
-"eslint-plugin-vue": patch
+"eslint-plugin-vue": minor
 ---
 
-Fixed `vue/prefer-separate-static-class` to report static text inside template literals
+Added support for template literals to `vue/prefer-separate-static-class`

--- a/lib/rules/prefer-separate-static-class.js
+++ b/lib/rules/prefer-separate-static-class.js
@@ -57,15 +57,11 @@ function findStaticClasses(expressionNode) {
       if (
         property.type === 'Property' &&
         property.value.type === 'Literal' &&
-        property.value.value === true
+        property.value.value === true &&
+        (isStringLiteral(property.key) ||
+          (property.key.type === 'Identifier' && !property.computed))
       ) {
-        const key = /** @type {ASTNode | TemplateLiteral} */ (property.key)
-        if (isStringLiteral(key)) {
-          return [key]
-        }
-        if (key.type === 'Identifier' && !property.computed) {
-          return [key]
-        }
+        return [property.key]
       }
       return []
     })

--- a/lib/rules/prefer-separate-static-class.js
+++ b/lib/rules/prefer-separate-static-class.js
@@ -11,10 +11,37 @@ const {
 } = require('../utils')
 
 /**
- * @param {Expression | VForExpression | VOnExpression | VSlotScopeExpression | VFilterSequenceExpression} expressionNode
- * @returns {(Literal | TemplateLiteral | Identifier)[]}
+ * @param {TemplateElement} templateElement
+ * @param {number} index
+ * @param {TemplateLiteral} templateLiteral
+ * @returns {boolean}
+ */
+function isStaticClassTemplateElement(templateElement, index, templateLiteral) {
+  const value = templateElement.value.cooked
+  if (!value || value.trim() === '') {
+    return false
+  }
+
+  return (
+    (index === 0 || /^\s/u.test(value)) &&
+    (index === templateLiteral.expressions.length || /\s$/u.test(value))
+  )
+}
+
+/**
+ * @param {ASTNode | TemplateLiteral} expressionNode
+ * @returns {(Literal | TemplateLiteral | TemplateElement | Identifier)[]}
  */
 function findStaticClasses(expressionNode) {
+  if (expressionNode.type === 'TemplateLiteral') {
+    if (expressionNode.expressions.length === 0) {
+      return [expressionNode]
+    }
+    return expressionNode.quasis.filter((templateElement, index) =>
+      isStaticClassTemplateElement(templateElement, index, expressionNode)
+    )
+  }
+
   if (isStringLiteral(expressionNode)) {
     return [expressionNode]
   }
@@ -33,17 +60,39 @@ function findStaticClasses(expressionNode) {
       if (
         property.type === 'Property' &&
         property.value.type === 'Literal' &&
-        property.value.value === true &&
-        (isStringLiteral(property.key) ||
-          (property.key.type === 'Identifier' && !property.computed))
+        property.value.value === true
       ) {
-        return [property.key]
+        const key = /** @type {ASTNode | TemplateLiteral} */ (property.key)
+        if (key.type === 'TemplateLiteral') {
+          return findStaticClasses(key)
+        }
+        if (isStringLiteral(key)) {
+          return [key]
+        }
+        if (key.type === 'Identifier' && !property.computed) {
+          return [key]
+        }
       }
       return []
     })
   }
 
   return []
+}
+
+/**
+ * @param {Literal | TemplateLiteral | TemplateElement | Identifier} staticClassNameNode
+ * @returns {string | null}
+ */
+function getStaticClassName(staticClassNameNode) {
+  if (staticClassNameNode.type === 'Identifier') {
+    return staticClassNameNode.name
+  }
+  if (staticClassNameNode.type === 'TemplateElement') {
+    const value = staticClassNameNode.value.cooked
+    return value === null ? null : value.trim().replaceAll(/\s+/gu, ' ')
+  }
+  return getStringLiteralValue(staticClassNameNode, true)
 }
 
 /**
@@ -119,10 +168,7 @@ module.exports = {
         const staticClassNameNodes = findStaticClasses(expressionNode)
 
         for (const staticClassNameNode of staticClassNameNodes) {
-          const className =
-            staticClassNameNode.type === 'Identifier'
-              ? staticClassNameNode.name
-              : getStringLiteralValue(staticClassNameNode, true)
+          const className = getStaticClassName(staticClassNameNode)
 
           if (className === null) {
             continue
@@ -133,6 +179,10 @@ module.exports = {
             messageId: 'preferSeparateStaticClass',
             data: { className },
             *fix(fixer) {
+              if (staticClassNameNode.type === 'TemplateElement') {
+                return
+              }
+
               let isDynamicClassDirectiveRemoved = false
 
               yield* removeFromClassDirective()

--- a/lib/rules/prefer-separate-static-class.js
+++ b/lib/rules/prefer-separate-static-class.js
@@ -33,17 +33,14 @@ function isStaticClassTemplateElement(templateElement, index, templateLiteral) {
  * @returns {(Literal | TemplateLiteral | TemplateElement | Identifier)[]}
  */
 function findStaticClasses(expressionNode) {
+  if (isStringLiteral(expressionNode)) {
+    return [expressionNode]
+  }
+
   if (expressionNode.type === 'TemplateLiteral') {
-    if (expressionNode.expressions.length === 0) {
-      return [expressionNode]
-    }
     return expressionNode.quasis.filter((templateElement, index) =>
       isStaticClassTemplateElement(templateElement, index, expressionNode)
     )
-  }
-
-  if (isStringLiteral(expressionNode)) {
-    return [expressionNode]
   }
 
   if (expressionNode.type === 'ArrayExpression') {
@@ -63,9 +60,6 @@ function findStaticClasses(expressionNode) {
         property.value.value === true
       ) {
         const key = /** @type {ASTNode | TemplateLiteral} */ (property.key)
-        if (key.type === 'TemplateLiteral') {
-          return findStaticClasses(key)
-        }
         if (isStringLiteral(key)) {
           return [key]
         }

--- a/tests/lib/rules/prefer-separate-static-class.test.ts
+++ b/tests/lib/rules/prefer-separate-static-class.test.ts
@@ -135,6 +135,21 @@ tester.run('prefer-separate-static-class', rule, {
     },
     {
       filename: 'test.vue',
+      code: '<template><div :class="`${start} static-class ${end}`" /></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Static class "static-class" should be in a static `class` attribute.',
+          line: 1,
+          column: 32,
+          endLine: 1,
+          endColumn: 49
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
       code: `<template><div :class='"static-class"' /></template>`,
       output: `<template><div class="static-class" /></template>`,
       errors: [

--- a/tests/lib/rules/prefer-separate-static-class.test.ts
+++ b/tests/lib/rules/prefer-separate-static-class.test.ts
@@ -30,6 +30,10 @@ tester.run('prefer-separate-static-class', rule, {
     },
     {
       filename: 'test.vue',
+      code: '<template><div :class="`${foo}-dynamic-class`" /></template>'
+    },
+    {
+      filename: 'test.vue',
       code: `<template><div :class="'dynamic-class-' + foo" /></template>`
     },
     {
@@ -96,6 +100,36 @@ tester.run('prefer-separate-static-class', rule, {
           column: 24,
           endLine: 1,
           endColumn: 38
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: "<template><div :class=\"`form-item input ${isDisabled ? 'disabled' : ''}`\" /></template>",
+      output: null,
+      errors: [
+        {
+          message:
+            'Static class "form-item input" should be in a static `class` attribute.',
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 43
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><div :class="`${dynamicClass} static-class`" /></template>',
+      output: null,
+      errors: [
+        {
+          message:
+            'Static class "static-class" should be in a static `class` attribute.',
+          line: 1,
+          column: 39,
+          endLine: 1,
+          endColumn: 54
         }
       ]
     },


### PR DESCRIPTION
## Summary

- report static class text inside dynamic `:class` template literals when the static text is bounded by class-name whitespace
- keep partial interpolated class names such as `` `foo-${bar}` `` valid to avoid false positives
- add regression coverage for issue #2128

Fixes #2128.

## Tests

- `npx vitest run --reporter=dot tests/lib/rules/prefer-separate-static-class.test.ts`
- `npx eslint lib/rules/prefer-separate-static-class.js tests/lib/rules/prefer-separate-static-class.test.ts`
- `npm run lint`
- `git diff --check`
