### PR TITLE
refactor: extract `getNameParamNode` and improve type handling

### DIFF
--- a/lib/rules/custom-event-name-casing.ts
+++ b/lib/rules/custom-event-name-casing.ts
@@ -2,7 +2,7 @@
  * @author Yosuke Ota
  * See LICENSE file in root directory for full license.
  */
-import type { VueObjectData } from '../utils/index.js'
+import type { NameWithLoc, VueObjectData } from '../utils/index.js'
 import { findVariable } from '@eslint-community/eslint-utils'
 import utils from '../utils/index.js'
 import { getChecker } from '../utils/casing.ts'
@@ -11,26 +11,6 @@ import { toRegExpGroupMatcher } from '../utils/regexp.ts'
 const ALLOWED_CASE_OPTIONS = ['kebab-case', 'camelCase']
 const DEFAULT_CASE = 'camelCase'
 
-interface NameWithLoc {
-  name: string
-  loc: SourceLocation
-}
-
-/**
- * Get the name param node from the given CallExpression
- */
-function getNameParamNode(node: CallExpression): NameWithLoc | null {
-  const nameLiteralNode = node.arguments[0]
-  if (nameLiteralNode && utils.isStringLiteral(nameLiteralNode)) {
-    const name = utils.getStringLiteralValue(nameLiteralNode)
-    if (name != null) {
-      return { name, loc: nameLiteralNode.loc }
-    }
-  }
-
-  // cannot check
-  return null
-}
 /**
  * Get the callee member node from the given CallExpression
  */
