### PR TITLE
feat: add `vue/no-content-outside-block` rule

### DIFF
--- a/.changeset/quiet-donuts-repeat.md
+++ b/.changeset/quiet-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Added new `vue/no-content-outside-block` rule

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -233,6 +233,7 @@ For example:
 | [vue/next-tick-style] | enforce Promise or callback style in `nextTick` | :wrench: | :hammer: |
 | [vue/no-bare-strings-in-template] | disallow the use of bare strings in `<template>` |  | :hammer: |
 | [vue/no-boolean-default] | disallow boolean defaults |  | :hammer: |
+| [vue/no-content-outside-block] | disallow content outside of the top-level blocks | :bulb: | :warning: |
 | [vue/no-duplicate-attr-inheritance] | enforce `inheritAttrs` to be set to `false` when using `v-bind="$attrs"` |  | :hammer: |
 | [vue/no-duplicate-class-names] | disallow duplication of class names in class attributes | :wrench: | :hammer: |
 | [vue/no-empty-component-block] | disallow the `<template>` `<script>` `<style>` block to be empty | :wrench: | :hammer: |
@@ -448,6 +449,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 [vue/no-computed-properties-in-data]: ./no-computed-properties-in-data.md
 [vue/no-console]: ./no-console.md
 [vue/no-constant-condition]: ./no-constant-condition.md
+[vue/no-content-outside-block]: ./no-content-outside-block.md
 [vue/no-custom-modifiers-on-v-model]: ./no-custom-modifiers-on-v-model.md
 [vue/no-deprecated-data-object-declaration]: ./no-deprecated-data-object-declaration.md
 [vue/no-deprecated-delete-set]: ./no-deprecated-delete-set.md

