### PR TITLE
fix: handle unresolved types in require-valid-default-prop

### DIFF
--- a/.changeset/quiet-trees-smile.md
+++ b/.changeset/quiet-trees-smile.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-vue': patch
+---
+
+Avoid false positives in `vue/require-valid-default-prop` for unions with unresolved imported types.

--- a/lib/rules/require-valid-default-prop.ts
+++ b/lib/rules/require-valid-default-prop.ts
@@ -11,6 +11,8 @@ import type {
 import utils from '../utils/index.js'
 import { capitalize } from '../utils/casing.ts'
 
+const UNKNOWN_TYPE = '__UNKNOWN__'
+
 const NATIVE_TYPES = new Set([
   'String',
   'Number',
@@ -332,6 +334,7 @@ export default {
         }
 
         if (defaultList.length === 0) continue
+        if (typeList.includes(UNKNOWN_TYPE)) continue
 
         const typeNames = new Set(
           typeList.filter((item) => NATIVE_TYPES.has(item))

--- a/lib/utils/ts-utils/ts-ast.js
+++ b/lib/utils/ts-utils/ts-ast.js
@@ -1,6 +1,7 @@
 const { getScope } = require('../scope')
 const { findVariable } = require('@eslint-community/eslint-utils')
 const { inferRuntimeTypeFromTypeNode } = require('./ts-types')
+const UNKNOWN_TYPE = '__UNKNOWN__'
 /**
  * @typedef {import('@typescript-eslint/types').TSESTree.TypeNode} TSESTreeTypeNode
  * @typedef {import('@typescript-eslint/types').TSESTree.TSInterfaceBody} TSESTreeTSInterfaceBody
@@ -510,10 +511,13 @@ function inferRuntimeType(context, node, checked = new Set()) {
           }
         }
       }
-      return inferRuntimeTypeFromTypeNode(
+      const inferredTypes = inferRuntimeTypeFromTypeNode(
         context,
         /** @type {TypeNode} */ (node)
       )
+      return inferredTypes.length === 1 && inferredTypes[0] === 'null'
+        ? [UNKNOWN_TYPE]
+        : inferredTypes
     }
 
     case 'TSUnionType':

--- a/tests/lib/rules/require-valid-default-prop.test.ts
+++ b/tests/lib/rules/require-valid-default-prop.test.ts
@@ -266,6 +266,26 @@ ruleTester.run('require-valid-default-prop', rule, {
       }
     },
     {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2279
+      filename: 'test.vue',
+      code: `<script setup lang="ts">
+      import type { Foo } from './foo'
+      withDefaults(defineProps<{
+        msg?: Foo | 'foo'
+      }>(), {
+        msg: false
+      })
+      </script>`,
+      languageOptions: {
+        parser: vueEslintParser,
+        ecmaVersion: 6,
+        sourceType: 'module',
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
       code: `
       <script setup lang="ts">
       import {Props2 as Props} from './test01'
@@ -326,6 +346,32 @@ ruleTester.run('require-valid-default-prop', rule, {
   ],
 
   invalid: [
+    {
+      filename: 'test.vue',
+      code: `<script setup lang="ts">
+withDefaults(defineProps<{ msg?: string | null }>(), {
+  msg: false
+})
+</script>`,
+      languageOptions: {
+        parser: vueEslintParser,
+        ecmaVersion: 6,
+        sourceType: 'module',
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message:
+            "Type of the default value for 'msg' prop must be a string.",
+          line: 3,
+          column: 8,
+          endLine: 3,
+          endColumn: 13
+        }
+      ]
+    },
     {
       filename: 'test.vue',
       code: `export default {


### PR DESCRIPTION
Fixes #2279.

Unresolved type references now use a dedicated inference marker instead of sharing the `null` placeholder. `require-valid-default-prop` skips validation only for that marker, while real `null` unions continue to validate known runtime types.

Tests cover both the imported-union case and a `string | null` mismatch.