### PR TITLE
docs: complete component detection patterns

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -323,7 +323,7 @@ All component-related rules are applied to code that passes any of the following
 - `component()` expression
 - `defineComponent()` expression
 - `defineNuxtComponent()` expression
-- `export default {}` in `.vue`, `.jsx`, or `.tsx` file
+- `export default {}` in `.vue`, `.jsx`, or `.tsx` files
 
 However, if you want to take advantage of the rules in any of your custom objects that are Vue components, you might need to use the special comment `// @vue/component` that marks an object in the next line as a Vue component in any file, e.g.:
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -316,6 +316,7 @@ All component-related rules are applied to code that passes any of the following
 - `Vue.component()` expression
 - `Vue.extend()` expression
 - `Vue.mixin()` expression
+- `new Vue()` expression
 - `app.component()` expression
 - `app.mixin()` expression
 - `createApp()` expression

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -314,6 +314,7 @@ The `parserOptions.parser` option can also specify an object to specify multiple
 All component-related rules are applied to code that passes any of the following checks:
 
 - `Vue.component()` expression
+- `component()` expression
 - `Vue.extend()` expression
 - `Vue.mixin()` expression
 - `new Vue()` expression
@@ -321,7 +322,8 @@ All component-related rules are applied to code that passes any of the following
 - `app.mixin()` expression
 - `createApp()` expression
 - `defineComponent()` expression
-- `export default {}` in `.vue` or `.jsx` file
+- `defineNuxtComponent()` expression
+- `export default {}` in `.vue`, `.jsx`, or `.tsx` file
 
 However, if you want to take advantage of the rules in any of your custom objects that are Vue components, you might need to use the special comment `// @vue/component` that marks an object in the next line as a Vue component in any file, e.g.:
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -314,13 +314,13 @@ The `parserOptions.parser` option can also specify an object to specify multiple
 All component-related rules are applied to code that passes any of the following checks:
 
 - `Vue.component()` expression
-- `component()` expression
 - `Vue.extend()` expression
 - `Vue.mixin()` expression
-- `new Vue()` expression
 - `app.component()` expression
 - `app.mixin()` expression
+- `new Vue()` expression
 - `createApp()` expression
+- `component()` expression
 - `defineComponent()` expression
 - `defineNuxtComponent()` expression
 - `export default {}` in `.vue`, `.jsx`, or `.tsx` file


### PR DESCRIPTION
## Summary

- document the existing `new Vue()`, `component()`, and `defineNuxtComponent()` component-detection forms
- document that `export default {}` is also detected in `.tsx` files
- keep the user-guide list aligned with the current detector implementation

Fixes #2077.

## Why

A maintainer confirmed that `new Vue()` has been a lint target since eslint-plugin-vue v3 and asked whether other detection patterns were also missing from the documentation. I audited `getVueComponentDefinitionType`, `isVueInstance`, and `isVueComponentFile`; this update documents the remaining existing forms without changing runtime behavior or adding per-rule exclusion options.

## Validation

- `npm.cmd run build`
- `npx.cmd eslint docs/user-guide/index.md`
- `npx.cmd markdownlint docs/user-guide/index.md`
- `npm.cmd run test:base` — 287 files, 11,514 tests
- `npx.cmd vitest run tests/integrations --hookTimeout=60000` — 2 files, 2 tests
- `npm.cmd run docs:build`
- `git diff --check`

## Local baseline notes

- A fresh unlocked dependency install makes the full-repository lint report three errors in two untouched rule documents; the changed file passes both linters.
- The default 10-second integration setup hooks were shorter than two nested npm installs on this Windows machine; both integration tests pass with a bounded 60-second hook timeout.
- The fresh install reports three development-dependency vulnerabilities; `npm.cmd audit --omit=dev --audit-level=high` reports zero production vulnerabilities.

## Automation disclosure

This documentation update was prepared and tested with OpenAI Codex automation. The initial patch received advisory AI reviews from an independent local agent and ChatGPT Web; the maintainer follow-up was implementation-audited and independently re-reviewed locally. No human review is claimed.
