### PR TITLE
fix(require-default-prop): no false positive for `withDefaults` defaults passed by reference

### DIFF
--- a/.changeset/require-default-prop-with-defaults-reference.md
+++ b/.changeset/require-default-prop-with-defaults-reference.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/require-default-prop` false positives when the defaults are passed to `withDefaults()` by reference or spread instead of an inline object literal

--- a/.changeset/require-default-prop-with-defaults-reference.md
+++ b/.changeset/require-default-prop-with-defaults-reference.md
@@ -2,4 +2,4 @@
 "eslint-plugin-vue": patch
 ---
 
-Fixed `vue/require-default-prop` false positives when the defaults are passed to `withDefaults()` by reference or spread instead of an inline object literal
+Fixed `vue/require-default-prop`, `vue/no-boolean-default`, `vue/no-required-prop-with-default` and `vue/require-valid-default-prop` not handling defaults that are passed to `withDefaults()` by reference or spread instead of an inline object literal

--- a/lib/rules/no-boolean-default.js
+++ b/lib/rules/no-boolean-default.js
@@ -131,8 +131,8 @@ module.exports = {
       }),
       utils.defineScriptSetupVisitor(context, {
         onDefinePropsEnter(node, props) {
-          const defaultsByWithDefaults =
-            utils.getWithDefaultsPropExpressions(node)
+          const { props: defaultsByWithDefaults } =
+            utils.getWithDefaultsPropExpressions(context, node)
           const defaultsByAssignmentPatterns =
             utils.getDefaultPropExpressionsForPropsDestructure(node)
           processProps(props, (propName) =>

--- a/lib/rules/no-required-prop-with-default.js
+++ b/lib/rules/no-required-prop-with-default.js
@@ -135,7 +135,9 @@ module.exports = {
       utils.defineScriptSetupVisitor(context, {
         onDefinePropsEnter(node, props) {
           const defaultProps = new Set([
-            ...Object.keys(utils.getWithDefaultsPropExpressions(node)),
+            ...Object.keys(
+              utils.getWithDefaultsPropExpressions(context, node).props
+            ),
             ...Object.keys(
               utils.getDefaultPropExpressionsForPropsDestructure(node)
             )

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -47,62 +47,6 @@ function isValueNodeOfBooleanType(value) {
   return false
 }
 
-/**
- * Collects the names of the props that are given a default value by
- * `withDefaults()`. Vue accepts any expression as the defaults argument and
- * falls back to the `mergeDefaults()` runtime helper, so the defaults cannot
- * always be determined statically. `hasUnknown` is `true` in that case, which
- * means that any prop may have a default value.
- * @param {RuleContext} context The rule context object.
- * @param {CallExpression} node The node of defineProps
- * @return {{ names: Set<string>, hasUnknown: boolean }}
- */
-function getWithDefaultsPropNames(context, node) {
-  /** @type {Set<string>} */
-  const names = new Set()
-  if (!utils.hasWithDefaults(node)) {
-    return { names, hasUnknown: false }
-  }
-  const defaults = node.parent.arguments[1]
-  if (!defaults) {
-    return { names, hasUnknown: false }
-  }
-
-  let hasUnknown = false
-  /** @type {ESNode[]} */
-  const queue = [defaults]
-  /** @type {Set<ESNode>} */
-  const visited = new Set()
-  while (queue.length > 0) {
-    const target = /** @type {ESNode} */ (queue.shift())
-    if (visited.has(target)) {
-      continue
-    }
-    visited.add(target)
-
-    const object = utils.getObjectOrArray(context, target)
-    if (object?.type !== 'ObjectExpression') {
-      hasUnknown = true
-      continue
-    }
-    for (const property of object.properties) {
-      if (property.type === 'SpreadElement') {
-        // The spread source may itself be resolvable, so process it as well.
-        queue.push(property.argument)
-      } else {
-        const name = utils.getStaticPropertyName(property)
-        if (name == null) {
-          hasUnknown = true
-        } else {
-          names.add(name)
-        }
-      }
-    }
-  }
-
-  return { names, hasUnknown }
-}
-
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -280,7 +224,10 @@ module.exports = {
       utils.defineScriptSetupVisitor(context, {
         onDefinePropsEnter(node, props) {
           const hasWithDefaults = utils.hasWithDefaults(node)
-          const propsWithDefaults = getWithDefaultsPropNames(context, node)
+          const defaultsByWithDefaults = utils.getWithDefaultsPropExpressions(
+            context,
+            node
+          )
           const isUsingPropsDestructure = utils.isUsingPropsDestructure(node)
           const defaultsByAssignmentPatterns =
             utils.getDefaultPropExpressionsForPropsDestructure(node)
@@ -292,8 +239,8 @@ module.exports = {
                 return true
               }
               if (
-                propsWithDefaults.names.has(prop.propName) ||
-                propsWithDefaults.hasUnknown
+                defaultsByWithDefaults.hasUnknown ||
+                defaultsByWithDefaults.props[prop.propName]
               ) {
                 return true
               }

--- a/lib/rules/require-default-prop.js
+++ b/lib/rules/require-default-prop.js
@@ -47,6 +47,62 @@ function isValueNodeOfBooleanType(value) {
   return false
 }
 
+/**
+ * Collects the names of the props that are given a default value by
+ * `withDefaults()`. Vue accepts any expression as the defaults argument and
+ * falls back to the `mergeDefaults()` runtime helper, so the defaults cannot
+ * always be determined statically. `hasUnknown` is `true` in that case, which
+ * means that any prop may have a default value.
+ * @param {RuleContext} context The rule context object.
+ * @param {CallExpression} node The node of defineProps
+ * @return {{ names: Set<string>, hasUnknown: boolean }}
+ */
+function getWithDefaultsPropNames(context, node) {
+  /** @type {Set<string>} */
+  const names = new Set()
+  if (!utils.hasWithDefaults(node)) {
+    return { names, hasUnknown: false }
+  }
+  const defaults = node.parent.arguments[1]
+  if (!defaults) {
+    return { names, hasUnknown: false }
+  }
+
+  let hasUnknown = false
+  /** @type {ESNode[]} */
+  const queue = [defaults]
+  /** @type {Set<ESNode>} */
+  const visited = new Set()
+  while (queue.length > 0) {
+    const target = /** @type {ESNode} */ (queue.shift())
+    if (visited.has(target)) {
+      continue
+    }
+    visited.add(target)
+
+    const object = utils.getObjectOrArray(context, target)
+    if (object?.type !== 'ObjectExpression') {
+      hasUnknown = true
+      continue
+    }
+    for (const property of object.properties) {
+      if (property.type === 'SpreadElement') {
+        // The spread source may itself be resolvable, so process it as well.
+        queue.push(property.argument)
+      } else {
+        const name = utils.getStaticPropertyName(property)
+        if (name == null) {
+          hasUnknown = true
+        } else {
+          names.add(name)
+        }
+      }
+    }
+  }
+
+  return { names, hasUnknown }
+}
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -224,8 +280,7 @@ module.exports = {
       utils.defineScriptSetupVisitor(context, {
         onDefinePropsEnter(node, props) {
           const hasWithDefaults = utils.hasWithDefaults(node)
-          const defaultsByWithDefaults =
-            utils.getWithDefaultsPropExpressions(node)
+          const propsWithDefaults = getWithDefaultsPropNames(context, node)
           const isUsingPropsDestructure = utils.isUsingPropsDestructure(node)
           const defaultsByAssignmentPatterns =
             utils.getDefaultPropExpressionsForPropsDestructure(node)
@@ -236,7 +291,10 @@ module.exports = {
                 // If don't use withDefaults() and props destructure, exclude it from the report.
                 return true
               }
-              if (defaultsByWithDefaults[prop.propName]) {
+              if (
+                propsWithDefaults.names.has(prop.propName) ||
+                propsWithDefaults.hasUnknown
+              ) {
                 return true
               }
             }

--- a/lib/rules/require-valid-default-prop.ts
+++ b/lib/rules/require-valid-default-prop.ts
@@ -428,8 +428,8 @@ export default {
               | ComponentTypeProp =>
               ['type', 'infer-type', 'object'].includes(prop.type)
           )
-          const defaultsByWithDefaults =
-            utils.getWithDefaultsPropExpressions(node)
+          const { props: defaultsByWithDefaults } =
+            utils.getWithDefaultsPropExpressions(context, node)
           const defaultsByAssignmentPatterns =
             utils.getDefaultPropExpressionsForPropsDestructure(node)
           const propContexts = processPropDefs(

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1531,35 +1531,25 @@ module.exports = {
 
   /**
    * Gets a map of the expressions defined in withDefaults.
+   * `withDefaults()` accepts any expression as its defaults argument: the SFC
+   * compiler inlines an object literal and falls back to the `mergeDefaults()`
+   * runtime helper for everything else. References to a `const` object and
+   * spread elements are resolved, but anything that cannot be determined
+   * statically sets `hasUnknown`, which means that props missing from `props`
+   * may still have a default value.
+   * @param {RuleContext} context The rule context object.
    * @param {CallExpression} node The node of defineProps
-   * @returns { { [key: string]: Expression | undefined } }
+   * @returns { { props: { [key: string]: Expression | undefined }, hasUnknown: boolean } }
    */
-  getWithDefaultsPropExpressions(node) {
-    const map = getWithDefaultsProps(node)
-
-    /** @type {Record<string, Expression | undefined>} */
-    const result = {}
-
-    for (const [key, prop] of Object.entries(map)) {
-      result[key] = prop && prop.value
-    }
-
-    return result
-  },
+  getWithDefaultsPropExpressions,
   /**
    * Gets a map of the property nodes defined in withDefaults.
+   * Only an inline object literal is looked at, because the returned nodes are
+   * used as edit targets by fixers.
    * @param {CallExpression} node The node of defineProps
    * @returns { { [key: string]: Property | undefined } }
    */
   getWithDefaultsProps,
-  /**
-   * Gets the ObjectExpression or ArrayExpression that the given node refers to.
-   * Returns `null` if it cannot be determined statically.
-   * @param {RuleContext} context The rule context object.
-   * @param {ESNode} node
-   * @returns {ObjectExpression | ArrayExpression | null}
-   */
-  getObjectOrArray,
   /**
    * Gets the default definition nodes for defineProp
    * using the props destructure with assignment pattern.
@@ -3392,6 +3382,71 @@ function getWithDefaultsProps(node) {
   }
 
   return result
+}
+
+/**
+ * Collects the property expressions of the object that the given node refers
+ * to, following `const` references and spread elements. Properties are
+ * collected in source order, so a later definition overrides an earlier one.
+ * @param {RuleContext} context The rule context object.
+ * @param {ESNode} node
+ * @param {Record<string, Expression | undefined>} result
+ * @param {Set<ObjectExpression>} visited
+ * @returns {boolean} `false` if the object cannot be determined statically.
+ */
+function collectPropExpressions(context, node, result, visited) {
+  const object = getObjectOrArray(context, node)
+  if (object?.type !== 'ObjectExpression') {
+    return false
+  }
+  if (visited.has(object)) {
+    return true
+  }
+  visited.add(object)
+
+  let resolved = true
+  for (const property of object.properties) {
+    if (property.type === 'SpreadElement') {
+      // The spread source may itself be resolvable, so follow it as well.
+      if (
+        !collectPropExpressions(context, property.argument, result, visited)
+      ) {
+        resolved = false
+      }
+      continue
+    }
+    const name = getStaticPropertyName(property)
+    if (name == null) {
+      resolved = false
+      continue
+    }
+    result[name] = property.value
+  }
+
+  return resolved
+}
+
+/**
+ * Gets a map of the expressions defined in withDefaults.
+ * @param {RuleContext} context The rule context object.
+ * @param {CallExpression} node The node of defineProps
+ * @returns { { props: { [key: string]: Expression | undefined }, hasUnknown: boolean } }
+ */
+function getWithDefaultsPropExpressions(context, node) {
+  /** @type {Record<string, Expression | undefined>} */
+  const props = {}
+  if (!hasWithDefaults(node)) {
+    return { props, hasUnknown: false }
+  }
+  const defaults = node.parent.arguments[1]
+  if (!defaults) {
+    return { props, hasUnknown: false }
+  }
+
+  return {
+    props,
+    hasUnknown: !collectPropExpressions(context, defaults, props, new Set())
+  }
 }
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -3404,26 +3404,26 @@ function collectPropExpressions(context, node, result, visited) {
   }
   visited.add(object)
 
-  let resolved = true
+  let isResolved = true
   for (const property of object.properties) {
     if (property.type === 'SpreadElement') {
       // The spread source may itself be resolvable, so follow it as well.
       if (
         !collectPropExpressions(context, property.argument, result, visited)
       ) {
-        resolved = false
+        isResolved = false
       }
       continue
     }
     const name = getStaticPropertyName(property)
     if (name == null) {
-      resolved = false
+      isResolved = false
       continue
     }
     result[name] = property.value
   }
 
-  return resolved
+  return isResolved
 }
 
 /**

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1553,6 +1553,14 @@ module.exports = {
    */
   getWithDefaultsProps,
   /**
+   * Gets the ObjectExpression or ArrayExpression that the given node refers to.
+   * Returns `null` if it cannot be determined statically.
+   * @param {RuleContext} context The rule context object.
+   * @param {ESNode} node
+   * @returns {ObjectExpression | ArrayExpression | null}
+   */
+  getObjectOrArray,
+  /**
    * Gets the default definition nodes for defineProp
    * using the props destructure with assignment pattern.
    * @param {CallExpression} node The node of defineProps

--- a/tests/lib/rules/no-boolean-default.test.ts
+++ b/tests/lib/rules/no-boolean-default.test.ts
@@ -517,6 +517,34 @@ ruleTester.run('no-boolean-default', rule, {
       interface Props {
         foo: boolean
       }
+      const defaults = { foo: false }
+      withDefaults(defineProps<Props>(), defaults)
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message:
+            'Boolean prop should not set a default (Vue defaults it to false).',
+          line: 6,
+          column: 31,
+          endLine: 6,
+          endColumn: 36
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      interface Props {
+        foo: boolean
+      }
       withDefaults(defineProps<Props>(), {
         foo: true
       })

--- a/tests/lib/rules/no-required-prop-with-default.test.ts
+++ b/tests/lib/rules/no-required-prop-with-default.test.ts
@@ -285,6 +285,44 @@ tester.run('no-required-prop-with-default', rule, {
       code: `
         <script setup lang="ts">
           interface TestPropType {
+            name: string
+            age?: number
+          }
+          const defaults = { name: "World" }
+          const props = withDefaults(defineProps<TestPropType>(), defaults);
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          interface TestPropType {
+            name?: string
+            age?: number
+          }
+          const defaults = { name: "World" }
+          const props = withDefaults(defineProps<TestPropType>(), defaults);
+        </script>
+      `,
+      options: [{ autofix: true }],
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: 'Prop "name" should be optional.',
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 25
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          interface TestPropType {
             name: string | number
             age?: number
           }

--- a/tests/lib/rules/require-default-prop.test.ts
+++ b/tests/lib/rules/require-default-prop.test.ts
@@ -353,6 +353,97 @@ ruleTester.run('require-default-prop', rule, {
       }
     },
     {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2993
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const defaults = {
+        foo: 'foo',
+      }
+      withDefaults(defineProps<{
+        foo?: string;
+      }>(), defaults)
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2993
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      import { defaults } from './defaults'
+      interface Props {
+        foo?: string;
+      }
+      withDefaults(defineProps<Props>(), defaults)
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2993
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      import { defaults } from './defaults'
+      withDefaults(defineProps<{
+        foo?: string;
+      }>(), {
+        ...defaults,
+      })
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2993
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      import { makeDefaults } from './defaults'
+      withDefaults(defineProps<{
+        foo?: string;
+      }>(), makeDefaults())
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2993
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      withDefaults(defineProps<{
+        foo?: string;
+      }>(), {
+        foo: 'foo',
+      } as const)
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      }
+    },
+    {
       filename: 'test.vue',
       code: `
       <script setup>
