### PR TITLE
Fix `eslint-plugin/no-incorrect-meta-schema` lint violations

### DIFF
--- a/.changeset/green-poems-post.md
+++ b/.changeset/green-poems-post.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Specify explicit `items` policies for array rule option schemas

--- a/lib/rules/attribute-hyphenation.ts
+++ b/lib/rules/attribute-hyphenation.ts
@@ -49,14 +49,12 @@ export default {
                 { not: { type: 'string', pattern: String.raw`^\s*$` } }
               ]
             },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           },
           ignoreTags: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/block-lang.js
+++ b/lib/rules/block-lang.js
@@ -137,8 +137,7 @@ module.exports = {
                         items: {
                           type: 'string'
                         },
-                        uniqueItems: true,
-                        additionalItems: false
+                        uniqueItems: true
                       }
                     ]
                   },

--- a/lib/rules/block-order.ts
+++ b/lib/rules/block-order.ts
@@ -45,8 +45,7 @@ export default {
                 { type: 'array', items: { type: 'string' }, uniqueItems: true }
               ]
             },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/component-api-style.js
+++ b/lib/rules/component-api-style.js
@@ -215,8 +215,7 @@ module.exports = {
         type: 'array',
         items: {
           enum: STYLE_OPTIONS,
-          uniqueItems: true,
-          additionalItems: false
+          uniqueItems: true
         },
         minItems: 1
       }

