### PR TITLE
feat: add `vue/no-props-shadow` rule

### DIFF
--- a/.changeset/brave-jars-invent.md
+++ b/.changeset/brave-jars-invent.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Added new `vue/no-props-shadow` rule

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -241,6 +241,7 @@ For example:
 | [vue/no-multiple-objects-in-class] | disallow passing multiple objects in an array to class |  | :hammer: |
 | [vue/no-negated-v-if-condition] | disallow negated conditions in v-if/v-else | :wrench: | :hammer: |
 | [vue/no-potential-component-option-typo] | disallow a potential typo in your component property | :bulb: | :hammer: |
+| [vue/no-props-shadow] | disallow declarations that shadow props in `<script setup>` |  | :warning: |
 | [vue/no-ref-object-reactivity-loss] | disallow usages of ref objects that can lead to loss of reactivity |  | :warning: |
 | [vue/no-restricted-block] | disallow specific block |  | :hammer: |
 | [vue/no-restricted-call-after-await] | disallow asynchronously called restricted methods |  | :hammer: |
@@ -496,6 +497,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 [vue/no-negated-v-if-condition]: ./no-negated-v-if-condition.md
 [vue/no-parsing-error]: ./no-parsing-error.md
 [vue/no-potential-component-option-typo]: ./no-potential-component-option-typo.md
+[vue/no-props-shadow]: ./no-props-shadow.md
 [vue/no-ref-as-operand]: ./no-ref-as-operand.md
 [vue/no-ref-object-reactivity-loss]: ./no-ref-object-reactivity-loss.md
 [vue/no-required-prop-with-default]: ./no-required-prop-with-default.md

