### PR TITLE
feat(define-props-declaration): check defineModel

### DIFF
--- a/.changeset/kind-models-declare.md
+++ b/.changeset/kind-models-declare.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Extended `vue/define-props-declaration` to enforce the declaration style of `defineModel`

--- a/docs/rules/define-props-declaration.md
+++ b/docs/rules/define-props-declaration.md
@@ -2,17 +2,17 @@
 pageClass: rule-details
 sidebarDepth: 0
 title: vue/define-props-declaration
-description: enforce declaration style of `defineProps`
+description: enforce declaration style of `defineProps` and `defineModel`
 since: v9.5.0
 ---
 
 # vue/define-props-declaration
 
-> enforce declaration style of `defineProps`
+> enforce declaration style of `defineProps` and `defineModel`
 
 ## :book: Rule Details
 
-This rule enforces `defineProps` typing style which you should use `type-based` or `runtime` declaration.
+This rule enforces whether `defineProps` and `defineModel` should use `type-based` or `runtime` declarations.
 
 This rule only works in setup script and `lang="ts"`.
 
@@ -25,12 +25,15 @@ const props = defineProps<{
   kind: string
   options: { title: string }
 }>()
+const model = defineModel<string>()
 
 /* ✗ BAD */
 const props = defineProps({
   kind: { type: String },
   options: { type: Object as PropType<{ title: string }> }
 })
+const model = defineModel({ type: String })
+const untypedModel = defineModel()
 </script>
 ```
 
@@ -56,12 +59,14 @@ const props = defineProps({
   kind: { type: String },
   options: { type: Object as PropType<{ title: string }> }
 })
+const model = defineModel({ type: String })
 
 /* ✗ BAD */
 const props = defineProps<{
   kind: string
   options: { title: string }
 }>()
+const model = defineModel<string>()
 </script>
 ```
 
