### PR TITLE
fix(no-unused-properties): ignore props typed as `never`

### DIFF
--- a/.changeset/no-unused-properties-never-type.md
+++ b/.changeset/no-unused-properties-never-type.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/no-unused-properties` false positive for props explicitly typed as `never`

--- a/lib/rules/no-unused-properties.ts
+++ b/lib/rules/no-unused-properties.ts
@@ -415,10 +415,7 @@ export default {
           )
 
           for (const prop of props) {
-            if (!prop.propName) {
-              continue
-            }
-            if (isNeverTypeProp(prop)) {
+            if (!prop.propName || isNeverTypeProp(prop)) {
               continue
             }
             if (prop.type === 'object') {

--- a/lib/rules/no-unused-properties.ts
+++ b/lib/rules/no-unused-properties.ts
@@ -67,6 +67,19 @@ const PROPERTY_LABEL = {
   expose: 'expose'
 }
 
+/**
+ * Check whether the given prop is explicitly typed as `never`.
+ * Such props are declared to forbid their usage, so they are never
+ * referenced by design and reporting them as unused is noise.
+ */
+function isNeverTypeProp(prop: ComponentProp): boolean {
+  return (
+    prop.type === 'type' &&
+    prop.node.type === 'TSPropertySignature' &&
+    prop.node.typeAnnotation?.typeAnnotation.type === 'TSNeverKeyword'
+  )
+}
+
 function findExpression(context: RuleContext, id: Identifier): Expression {
   const variable = utils.findVariableByIdentifier(context, id)
   if (!variable) {
@@ -403,6 +416,9 @@ export default {
 
           for (const prop of props) {
             if (!prop.propName) {
+              continue
+            }
+            if (isNeverTypeProp(prop)) {
               continue
             }
             if (prop.type === 'object') {

--- a/tests/lib/rules/no-unused-properties.test.ts
+++ b/tests/lib/rules/no-unused-properties.test.ts
@@ -2522,6 +2522,40 @@ tester.run('no-unused-properties', rule, {
       </template>`,
       ...getTypeScriptFixtureTestOptions()
     },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2545
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      interface Props {
+        foo: string
+        // prevent accidentally using min/max instead of minlength/maxlength
+        min?: never
+        max?: never
+      }
+      defineProps<Props>()
+      </script>
+      <template>{{ foo }}</template>`,
+      languageOptions: {
+        parserOptions: {
+          parser: '@typescript-eslint/parser'
+        }
+      }
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2545
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      defineProps<{ foo: string, min?: never }>()
+      </script>
+      <template>{{ foo }}</template>`,
+      languageOptions: {
+        parserOptions: {
+          parser: '@typescript-eslint/parser'
+        }
+      }
+    },
     // used inject
     {
       filename: 'test.vue',


### PR DESCRIPTION
Closes #2545

A prop explicitly typed as `never` is declared to *forbid* its usage, so it is never referenced by design. Reporting it as unused is noise:

```vue
<script setup lang="ts">
interface MyTextAreaInput extends /* @vue-ignore */ TextareaHTMLAttributes {
  // prevent accidentally using min/max instead of minlength/maxlength
  min?: never // <- 'min' of property found, but never used.
  max?: never // <- 'max' of property found, but never used.
}
defineProps<MyTextAreaInput>()
</script>
```

### Implementation note

`prop.types` cannot be used to detect this. `inferRuntimeType` has no `TSNeverKeyword` case, so it falls through to `inferRuntimeTypeFromTypeNode`, which returns `['null']` when no type information is available — making `never` indistinguishable from any other unresolved type.

The check is therefore done on the AST: the prop's `TSPropertySignature` type annotation is `TSNeverKeyword`. This only requires `@typescript-eslint/parser`, no type-aware setup, which matches @FloEdelmann's note on the issue.

### Deliberately out of scope

An aliased `never` (`type Impossible = never; min?: Impossible`) is **not** covered — that is a `TSTypeReference` and can only be resolved with full type information, which requires users to configure `parserOptions.project`. Happy to extend this if you would like it covered.

Props typed `never` are skipped regardless of optionality: a required `min: never` cannot be passed a value either, so reporting it as unused is equally unhelpful.