--- a/docs/rules/no-content-outside-block.md
+++ b/docs/rules/no-content-outside-block.md
@@ -1,0 +1,72 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/no-content-outside-block
+description: disallow content outside of the top-level blocks
+---
+
+# vue/no-content-outside-block
+
+> disallow content outside of the top-level blocks
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> _**This rule has not been released yet.**_ </badge>
+- :bulb: Some problems reported by this rule are manually fixable by editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+## :book: Rule Details
+
+This rule reports text content that is placed outside of the top-level blocks of a Single-File Component.
+
+The Vue compiler only processes the top-level blocks (`<template>`, `<script>`, `<style>` and custom blocks) and silently drops everything between them. Code written outside of a block never runs and text written outside of a block is never rendered, so such content is almost always a leftover or a mistake.
+
+HTML comments (`<!-- ... -->`) and custom blocks (such as `<docs>` or `<i18n>`) are not reported, since both are a legitimate part of an SFC.
+
+<eslint-code-block :rules="{'vue/no-content-outside-block': ['error']}">
+
+```vue
+<!-- ✓ GOOD -->
+<template>
+  <div>Hello</div>
+</template>
+
+<script>
+console.log('this runs')
+</script>
+
+<docs>
+Custom blocks are not reported.
+</docs>
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/no-content-outside-block': ['error']}">
+
+```vue
+<!-- ✗ BAD -->
+<template>
+  <div>Hello</div>
+</template>
+
+console.log('this never runs')
+
+<script>
+console.log('this runs')
+</script>
+
+hello world
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.
+
+## :books: Further Reading
+
+- [Vue Single-File Component Spec](https://vuejs.org/api/sfc-spec.html)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/no-content-outside-block.ts)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/no-content-outside-block.test.ts)

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -70,6 +70,7 @@ import noChildContent from './rules/no-child-content.js'
 import noComputedPropertiesInData from './rules/no-computed-properties-in-data.js'
 import noConsole from './rules/no-console.js'
 import noConstantCondition from './rules/no-constant-condition.js'
+import noContentOutsideBlock from './rules/no-content-outside-block.ts'
 import noCustomModifiersOnVModel from './rules/no-custom-modifiers-on-v-model.js'
 import noDeprecatedDataObjectDeclaration from './rules/no-deprecated-data-object-declaration.js'
 import noDeprecatedDeleteSet from './rules/no-deprecated-delete-set.js'
@@ -328,6 +329,7 @@ export default {
     'no-computed-properties-in-data': noComputedPropertiesInData,
     'no-console': noConsole,
     'no-constant-condition': noConstantCondition,
+    'no-content-outside-block': noContentOutsideBlock,
     'no-custom-modifiers-on-v-model': noCustomModifiersOnVModel,
     'no-deprecated-data-object-declaration': noDeprecatedDataObjectDeclaration,
     'no-deprecated-delete-set': noDeprecatedDeleteSet,

--- a/lib/rules/no-content-outside-block.ts
+++ b/lib/rules/no-content-outside-block.ts
@@ -1,0 +1,75 @@
+/**
+ * @author Valentin Yushkevich
+ * See LICENSE file in root directory for full license.
+ */
+import utils from '../utils/index.js'
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow content outside of the top-level blocks',
+      categories: undefined,
+      url: 'https://eslint.vuejs.org/rules/no-content-outside-block.html'
+    },
+    fixable: null,
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      unexpectedContent:
+        'Unexpected content outside of the top-level blocks. It is dropped by the compiler.',
+      removeContent: 'Remove the content outside of the top-level blocks.'
+    }
+  },
+  create(context: RuleContext): RuleListener {
+    const sourceCode = context.sourceCode
+    const documentFragment =
+      sourceCode.parserServices.getDocumentFragment &&
+      sourceCode.parserServices.getDocumentFragment()
+    if (!documentFragment) {
+      // Not a `.vue` file, or the parser is not `vue-eslint-parser`.
+      return {}
+    }
+
+    return {
+      Program(node: Program) {
+        if (utils.hasInvalidEOF(node)) {
+          return
+        }
+        for (const child of documentFragment.children) {
+          if (child.type !== 'VText') {
+            // Top-level elements (including custom blocks) are fine, and
+            // HTML comments are not stored in `children` at all.
+            continue
+          }
+          // The raw text has to be used instead of `child.value`, because the
+          // value is normalized (HTML entities are decoded and CRLF is
+          // converted to LF), so its length does not match the source range.
+          const [start, end] = child.range
+          const raw = sourceCode.text.slice(start, end)
+          const leading = raw.length - raw.trimStart().length
+          if (leading === raw.length) {
+            // Whitespace only.
+            continue
+          }
+          const trailing = raw.length - raw.trimEnd().length
+          const contentRange: Range = [start + leading, end - trailing]
+
+          context.report({
+            loc: {
+              start: sourceCode.getLocFromIndex(contentRange[0]),
+              end: sourceCode.getLocFromIndex(contentRange[1])
+            },
+            messageId: 'unexpectedContent',
+            suggest: [
+              {
+                messageId: 'removeContent',
+                fix: (fixer: RuleFixer) => fixer.removeRange(contentRange)
+              }
+            ]
+          })
+        }
+      }
+    }
+  }
+}

