### PR TITLE
feat(define-macros-order): add `allowTypesBetweenMacros` option

### DIFF
--- a/.changeset/brave-melons-invite.md
+++ b/.changeset/brave-melons-invite.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Added `allowTypesBetweenMacros` option to `vue/define-macros-order` rule

--- a/docs/rules/define-macros-order.md
+++ b/docs/rules/define-macros-order.md
@@ -23,13 +23,15 @@ This rule reports compiler macros (like `defineProps` or `defineEmits` but also 
 {
   "vue/define-macros-order": ["error", {
     "order": ["defineProps", "defineEmits"],
-    "defineExposeLast": false
+    "defineExposeLast": false,
+    "allowTypesBetweenMacros": false
   }]
 }
 ```
 
 - `order` (`string[]`) ... The order in which the macros should appear. The default is `["defineProps", "defineEmits"]`.
 - `defineExposeLast` (`boolean`) ... Force `defineExpose` at the end.
+- `allowTypesBetweenMacros` (`boolean`) ... Allow TypeScript code that is erased at compile time (e.g. `type` and `interface` declarations, `declare` statements, `import type`) between the macros. Anything that emits runtime code, such as an `enum` or a non-`declare`d `namespace`, is still reported. Default is `false`.
 
 ### `{ "order": ["defineProps", "defineEmits"] }` (default)
 
@@ -176,6 +178,38 @@ defineProps(/* ... */)
 defineEmits(/* ... */)
 defineExpose({/* ... */})
 const slots = defineSlots()
+</script>
+```
+
+</eslint-code-block>
+
+### `{ "allowTypesBetweenMacros": true }`
+
+<eslint-code-block fix :rules="{'vue/define-macros-order': ['error', {allowTypesBetweenMacros: true}]}">
+
+```vue
+<!-- ✓ GOOD -->
+<script setup lang="ts">
+defineProps(/* ... */)
+
+type Foo = 'bar'
+
+defineEmits(/* ... */)
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block fix :rules="{'vue/define-macros-order': ['error', {allowTypesBetweenMacros: true}]}">
+
+```vue
+<!-- ✗ BAD -->
+<script setup lang="ts">
+defineProps(/* ... */)
+
+enum Foo { Bar = 'bar' }
+
+defineEmits(/* ... */)
 </script>
 ```
 

--- a/lib/rules/define-macros-order.js
+++ b/lib/rules/define-macros-order.js
@@ -6,6 +6,12 @@
 
 const utils = require('../utils')
 
+/**
+ * @typedef {import('@typescript-eslint/types').TSESTree.ImportDeclaration} TSESTreeImportDeclaration
+ * @typedef {import('@typescript-eslint/types').TSESTree.ExportAllDeclaration} TSESTreeExportAllDeclaration
+ * @typedef {import('@typescript-eslint/types').TSESTree.ExportNamedDeclaration} TSESTreeExportNamedDeclaration
+ */
+
 const MACROS_EMITS = 'defineEmits'
 const MACROS_PROPS = 'defineProps'
 const MACROS_OPTIONS = 'defineOptions'
@@ -21,6 +27,17 @@ const KNOWN_MACROS = new Set([
   MACROS_EXPOSE
 ])
 const DEFAULT_ORDER = [MACROS_PROPS, MACROS_EMITS]
+
+/**
+ * Statement types that are always erased by the TypeScript compiler.
+ * Note that `TSEnumDeclaration` is intentionally missing, because enums
+ * (including `const enum`) can emit runtime code.
+ */
+const TYPE_ONLY_STATEMENTS = new Set([
+  'TSTypeAliasDeclaration',
+  'TSInterfaceDeclaration',
+  'TSDeclareFunction'
+])
 
 /**
  * @param {VElement} scriptSetup
@@ -49,6 +66,71 @@ function isUseStrictStatement(node) {
     node.expression.type === 'Literal' &&
     node.expression.value === 'use strict'
   )
+}
+
+/**
+ * Checks whether the given node is TypeScript syntax that is fully erased at
+ * compile time, and therefore does not emit any runtime code.
+ * @param {ASTNode} node
+ * @returns {boolean}
+ */
+function isTypeOnlyStatement(node) {
+  // `declare` makes a declaration ambient, so nothing is emitted for it.
+  // This covers `declare const`, `declare function`, `declare class`,
+  // `declare enum`, `declare module`, `declare namespace` and `declare global`.
+  if (isDeclareStatement(node)) {
+    return true
+  }
+
+  if (TYPE_ONLY_STATEMENTS.has(node.type)) {
+    return true
+  }
+
+  if (node.type === 'ImportDeclaration') {
+    const importNode = /** @type {TSESTreeImportDeclaration} */ (node)
+    // `import type { Foo } from 'foo'` and `import { type Foo } from 'foo'`
+    return (
+      importNode.importKind === 'type' ||
+      (importNode.specifiers.length > 0 &&
+        importNode.specifiers.every(
+          (specifier) =>
+            specifier.type === 'ImportSpecifier' &&
+            specifier.importKind === 'type'
+        ))
+    )
+  }
+
+  if (node.type === 'ExportNamedDeclaration') {
+    const exportNode = /** @type {TSESTreeExportNamedDeclaration} */ (node)
+    // `export type { Foo }`
+    if (exportNode.exportKind === 'type') {
+      return true
+    }
+    // `export type Foo = string`, `export interface Foo {}`, `export declare ...`
+    const declaration = exportNode.declaration
+    if (declaration) {
+      return (
+        TYPE_ONLY_STATEMENTS.has(declaration.type) ||
+        ('declare' in declaration && declaration.declare === true)
+      )
+    }
+    // `export { type Foo }`
+    return (
+      exportNode.specifiers.length > 0 &&
+      exportNode.specifiers.every(
+        (specifier) => specifier.exportKind === 'type'
+      )
+    )
+  }
+
+  if (node.type === 'ExportAllDeclaration') {
+    // `export type * from 'foo'`
+    return (
+      /** @type {TSESTreeExportAllDeclaration} */ (node).exportKind === 'type'
+    )
+  }
+
+  return false
 }
 
 /**
@@ -120,6 +202,9 @@ function create(context) {
       "`defineExpose` macro can't be in the `order` array if `defineExposeLast` is true."
     )
   }
+  /** @type {boolean} */
+  const allowTypesBetweenMacros =
+    (options[0] && options[0].allowTypesBetweenMacros) || false
 
   const sourceCode = context.sourceCode
   /** @type {Map<string, ASTNode[]>} */
@@ -175,6 +260,18 @@ function create(context) {
           scriptSetup,
           program
         )
+        // The statements the macros are compared against. When
+        // `allowTypesBetweenMacros` is enabled, statements that are erased at
+        // compile time are ignored, so they are allowed between the macros.
+        const targetStatements =
+          firstStatementIndex === -1
+            ? []
+            : program.body
+                .slice(firstStatementIndex)
+                .filter(
+                  (node) =>
+                    !allowTypesBetweenMacros || !isTypeOnlyStatement(node)
+                )
         const orderedList = order
           .flatMap((name) => {
             const nodes = macrosNodes.get(name) ?? []
@@ -194,7 +291,7 @@ function create(context) {
         }
 
         for (const [index, should] of orderedList.entries()) {
-          const targetStatement = program.body[firstStatementIndex + index]
+          const targetStatement = targetStatements[index]
 
           if (should.node !== targetStatement) {
             let moveTargetNodes = orderedList
@@ -392,6 +489,9 @@ module.exports = {
             additionalItems: false
           },
           defineExposeLast: {
+            type: 'boolean'
+          },
+          allowTypesBetweenMacros: {
             type: 'boolean'
           }
         },

--- a/tests/lib/rules/define-macros-order.test.ts
+++ b/tests/lib/rules/define-macros-order.test.ts
@@ -32,6 +32,12 @@ const optionsExposeLast = [
   }
 ]
 
+const optionsAllowTypesBetweenMacros = [
+  {
+    allowTypesBetweenMacros: true
+  }
+]
+
 function notAtTopMessage(macro: string): string {
   return `${macro} should be placed at the top of \`<script setup>\` (after any potential import statements or type definitions).`
 }