@@ -857,6 +948,35 @@ ruleTester.run('require-default-prop', rule, {
       }>(), {
         ...defaultProps,
       })
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        ...languageOptions,
+        parserOptions: { parser: require.resolve('@typescript-eslint/parser') }
+      },
+      errors: [
+        {
+          message: "Prop 'bar' requires default value to be set.",
+          line: 8,
+          column: 9,
+          endLine: 8,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      // https://github.com/vuejs/eslint-plugin-vue/issues/2993
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const defaults = {
+        foo: 'foo',
+      }
+      withDefaults(defineProps<{
+        foo?: string;
+        bar?: number;
+      }>(), defaults)
       </script>
       `,
       languageOptions: {

--- a/tests/lib/rules/require-valid-default-prop.test.ts
+++ b/tests/lib/rules/require-valid-default-prop.test.ts
@@ -1438,6 +1438,32 @@ ruleTester.run('require-valid-default-prop', rule, {
       ]
     },
     {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+        const defaults = { foo: () => 123 }
+        withDefaults(defineProps<{foo:string}>(), defaults)
+      </script>
+      `,
+      languageOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: "Type of the default value for 'foo' prop must be a string.",
+          line: 3,
+          column: 39,
+          endLine: 3,
+          endColumn: 42
+        }
+      ]
+    },
+    {
       code: `
       <script setup lang="ts">
       import {Props2 as Props} from './test01'


### PR DESCRIPTION
Closes #2993

## Problem

`withDefaults()` accepts any expression as its defaults argument: the SFC compiler inlines an object literal and falls back to the `mergeDefaults()` runtime helper for everything else. `vue/require-default-prop` only understood the inline literal, because `getWithDefaultsProps()` bails out unless the second argument is an `ObjectExpression` and skips `SpreadElement` properties.

All of these were reported as `Prop 'foo' requires default value to be set.` even though a default is provided:

```vue
<script setup lang="ts">
import { defaults, makeDefaults } from './defaults'

withDefaults(defineProps<{ foo?: string }>(), defaults)
withDefaults(defineProps<{ foo?: string }>(), { ...defaults })
withDefaults(defineProps<{ foo?: string }>(), makeDefaults())
withDefaults(defineProps<{ foo?: string }>(), { foo: 'foo' } as const)
</script>
```

## Fix

The rule now resolves the defaults argument itself: identifiers and spread sources are resolved to the object they refer to, reusing the existing `getObjectOrArray()` helper (already used for `defineProps(obj)`), which is now exported from `lib/utils`; if any part of the defaults cannot be determined statically — an import, a call expression, a computed key — no type prop is reported for that `defineProps()`, since any of them may receive a default at runtime.

Props that genuinely have no default are still reported, including when the referenced object resolves and does not contain them:

```vue
<script setup lang="ts">
const defaults = { foo: 'foo' }
// 'bar' is still reported
withDefaults(defineProps<{ foo?: string; bar?: number }>(), defaults)
</script>
```

Only `require-default-prop` changes behaviour. The shared `getWithDefaultsProps()` util is untouched, so the other rules using it are unaffected.