--- a/tests/lib/rules/no-content-outside-block.test.ts
+++ b/tests/lib/rules/no-content-outside-block.test.ts
@@ -18,58 +18,62 @@ tester.run('no-content-outside-block', rule as RuleModule, {
     },
     {
       filename: 'test.vue',
-      code: `<template>
-  <div>666</div>
-</template>
+      code: `
+        <template>
+          <div>666</div>
+        </template>
 
-<script>
-export default {}
-</script>
+        <script>
+          export default {}
+        </script>
 
-<style>
-div {
-  color: red;
-}
-</style>
-`
+        <style>
+          div {
+            color: red;
+          }
+        </style>
+      `
     },
     {
       // only a `<script>` block
       filename: 'test.vue',
-      code: `<script>
-console.log(1)
-</script>
-`
+      code: `
+        <script>
+          console.log(1)
+        </script>
+      `
     },
     {
       // HTML comments outside of the blocks are allowed
       filename: 'test.vue',
-      code: `<!-- leading comment -->
-<template>
-  <div>666</div>
-</template>
-<!-- comment between the blocks -->
-<script>
-export default {}
-</script>
-<!-- trailing comment -->
-`
+      code: `
+        <!-- leading comment -->
+        <template>
+          <div>666</div>
+        </template>
+        <!-- comment between the blocks -->
+        <script>
+          export default {}
+        </script>
+        <!-- trailing comment -->
+      `
     },
     {
       // custom blocks are elements, not stray content
       filename: 'test.vue',
-      code: `<docs>
-Some documentation.
-</docs>
+      code: `
+        <docs>
+          Some documentation.
+        </docs>
 
-<i18n>
-{ "en": { "hello": "hello" } }
-</i18n>
+        <i18n>
+          { "en": { "hello": "hello" } }
+        </i18n>
 
-<template>
-  <div>666</div>
-</template>
-`
+        <template>
+          <div>666</div>
+        </template>
+      `
     },
     {
       // not a `.vue` file
@@ -81,36 +85,38 @@ Some documentation.
     {
       // content between the blocks
       filename: 'test.vue',
-      code: `<template>
-  <div>666</div>
-</template>
+      code: `
+        <template>
+          <div>666</div>
+        </template>
 
-console.log(1);
+        console.log(1);
 
-<script>
-console.log(2);
-</script>
-`,
+        <script>
+          console.log(2);
+        </script>
+      `,
       errors: [
         {
           messageId: 'unexpectedContent',
-          line: 5,
-          column: 1,
-          endLine: 5,
-          endColumn: 16,
+          line: 6,
+          column: 9,
+          endLine: 6,
+          endColumn: 24,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `<template>
-  <div>666</div>
-</template>
+              output: `
+        <template>
+          <div>666</div>
+        </template>
 
+        
 
-
-<script>
-console.log(2);
-</script>
-`
+        <script>
+          console.log(2);
+        </script>
+      `
             }
           ]
         }
@@ -119,28 +125,30 @@ console.log(2);
     {
       // content before the first block
       filename: 'test.vue',
-      code: `hello world
+      code: `
+        hello world
 
-<template>
-  <div>666</div>
-</template>
-`,
+        <template>
+          <div>666</div>
+        </template>
+      `,
       errors: [
         {
           messageId: 'unexpectedContent',
-          line: 1,
-          column: 1,
-          endLine: 1,
-          endColumn: 12,
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 20,
           suggestions: [
             {
               messageId: 'removeContent',
               output: `
+        
 
-<template>
-  <div>666</div>
-</template>
-`
+        <template>
+          <div>666</div>
+        </template>
+      `
             }
           ]
         }
@@ -149,28 +157,30 @@ console.log(2);
     {
       // content after the last block
       filename: 'test.vue',
-      code: `<template>
-  <div>666</div>
-</template>
+      code: `
+        <template>
+          <div>666</div>
+        </template>
 
-trailing text
-`,
+        trailing text
+      `,
       errors: [
         {
           messageId: 'unexpectedContent',
-          line: 5,
-          column: 1,
-          endLine: 5,
-          endColumn: 14,
+          line: 6,
+          column: 9,
+          endLine: 6,
+          endColumn: 22,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `<template>
-  <div>666</div>
-</template>
+              output: `
+        <template>
+          <div>666</div>
+        </template>
 
-
-`
+        
+      `
             }
           ]
         }
@@ -179,96 +189,100 @@ trailing text
     {
       // multiple separate runs
       filename: 'test.vue',
-      code: `before
+      code: `
+        before
 
-<template>
-  <div>666</div>
-</template>
+        <template>
+          <div>666</div>
+        </template>
 
-middle
+        middle
 
-<script>
-export default {}
-</script>
+        <script>
+          export default {}
+        </script>
 
-after
-`,
+        after
+      `,
       errors: [
         {
           messageId: 'unexpectedContent',
-          line: 1,
-          column: 1,
-          endLine: 1,
-          endColumn: 7,
+          line: 2,
+          column: 9,
+          endLine: 2,
+          endColumn: 15,
           suggestions: [
             {
               messageId: 'removeContent',
               output: `
+        
 
-<template>
-  <div>666</div>
-</template>
+        <template>
+          <div>666</div>
+        </template>
 
-middle
+        middle
 
-<script>
-export default {}
-</script>
+        <script>
+          export default {}
+        </script>
 
-after
-`
+        after
+      `
             }
           ]
         },
         {
           messageId: 'unexpectedContent',
-          line: 7,
-          column: 1,
-          endLine: 7,
-          endColumn: 7,
+          line: 8,
+          column: 9,
+          endLine: 8,
+          endColumn: 15,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `before
+              output: `
+        before
 
-<template>
-  <div>666</div>
-</template>
+        <template>
+          <div>666</div>
+        </template>
 
+        
 
+        <script>
+          export default {}
+        </script>
 
-<script>
-export default {}
-</script>
-
-after
-`
+        after
+      `
             }
           ]
         },
         {
           messageId: 'unexpectedContent',
-          line: 13,
-          column: 1,
-          endLine: 13,
-          endColumn: 6,
+          line: 14,
+          column: 9,
+          endLine: 14,
+          endColumn: 14,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `before
+              output: `
+        before
 
-<template>
-  <div>666</div>
-</template>
+        <template>
+          <div>666</div>
+        </template>
 
-middle
+        middle
 
-<script>
-export default {}
-</script>
+        <script>
+          export default {}
+        </script>
 
-
-`
+        
+      `
             }
           ]
         }
