### PR TITLE
chore(tools): don't fail `npm run new` when VS Code CLI is missing

### DIFF
--- a/tools/new-rule.js
+++ b/tools/new-rule.js
@@ -139,7 +139,19 @@ Nothing.
 `
   )
 
-  cp.execSync(`code "${ruleFile}"`)
-  cp.execSync(`code "${testFile}"`)
-  cp.execSync(`code "${docFile}"`)
+  const createdFiles = [ruleFile, testFile, docFile]
+
+  logger.log('Created:')
+  for (const file of createdFiles) {
+    logger.log(`  ${path.relative(process.cwd(), file)}`)
+  }
+
+  try {
+    for (const file of createdFiles) {
+      cp.execSync(`code "${file}"`, { stdio: 'ignore' })
+    }
+  } catch {
+    // The VS Code CLI (`code`) is not available.
+    // The files have already been created, so there is nothing to recover from.
+  }
 })(process.argv[2], process.argv[3])


### PR DESCRIPTION
Closes #2781

`npm run new <rule name> <author name>` writes the rule, test and docs files and then opens them with the VS Code CLI. When `code` is not on `PATH` — the contributor uses another editor, or VS Code is installed without the shell command — the first `execSync` throws:

```
/bin/sh: code: command not found
Error: Command failed: code "path/to/generated/file"
    at Object.execSync (node:child_process:954:15)
    at tools/new-rule.js:143:6
```

All three files are generated successfully at that point, but:

- the remaining two files are never opened, because the first `execSync` throws;
- the script exits with code 1 and a Node stack trace, so it looks like the generation itself failed;
- the paths of the generated files are never printed, so it is not obvious what was created.

This is the first command a new contributor runs from the developer guide, so it is worth failing softly.

### Changes

- print the paths of the generated files;
- wrap the editor launch in `try`/`catch` and ignore the failure — the files are already on disk, there is nothing to recover from.

### Verification

Without `code` on `PATH`:

```
$ npm run new some-rule Someone
Created:
  lib/rules/some-rule.ts
  tests/lib/rules/some-rule.test.ts
  docs/rules/some-rule.md
$ echo $?
0
```

With `code` on `PATH` the three files are still opened as before.

No changeset: `tools/` is not part of the published package (`"files": ["dist"]`), same as #3049