--- a/lib/rules/component-name-in-template-casing.ts
+++ b/lib/rules/component-name-in-template-casing.ts
@@ -53,8 +53,7 @@ export default {
           ignores: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           },
           registeredComponentsOnly: {
             type: 'boolean'

--- a/lib/rules/custom-event-name-casing.ts
+++ b/lib/rules/custom-event-name-casing.ts
@@ -45,8 +45,7 @@ export default {
           ignores: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -388,8 +388,7 @@ module.exports = {
               type: 'string',
               minLength: 1
             },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           },
           defineExposeLast: {
             type: 'boolean'

--- a/lib/rules/html-indent.ts
+++ b/lib/rules/html-indent.ts
@@ -62,8 +62,7 @@ export default {
                 { not: { type: 'string', pattern: String.raw`^\s*$` } }
               ]
             },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/match-component-file-name.ts
+++ b/lib/rules/match-component-file-name.ts
@@ -36,8 +36,7 @@ export default {
             items: {
               type: 'string'
             },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           },
           shouldMatchCase: {
             type: 'boolean'

--- a/lib/rules/max-lines-per-block.js
+++ b/lib/rules/max-lines-per-block.js
@@ -40,8 +40,7 @@ module.exports = {
             minimum: 1
           },
           skipBlankLines: {
-            type: 'boolean',
-            minimum: 0
+            type: 'boolean'
           }
         },
         additionalProperties: false

--- a/lib/rules/multi-word-component-names.ts
+++ b/lib/rules/multi-word-component-names.ts
@@ -21,8 +21,7 @@ export default {
           ignores: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/multiline-html-element-content-newline.ts
+++ b/lib/rules/multiline-html-element-content-newline.ts
@@ -64,8 +64,7 @@ export default {
           ignores: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           },
           allowEmptyLines: {
             type: 'boolean'

--- a/lib/rules/no-async-in-computed-properties.js
+++ b/lib/rules/no-async-in-computed-properties.js
@@ -174,8 +174,7 @@ module.exports = {
           ignoredObjectNames: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -99,7 +99,8 @@ module.exports = {
         type: 'object',
         properties: {
           groups: {
-            type: 'array'
+            type: 'array',
+            items: { type: 'string' }
           }
         },
         additionalProperties: false

--- a/lib/rules/no-literals-in-template.ts
+++ b/lib/rules/no-literals-in-template.ts
@@ -33,8 +33,7 @@ export default {
           ignores: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/no-reserved-keys.js
+++ b/lib/rules/no-reserved-keys.js
@@ -35,10 +35,12 @@ module.exports = {
         type: 'object',
         properties: {
           reserved: {
-            type: 'array'
+            type: 'array',
+            items: { type: 'string' }
           },
           groups: {
-            type: 'array'
+            type: 'array',
+            items: { type: 'string' }
           }
         },
         additionalProperties: false

--- a/lib/rules/no-undef-components.ts
+++ b/lib/rules/no-undef-components.ts
@@ -95,7 +95,8 @@ export default {
         type: 'object',
         properties: {
           ignorePatterns: {
-            type: 'array'
+            type: 'array',
+            items: { type: 'string' }
           }
         },
         additionalProperties: false

--- a/lib/rules/no-unused-properties.ts
+++ b/lib/rules/no-unused-properties.ts
@@ -191,7 +191,6 @@ export default {
                 GROUP_INJECT
               ]
             },
-            additionalItems: false,
             uniqueItems: true
           },
           deepData: { type: 'boolean' },
@@ -201,7 +200,6 @@ export default {
             items: {
               enum: [UNREFERENCED_UNKNOWN_MEMBER, UNREFERENCED_RETURN]
             },
-            additionalItems: false,
             uniqueItems: true
           }
         },

--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -228,7 +228,13 @@ module.exports = {
         type: 'object',
         properties: {
           order: {
-            type: 'array'
+            type: 'array',
+            items: {
+              oneOf: [
+                { type: 'string' },
+                { type: 'array', items: { type: 'string' } }
+              ]
+            }
           }
         },
         additionalProperties: false

--- a/lib/rules/restricted-component-names.ts
+++ b/lib/rules/restricted-component-names.ts
@@ -35,8 +35,7 @@ export default {
           allow: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         }
       }

--- a/lib/rules/script-indent.ts
+++ b/lib/rules/script-indent.ts
@@ -33,8 +33,7 @@ export default {
                 { not: { type: 'string', pattern: String.raw`^\s*$` } }
               ]
             },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/singleline-html-element-content-newline.ts
+++ b/lib/rules/singleline-html-element-content-newline.ts
@@ -58,14 +58,12 @@ export default {
           ignores: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           },
           externalIgnores: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -85,10 +85,12 @@ module.exports = {
             type: 'boolean'
           },
           ignoreChildrenOf: {
-            type: 'array'
+            type: 'array',
+            items: { type: 'string' }
           },
           ignoreGrandchildrenOf: {
-            type: 'array'
+            type: 'array',
+            items: { type: 'string' }
           },
           minKeys: {
             type: 'integer',

--- a/lib/rules/v-on-event-hyphenation.ts
+++ b/lib/rules/v-on-event-hyphenation.ts
@@ -32,14 +32,12 @@ export default {
                 { not: { type: 'string', pattern: String.raw`^\s*$` } }
               ]
             },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           },
           ignoreTags: {
             type: 'array',
             items: { type: 'string' },
-            uniqueItems: true,
-            additionalItems: false
+            uniqueItems: true
           }
         },
         additionalProperties: false

--- a/lib/rules/valid-v-on.js
+++ b/lib/rules/valid-v-on.js
@@ -71,7 +71,8 @@ module.exports = {
         type: 'object',
         properties: {
           modifiers: {
-            type: 'array'
+            type: 'array',
+            items: { type: 'string' }
           }
         },
         additionalProperties: false


### PR DESCRIPTION
[eslint-plugin-eslint-plugin](https://github.com/eslint-community/eslint-plugin-eslint-plugin) recently [released](https://github.com/eslint-community/eslint-plugin-eslint-plugin/releases/tag/v7.6.0) the new [`no-incorrect-meta-schema`](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/v7.6.0/docs/rules/no-incorrect-meta-schema.md) rule.

This PR fixes all the newly reported violations, making the rule schemas more correct.