@@ -277,37 +291,39 @@ export default {}
     {
       // a multi-line run is reported once, without the surrounding blank lines
       filename: 'test.vue',
-      code: `<template>
-  <div>666</div>
-</template>
+      code: `
+        <template>
+          <div>666</div>
+        </template>
 
-console.log(1);
-console.log(2);
+        console.log(1);
+        console.log(2);
 
-<script>
-export default {}
-</script>
-`,
+        <script>
+          export default {}
+        </script>
+      `,
       errors: [
         {
           messageId: 'unexpectedContent',
-          line: 5,
-          column: 1,
-          endLine: 6,
-          endColumn: 16,
+          line: 6,
+          column: 9,
+          endLine: 7,
+          endColumn: 24,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `<template>
-  <div>666</div>
-</template>
+              output: `
+        <template>
+          <div>666</div>
+        </template>
 
+        
 
-
-<script>
-export default {}
-</script>
-`
+        <script>
+          export default {}
+        </script>
+      `
             }
           ]
         }
@@ -336,36 +352,38 @@ export default {}
     {
       // content around a custom block
       filename: 'test.vue',
-      code: `<docs>
-Some documentation.
-</docs>
+      code: `
+        <docs>
+          Some documentation.
+        </docs>
 
-stray
+        stray
 
-<template>
-  <div>666</div>
-</template>
-`,
+        <template>
+          <div>666</div>
+        </template>
+      `,
       errors: [
         {
           messageId: 'unexpectedContent',
-          line: 5,
-          column: 1,
-          endLine: 5,
-          endColumn: 6,
+          line: 6,
+          column: 9,
+          endLine: 6,
+          endColumn: 14,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `<docs>
-Some documentation.
-</docs>
+              output: `
+        <docs>
+          Some documentation.
+        </docs>
 
+        
 
-
-<template>
-  <div>666</div>
-</template>
-`
+        <template>
+          <div>666</div>
+        </template>
+      `
             }
           ]
         }
