### PR TITLE
fix(no-ref-object-reactivity-loss): report values gotten in an IIFE

### DIFF
--- a/.changeset/no-ref-object-reactivity-loss-iife.md
+++ b/.changeset/no-ref-object-reactivity-loss-iife.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/no-ref-object-reactivity-loss` false negatives for values gotten in an immediately invoked function expression (IIFE)

--- a/docs/rules/no-ref-object-reactivity-loss.md
+++ b/docs/rules/no-ref-object-reactivity-loss.md
@@ -25,21 +25,7 @@ const v3 = computed(() => count.value /* ✓ GOOD */)
 const v4 = fn(count.value) /* ✗ BAD */
 const v5 = fn(count) /* ✓ GOOD */
 const v6 = computed(() => fn(count.value) /* ✓ GOOD */)
-```
-
-</eslint-code-block>
-
-The body of an immediately invoked function expression (IIFE) is executed in the same scope, so the values gotten there also lose reactivity.
-
-<eslint-code-block :rules="{'vue/no-ref-object-reactivity-loss': ['error']}" language="javascript" filename="example.js" >
-
-```js
-import { ref } from 'vue'
-const count = ref(0)
-;(() => {
-  const v1 = count.value /* ✗ BAD */
-  const v2 = computed(() => count.value /* ✓ GOOD */)
-})()
+const v7 = (() => count.value)() /* ✗ BAD */
 ```
 
 </eslint-code-block>

--- a/docs/rules/no-ref-object-reactivity-loss.md
+++ b/docs/rules/no-ref-object-reactivity-loss.md
@@ -29,6 +29,21 @@ const v6 = computed(() => fn(count.value) /* ✓ GOOD */)
 
 </eslint-code-block>
 
+The body of an immediately invoked function expression (IIFE) is executed in the same scope, so the values gotten there also lose reactivity.
+
+<eslint-code-block :rules="{'vue/no-ref-object-reactivity-loss': ['error']}" language="javascript" filename="example.js" >
+
+```js
+import { ref } from 'vue'
+const count = ref(0)
+;(() => {
+  const v1 = count.value /* ✗ BAD */
+  const v2 = computed(() => count.value /* ✓ GOOD */)
+})()
+```
+
+</eslint-code-block>
+
 This rule also supports Reactivity Transform, but Reactivity Transform is an experimental feature and may have false positives due to future Vue changes.\
 See the [RFC](https://github.com/vuejs/rfcs/pull/420) for more information on Reactivity Transform.
 

--- a/lib/rules/no-ref-object-reactivity-loss.ts
+++ b/lib/rules/no-ref-object-reactivity-loss.ts
@@ -35,6 +35,26 @@ function isUpdate(node: Pattern | AssignmentProperty | Property): boolean {
   return false
 }
 
+/**
+ * Checks whether the given function is immediately invoked (IIFE).
+ * The body of such a function runs synchronously within the enclosing scope,
+ * so getting a value there loses reactivity in the same way.
+ * `async` functions and generators are excluded because their bodies are not
+ * guaranteed to run synchronously to completion.
+ */
+function isImmediatelyInvokedFunction(
+  node: FunctionExpression | FunctionDeclaration | ArrowFunctionExpression
+): boolean {
+  if (node.type === 'FunctionDeclaration') {
+    return false
+  }
+  if (node.async || (node.type === 'FunctionExpression' && node.generator)) {
+    return false
+  }
+  const parent = node.parent
+  return parent.type === 'CallExpression' && parent.callee === node
+}
+
 export default {
   meta: {
     type: 'problem',
@@ -110,9 +130,17 @@ export default {
 
     return {
       ':function'(node) {
+        if (isImmediatelyInvokedFunction(node)) {
+          // Keep the scope of an IIFE, because its body is executed in the
+          // same scope.
+          return
+        }
         scopeStack = { upper: scopeStack, node }
       },
-      ':function:exit'() {
+      ':function:exit'(node) {
+        if (isImmediatelyInvokedFunction(node)) {
+          return
+        }
         scopeStack = scopeStack.upper || scopeStack
       },
       CallExpression(node) {

--- a/tests/lib/rules/no-ref-object-reactivity-loss.test.ts
+++ b/tests/lib/rules/no-ref-object-reactivity-loss.test.ts
@@ -134,6 +134,33 @@ tester.run('no-ref-object-reactivity-loss', rule, {
         tr.value
       )
     }
+    `,
+    // https://github.com/vuejs/eslint-plugin-vue/issues/3056
+    // The body of an async function is not executed synchronously to the end.
+    `
+    import { ref } from 'vue'
+    const count = ref(0)
+    ;(async () => {
+      const value1 = count.value
+    })()
+    `,
+    // The body of a generator function is not executed by the call itself.
+    `
+    import { ref } from 'vue'
+    const count = ref(0)
+    ;(function* () {
+      const value1 = count.value
+    })()
+    `,
+    `
+    import { ref } from 'vue'
+    ;(() => {
+      const count = ref(0)
+      const value1 = computed(() => count.value)
+      function fn() {
+        console.log(count.value)
+      }
+    })()
     `
   ],
   invalid: [
@@ -571,6 +598,77 @@ tester.run('no-ref-object-reactivity-loss', rule, {
           column: 9,
           endLine: 17,
           endColumn: 11
+        }
+      ]
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/3056
+    {
+      code: `
+      import { ref } from 'vue'
+      const count = ref(0)
+      ;(() => {
+        const value1 = count.value
+      })()
+      ;(function () {
+        const value2 = count.value
+      })()
+      `,
+      errors: [
+        {
+          message:
+            'Getting a value from the ref object in the same scope will cause the value to lose reactivity.',
+          line: 5,
+          column: 24,
+          endLine: 5,
+          endColumn: 29
+        },
+        {
+          message:
+            'Getting a value from the ref object in the same scope will cause the value to lose reactivity.',
+          line: 8,
+          column: 24,
+          endLine: 8,
+          endColumn: 29
+        }
+      ]
+    },
+    {
+      code: `
+      import { ref } from 'vue'
+      const count = ref(0)
+      ;(() => {
+        ;(() => {
+          const value1 = count.value
+        })()
+      })()
+      `,
+      errors: [
+        {
+          message:
+            'Getting a value from the ref object in the same scope will cause the value to lose reactivity.',
+          line: 6,
+          column: 26,
+          endLine: 6,
+          endColumn: 31
+        }
+      ]
+    },
+    // Reactivity Transform
+    {
+      code: `
+      const count = $ref(0)
+      ;(() => {
+        const value1 = count
+      })()
+      `,
+      errors: [
+        {
+          message:
+            'Getting a reactive variable in the same scope will cause the value to lose reactivity.',
+          line: 4,
+          column: 24,
+          endLine: 4,
+          endColumn: 29
         }
       ]
     }


### PR DESCRIPTION
Closes #3056

The body of an immediately invoked function expression runs synchronously in the enclosing scope, so getting a value from a ref object there loses reactivity just like getting it directly:

```js
import { ref } from 'vue'
const count = ref(0)
const v1 = count.value // reported
;(() => {
  const v2 = count.value // not reported before this PR
})()
```

The rule pushes a new scope entry for every function it enters and compares the scope of the `ref()`/`computed()` call with the current one by identity. The callee of an IIFE got its own entry, so the check failed and the report was silenced.

This PR keeps the enclosing scope when entering a function that is the callee of a call expression. `async` functions and generators are excluded, because their bodies are not guaranteed to run synchronously to the end.

The second case from the issue — a ref passed as an argument to a plain function that is then called — is not covered, since it needs inter-procedural analysis.