@@ -116,7 +96,7 @@ export default {
 
     const callVisitor = {
       CallExpression(node: CallExpression, info?: VueObjectData) {
-        const nameWithLoc = getNameParamNode(node)
+        const nameWithLoc = utils.getNameParamNode(node)
         if (!nameWithLoc) {
           // cannot check
           return
@@ -153,7 +133,7 @@ export default {
       {
         CallExpression(node) {
           const callee = node.callee
-          const nameWithLoc = getNameParamNode(node)
+          const nameWithLoc = utils.getNameParamNode(node)
           if (!nameWithLoc) {
             // cannot check
             return
@@ -264,7 +244,7 @@ export default {
         }),
         {
           CallExpression(node) {
-            const nameLiteralNode = getNameParamNode(node)
+            const nameLiteralNode = utils.getNameParamNode(node)
             if (!nameLiteralNode) {
               // cannot check
               return

--- a/lib/rules/no-restricted-custom-event.ts
+++ b/lib/rules/no-restricted-custom-event.ts
@@ -3,6 +3,7 @@
  * See LICENSE file in root directory for full license.
  */
 import { findVariable } from '@eslint-community/eslint-utils'
+import type { NameWithLoc } from '../utils/index.js'
 import utils from '../utils/index.js'
 import { toRegExp } from '../utils/regexp.ts'
 
@@ -29,26 +30,6 @@ function parseOption(
   return parsed
 }
 
-interface NameWithLoc {
-  name: string
-  loc: SourceLocation
-  range: Range
-}
-/**
- * Get the name param node from the given CallExpression
- */
-function getNameParamNode(node: CallExpression): NameWithLoc | null {
-  const nameLiteralNode = node.arguments[0]
-  if (nameLiteralNode && utils.isStringLiteral(nameLiteralNode)) {
-    const name = utils.getStringLiteralValue(nameLiteralNode)
-    if (name != null) {
-      return { name, loc: nameLiteralNode.loc, range: nameLiteralNode.range }
-    }
-  }
-
-  // cannot check
-  return null
-}
 /**
  * Get the callee member node from the given CallExpression
  */
@@ -154,7 +135,7 @@ export default {
       {
         CallExpression(node) {
           const callee = node.callee
-          const nameWithLoc = getNameParamNode(node)
+          const nameWithLoc = utils.getNameParamNode(node)
           if (!nameWithLoc) {
             // cannot check
             return
@@ -220,7 +201,7 @@ export default {
             })
           },
           CallExpression(node, { node: vueNode }) {
-            const nameWithLoc = getNameParamNode(node)
+            const nameWithLoc = utils.getNameParamNode(node)
             if (!nameWithLoc) {
               // cannot check
               return
@@ -256,7 +237,7 @@ export default {
         }),
         {
           CallExpression(node) {
-            const nameWithLoc = getNameParamNode(node)
+            const nameWithLoc = utils.getNameParamNode(node)
             if (!nameWithLoc) {
               // cannot check
               return

--- a/lib/rules/no-shadow-native-events.ts
+++ b/lib/rules/no-shadow-native-events.ts
@@ -6,31 +6,15 @@ import domEvents from '../utils/dom-events.json' with { type: 'json' }
 import { findVariable } from '@eslint-community/eslint-utils'
 import utils, {
   type ComponentEmit,
+  type NameWithLoc,
   type VueObjectData,
   type VueObjectType
 } from '../utils/index.js'
-import { type NameWithLoc } from './require-explicit-emits.ts'
 
 interface VueTemplateDefineData {
   type: VueObjectType | 'setup'
   define: ObjectExpression | Program
   defineEmits?: CallExpression
-}
-
-/**
- * Get the name param node from the given CallExpression
- */
-function getNameParamNode(node: CallExpression) {
-  const nameLiteralNode = node.arguments[0]
-  if (nameLiteralNode && utils.isStringLiteral(nameLiteralNode)) {
-    const name = utils.getStringLiteralValue(nameLiteralNode)
-    if (name != null) {
-      return { name, loc: nameLiteralNode.loc, range: nameLiteralNode.range }
-    }
-  }
-
-  // cannot check
-  return null
 }
 
 /**
@@ -120,7 +104,7 @@ export default {
     const callVisitor = {
       CallExpression(node: CallExpression, info?: VueObjectData) {
         const callee = utils.skipChainExpression(node.callee)
-        const nameWithLoc = getNameParamNode(node)
+        const nameWithLoc = utils.getNameParamNode(node)
         if (!nameWithLoc) {
           // cannot check
           return
@@ -294,7 +278,7 @@ export default {
         {
           CallExpression(node) {
             const callee = utils.skipChainExpression(node.callee)
-            const nameWithLoc = getNameParamNode(node)
+            const nameWithLoc = utils.getNameParamNode(node)
             if (!nameWithLoc) {
               // cannot check
               return

--- a/lib/rules/no-unused-emit-declarations.js
+++ b/lib/rules/no-unused-emit-declarations.js
@@ -9,6 +9,7 @@ const utils = require('../utils')
 
 /**
  * @typedef {import('../utils').ComponentEmit} ComponentEmit
+ * @typedef {import('../utils').NameWithLoc} NameWithLoc
  * @typedef {import('../utils').VueObjectData} VueObjectData
  */
 
@@ -17,30 +18,6 @@ const utils = require('../utils')
  * @property {Set<Identifier>} contextReferenceIds
  * @property {Set<Identifier>} emitReferenceIds
  */
-
-/**
- * @typedef {object} NameWithLoc
- * @property {string} name
- * @property {SourceLocation} loc
- * @property {Range} range
- */
-
-/**
- * Get the name param node from the given CallExpression
- * @param {CallExpression} node CallExpression
- * @returns {NameWithLoc | null}
- */
-function getNameParamNode(node) {
-  const nameLiteralNode = node.arguments[0]
-  if (nameLiteralNode && utils.isStringLiteral(nameLiteralNode)) {
-    const name = utils.getStringLiteralValue(nameLiteralNode)
-    if (name != null) {
-      return { name, loc: nameLiteralNode.loc, range: nameLiteralNode.range }
-    }
-  }
-
-  return null
-}
 
 /**
  * Check if the given node is a reference of setup context
@@ -85,7 +62,7 @@ module.exports = {
      * @param {CallExpression} node
      * */
     function addEmitCall(node) {
-      const nameParamNode = getNameParamNode(node)
+      const nameParamNode = utils.getNameParamNode(node)
       if (nameParamNode) {
         emitCalls.set(nameParamNode.name, node)
       }

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -9,6 +9,7 @@
  * @typedef {import('../utils').ComponentObjectProp} ComponentObjectProp
  * @typedef {import('../utils').ComponentTypeProp} ComponentTypeProp
  * @typedef {import('../utils').ComponentModel} ComponentModel
+ * @typedef {import('@typescript-eslint/types').TSESTree.TypeNode} TypeNode
  * @typedef {ComponentObjectProp & { value: ObjectExpression} } ComponentObjectPropObject
  */
 
@@ -138,10 +139,10 @@ module.exports = {
      * Detects whether the given model is a Boolean model, which (like a
      * Boolean prop) does not require a default value.
      * @param {ComponentModel} model
+     * @param {Expression|null} options
      * @return {boolean}
      */
-    function isBooleanModel(model) {
-      const options = model.options
+    function isBooleanModel(model, options) {
       if (options) {
         if (isValueNodeOfBooleanType(options)) {
           // Shorthand constructor form, e.g. `defineModel(Boolean)`.
@@ -160,7 +161,10 @@ module.exports = {
         }
       }
       if (model.typeNode) {
-        const types = inferRuntimeType(context, model.typeNode)
+        const types = inferRuntimeType(
+          context,
+          /** @type {TypeNode} */ (model.typeNode)
+        )
         return types.length === 1 && types[0] === 'Boolean'
       }
       return false
@@ -248,16 +252,20 @@ module.exports = {
           })
         },
         onDefineModelEnter(node, model) {
-          if (isBooleanModel(model)) {
+          const options =
+            model.options && utils.skipTSAsExpression(model.options)
+
+          if (isBooleanModel(model, options)) {
             return
           }
 
-          const options =
-            model.options && model.options.type === 'ObjectExpression'
-              ? model.options
-              : null
+          const objectOptions =
+            options?.type === 'ObjectExpression' ? options : null
 
-          if (options && (propIsRequired(options) || propHasDefault(options))) {
+          if (
+            objectOptions &&
+            (propIsRequired(objectOptions) || propHasDefault(objectOptions))
+          ) {
             return
           }
 

--- a/lib/rules/require-explicit-emits.ts
+++ b/lib/rules/require-explicit-emits.ts
@@ -2,7 +2,12 @@
  * @author Yosuke Ota
  * See LICENSE file in root directory for full license.
  */
-import type { ComponentEmit, ComponentProp, VueObjectData } from '../utils'
+import type {
+  ComponentEmit,
+  ComponentProp,
+  NameWithLoc,
+  VueObjectData
+} from '../utils'
 import {
   findVariable,
   isOpeningBraceToken,
@@ -39,28 +44,6 @@ const FIX_EMITS_AFTER_OPTIONS = new Set([
   'renderTriggered',
   'errorCaptured'
 ])
-
-export interface NameWithLoc {
-  name: string
-  loc: SourceLocation
-  range: Range
-}
-
-/**
- * Get the name param node from the given CallExpression
- */
-function getNameParamNode(node: CallExpression): NameWithLoc | null {
-  const nameLiteralNode = node.arguments[0]
-  if (nameLiteralNode && utils.isStringLiteral(nameLiteralNode)) {
-    const name = utils.getStringLiteralValue(nameLiteralNode)
-    if (name != null) {
-      return { name, loc: nameLiteralNode.loc, range: nameLiteralNode.range }
-    }
-  }
-
-  // cannot check
-  return null
-}
 
 export default {
   meta: {
@@ -167,7 +150,7 @@ export default {
     const callVisitor = {
       CallExpression(node: CallExpression, info?: VueObjectData) {
         const callee = utils.skipChainExpression(node.callee)
-        const nameWithLoc = getNameParamNode(node)
+        const nameWithLoc = utils.getNameParamNode(node)
         if (!nameWithLoc) {
           // cannot check
           return
@@ -236,7 +219,7 @@ export default {
       {
         CallExpression(node) {
           const callee = utils.skipChainExpression(node.callee)
-          const nameWithLoc = getNameParamNode(node)
+          const nameWithLoc = utils.getNameParamNode(node)
           if (!nameWithLoc) {
             // cannot check
             return

--- a/lib/rules/require-valid-default-prop.ts
+++ b/lib/rules/require-valid-default-prop.ts
@@ -2,6 +2,7 @@
  * @fileoverview Enforces props default values to be valid.
  * @author Armano
  */
+import type { TSESTree } from '@typescript-eslint/types'
 import type {
   ComponentObjectProp,
   ComponentTypeProp,
@@ -10,7 +11,7 @@ import type {
 } from '../utils/index.js'
 import utils from '../utils/index.js'
 import { capitalize } from '../utils/casing.ts'
-import tsTypes from '../utils/ts-utils/ts-types.js'
+import tsAST from '../utils/ts-utils/ts-ast.js'
 
 const NATIVE_TYPES = new Set([
   'String',
@@ -484,6 +485,8 @@ export default {
           }
         },
         onDefineModelEnter(node, model) {
+          const options =
+            model.options && utils.skipTSAsExpression(model.options)
           let syntheticProp:
             ComponentObjectProp | ComponentInferTypeProp | null = null
           let defaultFromOptions: Property | null = null
@@ -494,23 +497,20 @@ export default {
               propName: model.name.modelName,
               node: model.typeNode,
               required: false,
-              types: tsTypes.inferRuntimeTypeFromTypeNode(
+              types: tsAST.inferRuntimeType(
                 context,
-                model.typeNode
+                model.typeNode as TSESTree.TypeNode
               )
             }
-            if (model.options && model.options.type === 'ObjectExpression') {
-              defaultFromOptions = getPropertyNode(model.options, 'default')
+            if (options?.type === 'ObjectExpression') {
+              defaultFromOptions = getPropertyNode(options, 'default')
             }
-          } else if (
-            model.options &&
-            model.options.type === 'ObjectExpression'
-          ) {
+          } else if (options?.type === 'ObjectExpression') {
             syntheticProp = {
               type: 'object',
               propName: model.name.modelName,
-              key: model.options,
-              value: model.options,
+              key: options,
+              value: options,
               // `node` is only accessed in report() when propName is null,
               // which never occurs here since propName is always modelName.
               node: node as any

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -26,6 +26,7 @@ const { getScope } = require('./scope')
  * @typedef {import('../../typings/eslint-plugin-vue/util-types/utils').ComponentInferTypeEmit} ComponentInferTypeEmit
  * @typedef {import('../../typings/eslint-plugin-vue/util-types/utils').ComponentUnknownEmit} ComponentUnknownEmit
  * @typedef {import('../../typings/eslint-plugin-vue/util-types/utils').ComponentEmit} ComponentEmit
+ * @typedef {import('../../typings/eslint-plugin-vue/util-types/utils').NameWithLoc} NameWithLoc
  * @typedef {import('../../typings/eslint-plugin-vue/util-types/utils').ComponentTypeSlot} ComponentTypeSlot
  * @typedef {import('../../typings/eslint-plugin-vue/util-types/utils').ComponentInferTypeSlot} ComponentInferTypeSlot
  * @typedef {import('../../typings/eslint-plugin-vue/util-types/utils').ComponentUnknownSlot} ComponentUnknownSlot
@@ -1087,6 +1088,12 @@ module.exports = {
    * @return {string|null} The string if static. Otherwise, null.
    */
   getStringLiteralValue,
+  /**
+   * Gets the name parameter from the given call expression.
+   * @param {CallExpression} node - The call expression to get.
+   * @returns {NameWithLoc|null} The name and location if static.
+   */
+  getNameParamNode,
   /**
    * Get all props by looking at all component's properties
    * @param {ObjectExpression} componentObject Object with component definition
@@ -2715,6 +2722,22 @@ function getStringLiteralValue(node, stringOnly) {
     node.quasis.length === 1
   ) {
     return node.quasis[0].value.cooked
+  }
+  return null
+}
+
+/**
+ * Gets the name parameter from the given call expression.
+ * @param {CallExpression} node - The call expression to get.
+ * @returns {NameWithLoc|null} The name and location if static.
+ */
+function getNameParamNode(node) {
+  const nameLiteralNode = node.arguments[0]
+  if (nameLiteralNode && isStringLiteral(nameLiteralNode)) {
+    const name = getStringLiteralValue(nameLiteralNode)
+    if (name != null) {
+      return { name, loc: nameLiteralNode.loc, range: nameLiteralNode.range }
+    }
   }
   return null
 }

--- a/typings/eslint-plugin-vue/util-types/utils.ts
+++ b/typings/eslint-plugin-vue/util-types/utils.ts
@@ -1,4 +1,9 @@
 import * as VAST from './ast'
+export type NameWithLoc = {
+  name: string
+  loc: SourceLocation
+  range: Range
+}
 export type VueObjectType = 'mark' | 'export' | 'definition' | 'instance'
 export type VueObjectData = {
   node: ObjectExpression


### PR DESCRIPTION
A couple of small refactors:

1. Reuse the `getNameParamNode` helper and the `NameWithLoc` type.
2. Similar to how it’s handled in the `no-boolean-default` rule, use `skipTSAsExpression` here. 
3. Use `inferRuntimeType` instead of `inferRuntimeTypeFromTypeNode` to better handle common TypeScript syntax without requiring type-aware parser services.