### PR TITLE
chore: disable require-meta-languages rule to avoid breaking changes

### DIFF
--- a/eslint-internal-rules/no-invalid-meta-docs-categories.js
+++ b/eslint-internal-rules/no-invalid-meta-docs-categories.js
@@ -119,7 +119,8 @@ module.exports = {
       missingCategories: 'Rule is missing a meta.docs.categories property.',
       // eslint-disable-next-line eslint-plugin/report-message-format
       categoriesMustBeArray: 'meta.docs.categories must be an array.'
-    }
+    },
+    languages: ['js/js']
   },
 
   create(context) {

--- a/eslint-internal-rules/no-invalid-meta.js
+++ b/eslint-internal-rules/no-invalid-meta.js
@@ -87,7 +87,8 @@ module.exports = {
         'Rule is missing a meta.docs.categories property.',
       invalidMetaDocsRecommended:
         'Rule should not have a meta.docs.recommended property.'
-    }
+    },
+    languages: ['js/js']
   },
 
   create(context) {

--- a/eslint-internal-rules/require-eslint-community.js
+++ b/eslint-internal-rules/require-eslint-community.js
@@ -12,7 +12,8 @@ module.exports = {
     messages: {
       useCommunityPackageInstead:
         'Please use `@eslint-community/{{name}}` instead.'
-    }
+    },
+    languages: ['js/js']
   },
 
   /** @param {import('eslint').Rule.RuleContext} context */

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -316,7 +316,8 @@ export default typegen([
         { pattern: 'https://eslint.vuejs.org/rules/{{name}}.html' }
       ],
       'internal/no-invalid-meta': 'error',
-      'internal/no-invalid-meta-docs-categories': 'error'
+      'internal/no-invalid-meta-docs-categories': 'error',
+      'eslint-plugin/require-meta-languages': 'off'
     }
   },
   {
@@ -324,7 +325,8 @@ export default typegen([
     rules: {
       'eslint-plugin/require-meta-docs-url': 'off',
       'internal/no-invalid-meta': 'error',
-      'internal/no-invalid-meta-docs-categories': 'error'
+      'internal/no-invalid-meta-docs-categories': 'error',
+      'eslint-plugin/require-meta-languages': 'off' // We are intentionally disabling it because it is a breaking change.
     }
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -315,9 +315,9 @@ export default typegen([
         'error',
         { pattern: 'https://eslint.vuejs.org/rules/{{name}}.html' }
       ],
+      'eslint-plugin/require-meta-languages': 'off', // Enabling this would require adding `meta.languages` to every published rule, which is a breaking change, so we keep it disabled for now.
       'internal/no-invalid-meta': 'error',
-      'internal/no-invalid-meta-docs-categories': 'error',
-      'eslint-plugin/require-meta-languages': 'off'
+      'internal/no-invalid-meta-docs-categories': 'error'
     }
   },
   {
@@ -325,8 +325,7 @@ export default typegen([
     rules: {
       'eslint-plugin/require-meta-docs-url': 'off',
       'internal/no-invalid-meta': 'error',
-      'internal/no-invalid-meta-docs-categories': 'error',
-      'eslint-plugin/require-meta-languages': 'off' // We are intentionally disabling it because it is a breaking change.
+      'internal/no-invalid-meta-docs-categories': 'error'
     }
   },
   {


### PR DESCRIPTION
This PR disables the `eslint-plugin/require-meta-languages` rule in our ESLint config.


It appears that the new `eslint-plugin-eslint-plugin` introduced the `eslint-plugin/require-meta-languages` rule, but we do not need it at this time.