@@ -374,64 +392,67 @@ Some documentation.
     {
       // an HTML comment splits the content into separate runs
       filename: 'test.vue',
-      code: `<template>
-  <div>666</div>
-</template>
+      code: `
+        <template>
+          <div>666</div>
+        </template>
 
-foo
-<!-- comment -->
-bar
+        foo
+        <!-- comment -->
+        bar
 
-<script>
-export default {}
-</script>
-`,
+        <script>
+          export default {}
+        </script>
+      `,
       errors: [
         {
           messageId: 'unexpectedContent',
-          line: 5,
-          column: 1,
-          endLine: 5,
-          endColumn: 4,
+          line: 6,
+          column: 9,
+          endLine: 6,
+          endColumn: 12,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `<template>
-  <div>666</div>
-</template>
+              output: `
+        <template>
+          <div>666</div>
+        </template>
 
+        
+        <!-- comment -->
+        bar
 
-<!-- comment -->
-bar
-
-<script>
-export default {}
-</script>
-`
+        <script>
+          export default {}
+        </script>
+      `
             }
           ]
         },
         {
           messageId: 'unexpectedContent',
-          line: 7,
-          column: 1,
-          endLine: 7,
-          endColumn: 4,
+          line: 8,
+          column: 9,
+          endLine: 8,
+          endColumn: 12,
           suggestions: [
             {
               messageId: 'removeContent',
-              output: `<template>
-  <div>666</div>
-</template>
+              output: `
+        <template>
+          <div>666</div>
+        </template>
 
-foo
-<!-- comment -->
+        foo
+        <!-- comment -->
+        
 
-
-<script>
-export default {}
-</script>
-`
+        <script>
+          export default {}
+        </script>
+      `
             }
           ]
         }