@@ -75,6 +80,7 @@ const props = defineProps<{
 ## :books: Further Reading
 
 - [`defineProps`](https://vuejs.org/api/sfc-script-setup.html#defineprops-defineemits)
+- [`defineModel`](https://vuejs.org/api/sfc-script-setup.html#definemodel)
 - [Typescript-only-features of `defineProps`](https://vuejs.org/api/sfc-script-setup.html#typescript-only-features)
 - [Guide - Typing-component-props](https://vuejs.org/guide/typescript/composition-api.html#typing-component-props)
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -217,7 +217,7 @@ For example:
 | [vue/custom-event-name-casing] | enforce specific casing for custom event name |  | :hammer: |
 | [vue/define-emits-declaration] | enforce declaration style of `defineEmits` |  | :hammer: |
 | [vue/define-macros-order] | enforce order of compiler macros (`defineProps`, `defineEmits`, etc.) | :wrench::bulb: | :lipstick: |
-| [vue/define-props-declaration] | enforce declaration style of `defineProps` |  | :hammer: |
+| [vue/define-props-declaration] | enforce declaration style of `defineProps` and `defineModel` |  | :hammer: |
 | [vue/define-props-destructuring] | enforce consistent style for props destructuring |  | :hammer: |
 | [vue/enforce-style-attribute] | enforce or forbid the use of the `scoped` and `module` attributes in SFC top level style tags |  | :hammer: |
 | [vue/html-button-has-type] | disallow usage of button without an explicit type attribute |  | :hammer: |

--- a/lib/rules/define-props-declaration.js
+++ b/lib/rules/define-props-declaration.js
@@ -10,7 +10,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'enforce declaration style of `defineProps`',
+      description:
+        'enforce declaration style of `defineProps` and `defineModel`',
       categories: undefined,
       url: 'https://eslint.vuejs.org/rules/define-props-declaration.html'
     },
@@ -50,6 +51,29 @@ module.exports = {
             const typeArguments =
               'typeArguments' in node ? node.typeArguments : node.typeParameters
             if (typeArguments && typeArguments.params.length > 0) {
+              context.report({
+                node,
+                messageId: 'hasTypeArg'
+              })
+            }
+            break
+          }
+        }
+      },
+      onDefineModelEnter(node, model) {
+        switch (defineType) {
+          case 'type-based': {
+            if (!model.typeNode) {
+              context.report({
+                node,
+                messageId: 'hasArg'
+              })
+            }
+            break
+          }
+
+          case 'runtime': {
+            if (model.typeNode) {
               context.report({
                 node,
                 messageId: 'hasTypeArg'

--- a/tests/lib/rules/define-props-declaration.test.ts
+++ b/tests/lib/rules/define-props-declaration.test.ts
@@ -60,6 +60,31 @@ tester.run('define-props-declaration', rule, {
     },
     {
       filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const model = defineModel<string>()
+      const namedModel = defineModel<number>('count', { default: 0 })
+      </script>
+      `,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const model = defineModel({ type: String })
+      const namedModel = defineModel('count', { type: Number })
+      const untypedModel = defineModel()
+      </script>
+      `,
+      options: ['runtime']
+    },
+    {
+      filename: 'test.vue',
       // ignore script without lang="ts"
       code: `
       <script setup>
@@ -168,6 +193,79 @@ tester.run('define-props-declaration', rule, {
           column: 21,
           endLine: 5,
           endColumn: 11
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const model = defineModel()
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'hasArg',
+          line: 3,
+          column: 21,
+          endLine: 3,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const model = defineModel({ type: String })
+      const namedModel = defineModel('count', { type: Number })
+      </script>
+      `,
+      errors: [
+        {
+          messageId: 'hasArg',
+          line: 3,
+          column: 21,
+          endLine: 3,
+          endColumn: 50
+        },
+        {
+          messageId: 'hasArg',
+          line: 4,
+          column: 26,
+          endLine: 4,
+          endColumn: 64
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const model = defineModel<string>()
+      const namedModel = defineModel<number>('count', { default: 0 })
+      </script>
+      `,
+      options: ['runtime'],
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          messageId: 'hasTypeArg',
+          line: 3,
+          column: 21,
+          endLine: 3,
+          endColumn: 42
+        },
+        {
+          messageId: 'hasTypeArg',
+          line: 4,
+          column: 26,
+          endLine: 4,
+          endColumn: 70
         }
       ]
     }


### PR DESCRIPTION
## What changed

- extend `vue/define-props-declaration` to inspect `defineModel`
- require explicit type arguments in `type-based` mode and reject them in `runtime` mode
- preserve valid type-based model options such as `default` and `required`
- add named and unnamed regression cases, documentation, generated rule metadata, and a minor changeset

## Why

`defineModel` declares a model prop but was not covered by the declaration-style rule. This implements the accepted direction discussed in #3069 by extending the existing rule instead of adding a nearly overlapping rule.

Closes #3069

## How tested

- `npx vitest run --reporter=dot tests/lib/rules/define-props-declaration.test.ts` (14 passed)
- `npm test` (289 files, 11,525 tests passed)
- `npm run build`
- `npm run update`
- ESLint on the changed rule and test, with the newly introduced repository-wide `require-meta-languages` check disabled
- markdownlint on the changed rule documentation and generated index
- `git diff --check`

Current `master` baseline notes:

- `npm run lint` reports 220 repository-wide `meta.languages` errors after resolving `eslint-plugin-eslint-plugin@7.5.0`; this affects existing rules and internal rules, not only this change.
- `npm run tsc` reports four existing errors in `lib/rules/prefer-separate-static-class.js`, which is not changed here.

## Risk and rollout

- Risk: Low. This only changes an opt-in rule and only adds checks for `defineModel` calls inside `<script setup lang=ts>`.
- Rollback: Revert this commit to restore `defineProps`-only behavior.

## Notes for reviewers

- Duplicate search covered issue `#3069`, `define-model-declaration`, `define-props-declaration`, `defineModel` + runtime/type-based declaration, and `onDefineModelEnter` across open/closed/merged PRs, issues, comments, and commits.
- Open PR #2466 adds autofixing for `defineProps`; it does not inspect `defineModel` or implement this issue.
- Open PR #3032 adds `defineModel` checks to the default-prop rules; it does not enforce declaration style.
- In type-based mode, `defineModel<T>(name, options)` remains valid because runtime options such as `default` and `required` can accompany a type argument.