--- a/docs/rules/no-props-shadow.md
+++ b/docs/rules/no-props-shadow.md
@@ -1,0 +1,119 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-props-shadow
+description: disallow declarations that shadow props in `<script setup>`
+---
+
+# vue/no-props-shadow
+
+> disallow declarations that shadow props in `<script setup>`
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> _**This rule has not been released yet.**_ </badge>
+
+## :book: Rule Details
+
+This rule reports top-level declarations in `<script setup>` that have the same name as a prop.
+
+In `<script setup>` the props and the top-level bindings of the script are both exposed to the template. When a local binding has the same name as a prop, it is ambiguous which of the two the template renders, and the answer (the local binding wins) is rarely what the author expected.
+
+<eslint-code-block :rules="{'vue/no-props-shadow': ['error']}">
+
+```vue
+<script setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  isDisabled: Boolean,
+  title: String,
+  count: Number
+})
+
+/* ✓ GOOD */
+const disabledLabel = computed(() => (props.isDisabled ? 'yes' : 'no'))
+
+/* ✗ BAD */
+const isDisabled = computed(() => (props.isDisabled ? 'yes' : 'no'))
+const title = ref('')
+const count = 0
+</script>
+
+<template>
+  <!-- Renders the local `isDisabled`, not the prop. -->
+  <h1>Disabled: {{ isDisabled }}</h1>
+</template>
+```
+
+</eslint-code-block>
+
+The rule reports every kind of top-level binding, because they all reach the template: `const`, `let`, `var`, function declarations, class declarations and imports.
+
+The following are **not** reported:
+
+- The binding that holds the result of `defineProps()`, including the destructured form. Those bindings _are_ the props, so they cannot shadow them.
+
+  <eslint-code-block :rules="{'vue/no-props-shadow': ['error']}">
+
+  ```vue
+  <script setup>
+  /* ✓ GOOD */
+  const props = defineProps({ foo: String })
+  </script>
+  ```
+
+  </eslint-code-block>
+
+  <eslint-code-block :rules="{'vue/no-props-shadow': ['error']}">
+
+  ```vue
+  <script setup>
+  /* ✓ GOOD */
+  const { foo } = defineProps({ foo: String })
+  </script>
+  ```
+
+  </eslint-code-block>
+
+- Declarations in nested scopes. A variable inside a function body or a block is not exposed to the template, so it cannot make the template ambiguous.
+
+  <eslint-code-block :rules="{'vue/no-props-shadow': ['error']}">
+
+  ```vue
+  <script setup>
+  defineProps({ foo: String })
+
+  /* ✓ GOOD */
+  function log(foo) {
+    const bar = foo
+    console.log(bar)
+  }
+  </script>
+  ```
+
+  </eslint-code-block>
+
+- Type-only declarations, such as `interface`, `type` and type-only imports. They exist only at compile time.
+
+- Code outside `<script setup>`. In the Options API the template resolves names through the component instance, where a local variable of `setup()` or of the module scope is not visible, so the same ambiguity cannot arise. Duplicated names in the Options API are reported by [vue/no-dupe-keys](./no-dupe-keys.md) instead.
+
+- Props created by `defineModel()`. Such a prop is meant to be consumed through the ref that the macro returns, and naming that ref after the model (`const foo = defineModel('foo')`) is the idiomatic usage rather than a mistake.
+
+## :wrench: Options
+
+Nothing.
+
+## :couple: Related Rules
+
+- [vue/no-dupe-keys](./no-dupe-keys.md)
+- [vue/no-reserved-props](./no-reserved-props.md)
+- [vue/no-template-shadow](./no-template-shadow.md)
+
+## :books: Further Reading
+
+- [Guide - SFC `<script setup>`](https://vuejs.org/api/sfc-script-setup.html)
+- [Guide - Props / Reactive Props Destructure](https://vuejs.org/guide/components/props.html#reactive-props-destructure)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-props-shadow.ts)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-props-shadow.test.ts)

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -118,6 +118,7 @@ import noNegatedCondition from './rules/no-negated-condition.js'
 import noNegatedVIfCondition from './rules/no-negated-v-if-condition.js'
 import noParsingError from './rules/no-parsing-error.js'
 import noPotentialComponentOptionTypo from './rules/no-potential-component-option-typo.js'
+import noPropsShadow from './rules/no-props-shadow.ts'
 import noRefAsOperand from './rules/no-ref-as-operand.ts'
 import noRefObjectReactivityLoss from './rules/no-ref-object-reactivity-loss.ts'
 import noRequiredPropWithDefault from './rules/no-required-prop-with-default.js'
@@ -376,6 +377,7 @@ export default {
     'no-negated-v-if-condition': noNegatedVIfCondition,
     'no-parsing-error': noParsingError,
     'no-potential-component-option-typo': noPotentialComponentOptionTypo,
+    'no-props-shadow': noPropsShadow,
     'no-ref-as-operand': noRefAsOperand,
     'no-ref-object-reactivity-loss': noRefObjectReactivityLoss,
     'no-required-prop-with-default': noRequiredPropWithDefault,

--- a/lib/rules/no-props-shadow.ts
+++ b/lib/rules/no-props-shadow.ts
@@ -1,0 +1,100 @@
+/**
+ * @author Valentin Yushkevich
+ * See LICENSE file in root directory for full license.
+ */
+import utils from '../utils/index.js'
+
+/**
+ * Checks whether the given variable only exists in the type space.
+ * e.g. `type Foo = {}`, `interface Foo {}`, `import type { Foo } from './foo'`
+ * Such a declaration cannot be referenced from the template,
+ * so it never shadows a prop.
+ */
+function isTypeOnlyVariable(variable: Variable): boolean {
+  if (variable.defs.length === 0) return true
+
+  // e.g. `type Foo = {}`, `interface Foo {}`
+  if (variable.isTypeVariable && !variable.isValueVariable) return true
+
+  // Type-only imports have `isValueVariable` set to true,
+  // so the actual nodes need to be checked.
+  return variable.defs.every((def) => {
+    if (def.type !== 'ImportBinding') {
+      return false
+    }
+    if (def.parent.importKind === 'type') {
+      // e.g. `import type Foo from './foo'`
+      return true
+    }
+    // e.g. `import { type Foo } from './foo'`
+    return def.node.type === 'ImportSpecifier' && def.node.importKind === 'type'
+  })
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow declarations that shadow props in `<script setup>`',
+      categories: undefined,
+      url: 'https://eslint.vuejs.org/rules/no-props-shadow.html'
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      shadow: "Declaration of '{{name}}' shadows the prop with the same name."
+    }
+  },
+  create(context: RuleContext) {
+    const propNames = new Set<string>()
+    // Declarators that hold the `defineProps()` result.
+    // Their bindings are the props themselves, not a shadowing declaration.
+    const propsDeclarators = new Set<VariableDeclarator>()
+
+    return utils.defineScriptSetupVisitor(context, {
+      onDefinePropsEnter(node, props) {
+        for (const prop of props) {
+          if (prop.propName != null) {
+            propNames.add(prop.propName)
+          }
+        }
+
+        // e.g. `const props = defineProps()`
+        //      `const { foo } = withDefaults(defineProps<Props>(), {})`
+        const target = utils.hasWithDefaults(node) ? node.parent : node
+        if (target.parent?.type === 'VariableDeclarator') {
+          propsDeclarators.add(target.parent)
+        }
+      },
+      'Program:exit'() {
+        if (propNames.size === 0) return
+
+        const globalScope = context.sourceCode.scopeManager.globalScope
+        if (!globalScope) return
+        // Only the top level scope of the script is exposed to the template.
+        const moduleScope =
+          globalScope.childScopes.find((scope) => scope.type === 'module') ||
+          globalScope
+
+        for (const variable of moduleScope.variables) {
+          if (!propNames.has(variable.name)) continue
+          if (isTypeOnlyVariable(variable)) continue
+          if (
+            variable.defs.some(
+              (def) => def.type === 'Variable' && propsDeclarators.has(def.node)
+            )
+          ) {
+            continue
+          }
+
+          context.report({
+            node: variable.defs[0].name,
+            messageId: 'shadow',
+            data: { name: variable.name }
+          })
+        }
+      }
+    })
+  }
+}

--- a/tests/lib/rules/no-props-shadow.test.ts
+++ b/tests/lib/rules/no-props-shadow.test.ts
@@ -1,0 +1,396 @@
+/**
+ * @author Valentin Yushkevich
+ * See LICENSE file in root directory for full license.
+ */
+import { RuleTester } from '../../eslint-compat'
+import rule from '../../../lib/rules/no-props-shadow'
+import vueEslintParser from 'vue-eslint-parser'
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: vueEslintParser,
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  }
+})
+
+tester.run('no-props-shadow', rule, {
+  valid: [
+    // The `defineProps()` result binding is not a shadowing declaration.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps(['foo'])
+      </script>
+      `
+    },
+    // Reactive props destructure: the binding is the prop itself.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const { foo } = defineProps({ foo: String })
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const { foo, bar } = defineProps<{ foo: string, bar: number }>()
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      interface Props {
+        foo: string
+      }
+      const { foo = 'default' } = withDefaults(defineProps<Props>(), { foo: 'default' })
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    // Different names.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import { ref } from 'vue'
+      const props = defineProps(['foo'])
+      const bar = ref(props.foo)
+      </script>
+      `
+    },
+    // Nested scopes are not exposed to the template.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps(['foo'])
+      function bar() {
+        const foo = 1
+        return foo
+      }
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps(['foo'])
+      const bar = (foo) => foo
+      </script>
+      `
+    },
+    // `defineModel()` is not handled by this rule.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps(['bar'])
+      const foo = defineModel('foo')
+      </script>
+      `
+    },
+    // Type-only declarations cannot be referenced from the template.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      interface foo {
+        bar: string
+      }
+      defineProps<{ foo: string }>()
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      import type { foo } from './foo'
+      import { type bar } from './bar'
+      defineProps<{ foo: foo, bar: string }>()
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    // Not `<script setup>`: a local variable cannot shadow a prop in the template.
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      const foo = 1
+      export default {
+        props: ['foo'],
+        setup() {
+          const foo = 2
+          return { bar: foo }
+        }
+      }
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const foo = 1
+      </script>
+      `
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import { ref } from 'vue'
+      defineProps(['foo'])
+      const foo = ref(false)
+      </script>
+      `,
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 16
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      import { computed } from 'vue'
+      const props = defineProps<{ isDisabled: boolean }>()
+      const isDisabled = computed(() => props.isDisabled ? 'yes' : 'no')
+      </script>
+      <template>
+        <h1>Disabled: {{ isDisabled }}</h1>
+      </template>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message:
+            "Declaration of 'isDisabled' shadows the prop with the same name.",
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps({ foo: String })
+      const foo = props.foo.trim()
+      </script>
+      `,
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 16
+        }
+      ]
+    },
+    // Function declaration.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps(['foo'])
+      function foo() {}
+      </script>
+      `,
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 4,
+          column: 16,
+          endLine: 4,
+          endColumn: 19
+        }
+      ]
+    },
+    // Class declaration.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps(['foo'])
+      class foo {}
+      </script>
+      `,
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 16
+        }
+      ]
+    },
+    // Import binding.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import foo from './foo'
+      defineProps(['foo'])
+      </script>
+      `,
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 3,
+          column: 14,
+          endLine: 3,
+          endColumn: 17
+        }
+      ]
+    },
+    // `let` and `var`.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      defineProps(['foo', 'bar'])
+      let foo = 1
+      var bar = 2
+      </script>
+      `,
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 14
+        },
+        {
+          message: "Declaration of 'bar' shadows the prop with the same name.",
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 14
+        }
+      ]
+    },
+    // Type-based props declared with an interface reference.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      interface Props {
+        foo: string
+      }
+      defineProps<Props>()
+      const foo = 'bar'
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 7,
+          column: 13,
+          endLine: 7,
+          endColumn: 16
+        }
+      ]
+    },
+    // `withDefaults()`.
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+      const props = withDefaults(defineProps<{ foo?: string }>(), { foo: 'bar' })
+      const foo = props.foo
+      </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 16
+        }
+      ]
+    },
+    // Declarations in a normal `<script>` block are exposed to the template too.
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      const foo = 1
+      </script>
+      <script setup>
+      defineProps(['foo'])
+      </script>
+      `,
+      errors: [
+        {
+          message: "Declaration of 'foo' shadows the prop with the same name.",
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 16
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
resolves #2287

Scoped to `<script setup>` and to module-scope bindings — those are the ones the template actually resolves. `const props = defineProps()` and destructured props aren't reported, since those bindings *are* the props.

`defineModel` isn't covered: `const foo = defineModel('foo')` is the idiomatic form and would need an exception of its own. Can add it if you'd prefer.