--- a/tests/lib/rules/no-content-outside-block.test.ts
+++ b/tests/lib/rules/no-content-outside-block.test.ts
@@ -1,0 +1,441 @@
+/**
+ * @author Valentin Yushkevich
+ * See LICENSE file in root directory for full license.
+ */
+import { RuleTester } from '../../eslint-compat'
+import rule from '../../../lib/rules/no-content-outside-block'
+import vueEslintParser from 'vue-eslint-parser'
+
+const tester = new RuleTester({
+  languageOptions: { parser: vueEslintParser, ecmaVersion: 2020 }
+})
+
+tester.run('no-content-outside-block', rule as RuleModule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: ''
+    },
+    {
+      filename: 'test.vue',
+      code: `<template>
+  <div>666</div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style>
+div {
+  color: red;
+}
+</style>
+`
+    },
+    {
+      // only a `<script>` block
+      filename: 'test.vue',
+      code: `<script>
+console.log(1)
+</script>
+`
+    },
+    {
+      // HTML comments outside of the blocks are allowed
+      filename: 'test.vue',
+      code: `<!-- leading comment -->
+<template>
+  <div>666</div>
+</template>
+<!-- comment between the blocks -->
+<script>
+export default {}
+</script>
+<!-- trailing comment -->
+`
+    },
+    {
+      // custom blocks are elements, not stray content
+      filename: 'test.vue',
+      code: `<docs>
+Some documentation.
+</docs>
+
+<i18n>
+{ "en": { "hello": "hello" } }
+</i18n>
+
+<template>
+  <div>666</div>
+</template>
+`
+    },
+    {
+      // not a `.vue` file
+      filename: 'test.js',
+      code: 'console.log(1)'
+    }
+  ],
+  invalid: [
+    {
+      // content between the blocks
+      filename: 'test.vue',
+      code: `<template>
+  <div>666</div>
+</template>
+
+console.log(1);
+
+<script>
+console.log(2);
+</script>
+`,
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 5,
+          column: 1,
+          endLine: 5,
+          endColumn: 16,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `<template>
+  <div>666</div>
+</template>
+
+
+
+<script>
+console.log(2);
+</script>
+`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      // content before the first block
+      filename: 'test.vue',
+      code: `hello world
+
+<template>
+  <div>666</div>
+</template>
+`,
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 12,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `
+
+<template>
+  <div>666</div>
+</template>
+`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      // content after the last block
+      filename: 'test.vue',
+      code: `<template>
+  <div>666</div>
+</template>
+
+trailing text
+`,
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 5,
+          column: 1,
+          endLine: 5,
+          endColumn: 14,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `<template>
+  <div>666</div>
+</template>
+
+
+`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      // multiple separate runs
+      filename: 'test.vue',
+      code: `before
+
+<template>
+  <div>666</div>
+</template>
+
+middle
+
+<script>
+export default {}
+</script>
+
+after
+`,
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 7,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `
+
+<template>
+  <div>666</div>
+</template>
+
+middle
+
+<script>
+export default {}
+</script>
+
+after
+`
+            }
+          ]
+        },
+        {
+          messageId: 'unexpectedContent',
+          line: 7,
+          column: 1,
+          endLine: 7,
+          endColumn: 7,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `before
+
+<template>
+  <div>666</div>
+</template>
+
+
+
+<script>
+export default {}
+</script>
+
+after
+`
+            }
+          ]
+        },
+        {
+          messageId: 'unexpectedContent',
+          line: 13,
+          column: 1,
+          endLine: 13,
+          endColumn: 6,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `before
+
+<template>
+  <div>666</div>
+</template>
+
+middle
+
+<script>
+export default {}
+</script>
+
+
+`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      // a multi-line run is reported once, without the surrounding blank lines
+      filename: 'test.vue',
+      code: `<template>
+  <div>666</div>
+</template>
+
+console.log(1);
+console.log(2);
+
+<script>
+export default {}
+</script>
+`,
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 5,
+          column: 1,
+          endLine: 6,
+          endColumn: 16,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `<template>
+  <div>666</div>
+</template>
+
+
+
+<script>
+export default {}
+</script>
+`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      // a file without any block
+      filename: 'test.vue',
+      code: 'hello',
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 6,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: ''
+            }
+          ]
+        }
+      ]
+    },
+    {
+      // content around a custom block
+      filename: 'test.vue',
+      code: `<docs>
+Some documentation.
+</docs>
+
+stray
+
+<template>
+  <div>666</div>
+</template>
+`,
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 5,
+          column: 1,
+          endLine: 5,
+          endColumn: 6,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `<docs>
+Some documentation.
+</docs>
+
+
+
+<template>
+  <div>666</div>
+</template>
+`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      // an HTML comment splits the content into separate runs
+      filename: 'test.vue',
+      code: `<template>
+  <div>666</div>
+</template>
+
+foo
+<!-- comment -->
+bar
+
+<script>
+export default {}
+</script>
+`,
+      errors: [
+        {
+          messageId: 'unexpectedContent',
+          line: 5,
+          column: 1,
+          endLine: 5,
+          endColumn: 4,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `<template>
+  <div>666</div>
+</template>
+
+
+<!-- comment -->
+bar
+
+<script>
+export default {}
+</script>
+`
+            }
+          ]
+        },
+        {
+          messageId: 'unexpectedContent',
+          line: 7,
+          column: 1,
+          endLine: 7,
+          endColumn: 4,
+          suggestions: [
+            {
+              messageId: 'removeContent',
+              output: `<template>
+  <div>666</div>
+</template>
+
+foo
+<!-- comment -->
+
+
+<script>
+export default {}
+</script>
+`
+            }
+          ]
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
resolves #2209

Comments and custom blocks are left alone as you asked. Comments turned out to be free — `vue-eslint-parser` keeps them in `documentFragment.comments`, not in `children`.

Removal is a suggestion rather than an autofix: stray text is usually code that was meant to go inside a block, and having `--fix` silently delete it felt wrong.