@@ -336,6 +342,98 @@ tester.run('define-macros-order', rule, {
           order: ['definePage', 'defineModel']
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+
+          type Emit = 'update:foo'
+
+          defineEmits<{ (e: Emit): void }>()
+        </script>
+      `,
+      options: optionsAllowTypesBetweenMacros,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          type Alias = string
+          interface Interface { foo: Alias }
+          declare const ambient: string
+          declare function ambientFn(): void
+          declare module 'ambient-module' {}
+          declare namespace AmbientNamespace {}
+          declare enum AmbientEnum { A }
+          function overloadSignature(value: string): void
+          import type { Foo } from './foo'
+          import { type Bar } from './bar'
+          export type ExportedAlias = Foo
+          export interface ExportedInterface { bar: Bar }
+          export type { Alias }
+          export { type Interface }
+          export type * from './baz'
+          export declare const exportedAmbient: string
+          defineEmits<{ (e: 'x'): void }>()
+        </script>
+      `,
+      options: optionsAllowTypesBetweenMacros,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          const a = defineModel<string>('a')
+          type B = number
+          const b = defineModel<B>('b')
+        </script>
+      `,
+      options: [
+        {
+          order: ['defineModel'],
+          allowTypesBetweenMacros: true
+        }
+      ],
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          type Foo = string
+          defineEmits<{ (e: 'x'): void }>()
+          defineExpose({})
+        </script>
+      `,
+      options: [
+        {
+          allowTypesBetweenMacros: true,
+          defineExposeLast: true
+        }
+      ],
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      }
     }
   ],
   invalid: [
@@ -1300,6 +1398,301 @@ tester.run('define-macros-order', rule, {
       `
             }
           ]
+        }
+      ]
+    },
+    {
+      // `allowTypesBetweenMacros` is disabled by default
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+
+          type Emit = 'update:foo'
+
+          defineEmits<{ (e: Emit): void }>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+
+          defineEmits<{ (e: Emit): void }>()
+
+          type Emit = 'update:foo'
+
+        </script>
+      `,
+      options: optionsPropsFirst,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: notAtTopMessage('defineEmits'),
+          line: 7,
+          column: 11,
+          endLine: 7,
+          endColumn: 45
+        }
+      ]
+    },
+    {
+      // runtime code is still reported
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+
+          const foo = 'bar'
+
+          defineEmits<{ (e: 'x'): void }>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+
+          defineEmits<{ (e: 'x'): void }>()
+
+          const foo = 'bar'
+
+        </script>
+      `,
+      options: optionsAllowTypesBetweenMacros,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: notAtTopMessage('defineEmits'),
+          line: 7,
+          column: 11,
+          endLine: 7,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      // enums emit runtime code, so they are still reported
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+
+          enum Foo { A = 'a' }
+
+          defineEmits<{ (e: 'x'): void }>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+
+          defineEmits<{ (e: 'x'): void }>()
+
+          enum Foo { A = 'a' }
+
+        </script>
+      `,
+      options: optionsAllowTypesBetweenMacros,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: notAtTopMessage('defineEmits'),
+          line: 7,
+          column: 11,
+          endLine: 7,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      // `const enum` can emit runtime code as well
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          const enum Foo { A = 'a' }
+          defineEmits<{ (e: 'x'): void }>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          defineEmits<{ (e: 'x'): void }>()
+          const enum Foo { A = 'a' }
+        </script>
+      `,
+      options: optionsAllowTypesBetweenMacros,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: notAtTopMessage('defineEmits'),
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      // a namespace that is not `declare`d can emit runtime code
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          namespace Foo { export type A = string }
+          defineEmits<{ (e: 'x'): void }>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          defineEmits<{ (e: 'x'): void }>()
+          namespace Foo { export type A = string }
+        </script>
+      `,
+      options: optionsAllowTypesBetweenMacros,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: notAtTopMessage('defineEmits'),
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      // only type imports are allowed between the macros
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          import { bar } from './bar'
+          defineEmits<{ (e: 'x'): void }>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          defineEmits<{ (e: 'x'): void }>()
+          import { bar } from './bar'
+        </script>
+      `,
+      options: optionsAllowTypesBetweenMacros,
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: notAtTopMessage('defineEmits'),
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 44
+        }
+      ]
+    },
+    {
+      // the type declaration between the macros is left untouched by the fixer
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          defineEmits<{ (e: 'x'): void }>()
+
+          type Props = { foo: string }
+
+          defineProps<Props>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<Props>()
+
+          defineEmits<{ (e: 'x'): void }>()
+
+          type Props = { foo: string }
+
+        </script>
+      `,
+      options: [
+        {
+          order: ['defineProps', 'defineEmits'],
+          allowTypesBetweenMacros: true
+        }
+      ],
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: unorderedMessage('defineProps', 'defineEmits'),
+          line: 7,
+          column: 11,
+          endLine: 7,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          const bar = ref()
+          defineProps<{ foo: string }>()
+          type Foo = string
+          defineEmits<{ (e: 'x'): void }>()
+        </script>
+      `,
+      output: `
+        <script setup lang="ts">
+          defineProps<{ foo: string }>()
+          defineEmits<{ (e: 'x'): void }>()
+          const bar = ref()
+          type Foo = string
+        </script>
+      `,
+      options: [
+        {
+          order: ['defineProps', 'defineEmits'],
+          allowTypesBetweenMacros: true
+        }
+      ],
+      languageOptions: {
+        parserOptions: {
+          parser: require.resolve('@typescript-eslint/parser')
+        }
+      },
+      errors: [
+        {
+          message: notAtTopMessage('defineProps'),
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 41
         }
       ]
     }


### PR DESCRIPTION
resolves #2978

`allowTypesBetweenMacros`, off by default. Allows `type` / `interface` / overload signatures / anything `declare`d / type-only imports and exports between the macros.

Enums and non-ambient namespaces are deliberately not allowed, since they emit runtime code. That differs from the `skipStatements` list in `getTargetStatementPosition`, which does skip `TSEnumDeclaration` and `TSModuleDeclaration`. Should those be brought in line as well, or is the asymmetry fine? I left it as is for now.
