### PR TITLE
feat: add `vue/single-v-slot-style` rule

### DIFF
--- a/.changeset/brave-lions-smile.md
+++ b/.changeset/brave-lions-smile.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Added new `vue/single-v-slot-style` rule

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -292,6 +292,7 @@ For example:
 | [vue/require-typed-ref] | require `ref` and `shallowRef` functions to be strongly typed |  | :hammer: |
 | [vue/restricted-component-names] | enforce using only specific component names |  | :warning: |
 | [vue/script-indent] | enforce consistent indentation in `<script>` | :wrench: | :lipstick: |
+| [vue/single-v-slot-style] | enforce a consistent style for components with a single `v-slot` | :wrench: | :hammer: |
 | [vue/slot-name-casing] | enforce specific casing for slot names |  | :hammer: |
 | [vue/sort-keys] | enforce sort-keys in a manner that is compatible with order-in-components |  | :hammer: |
 | [vue/static-class-names-order] | enforce static class names order | :wrench: | :hammer: |
@@ -595,6 +596,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 [vue/return-in-computed-property]: ./return-in-computed-property.md
 [vue/return-in-emits-validator]: ./return-in-emits-validator.md
 [vue/script-indent]: ./script-indent.md
+[vue/single-v-slot-style]: ./single-v-slot-style.md
 [vue/singleline-html-element-content-newline]: ./singleline-html-element-content-newline.md
 [vue/slot-name-casing]: ./slot-name-casing.md
 [vue/sort-keys]: ./sort-keys.md

--- a/docs/rules/single-v-slot-style.md
+++ b/docs/rules/single-v-slot-style.md
@@ -1,0 +1,242 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/single-v-slot-style
+description: enforce a consistent style for components with a single `v-slot`
+---
+
+# vue/single-v-slot-style
+
+> enforce a consistent style for components with a single `v-slot`
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> _**This rule has not been released yet.**_ </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fix-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+When a component is given exactly one slot and has no other children, the `<template>` wrapper around that slot is optional. The following pairs render the same output:
+
+```vue
+<template>
+  <my-component>
+    <template #foo>content</template>
+  </my-component>
+  <my-component #foo>content</my-component>
+</template>
+```
+
+```vue
+<template>
+  <my-component>
+    <template #default>content</template>
+  </my-component>
+  <my-component>content</my-component>
+</template>
+```
+
+This rule enforces one of those styles consistently. By default it prefers the shorter form without the `<template>` wrapper.
+
+<eslint-code-block fix :rules="{'vue/single-v-slot-style': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <my-component #foo>content</my-component>
+  <my-component>content</my-component>
+  <my-component v-slot="{ bar }">{{ bar }}</my-component>
+
+  <!-- ✗ BAD -->
+  <my-component>
+    <template #foo>content</template>
+  </my-component>
+  <my-component>
+    <template #default>content</template>
+  </my-component>
+</template>
+```
+
+</eslint-code-block>
+
+The rule only reports a component whose slot is its **only** significant child. A component that distributes several slots, or that mixes a slot with other content, is always left alone.
+
+<eslint-code-block fix :rules="{'vue/single-v-slot-style': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <my-component>
+    <template #foo>foo</template>
+    <template #bar>bar</template>
+  </my-component>
+  <my-component>
+    <template #foo>foo</template>
+    <span>other content</span>
+  </my-component>
+</template>
+```
+
+</eslint-code-block>
+
+A `<template>` that carries anything besides the `v-slot` directive is never reported either, because removing the wrapper would change what the code means.
+
+<eslint-code-block fix :rules="{'vue/single-v-slot-style': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <my-component>
+    <template #foo v-if="condition">content</template>
+  </my-component>
+</template>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+```json
+{
+  "vue/single-v-slot-style": ["error", {
+    "namedSlotStyle": "any" | "with-wrapper" | "without-wrapper",
+    "defaultSlotStyle": "any" | "with-wrapper" | "without-wrapper",
+    "treatCommentsAsInsignificant": false
+  }]
+}
+```
+
+| Name | Type | Default Value | Description
+|:-----|:-----|:--------------|:------------
+| `namedSlotStyle` | `"any"` \| `"with-wrapper"` \| `"without-wrapper"` | `"without-wrapper"` | The style for a single named slot (E.g. `#foo`).
+| `defaultSlotStyle` | `"any"` \| `"with-wrapper"` \| `"without-wrapper"` | inherited from `namedSlotStyle` | The style for a single default slot (E.g. `#default`).
+| `treatCommentsAsInsignificant` | `boolean` | `false` | Whether HTML comments next to the slot are ignored when deciding if the slot is the only child.
+
+Each style value means:
+
+- `"without-wrapper"` ... put the `v-slot` directive on the component itself. E.g. `<my-component #foo>`.
+- `"with-wrapper"` ... keep the `<template>` wrapper. E.g. `<my-component><template #foo></template></my-component>`.
+- `"any"` ... do not report either form.
+
+`defaultSlotStyle` inherits the value of `namedSlotStyle` when it is not set, so a single option value configures both.
+
+A string option is supported as a shorthand, to be consistent with the similar [vue/v-slot-style](./v-slot-style.md) rule.
+
+- `["error", "with-wrapper"]` is same as `["error", { namedSlotStyle: "with-wrapper", defaultSlotStyle: "with-wrapper" }]`.
+
+### `"with-wrapper"`
+
+<eslint-code-block fix :rules="{'vue/single-v-slot-style': ['error', 'with-wrapper']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <my-component>
+    <template #foo>content</template>
+  </my-component>
+  <my-component>
+    <template #default="{ bar }">{{ bar }}</template>
+  </my-component>
+
+  <!-- ✗ BAD -->
+  <my-component #foo>content</my-component>
+  <my-component v-slot="{ bar }">{{ bar }}</my-component>
+</template>
+```
+
+</eslint-code-block>
+
+Note that a component which has no `v-slot` directive at all is never reported, so `"with-wrapper"` does not require you to wrap ordinary component content in `<template #default>`.
+
+### `{ "defaultSlotStyle": "with-wrapper" }`
+
+`defaultSlotStyle` can differ from `namedSlotStyle`, for example to unwrap named slots but keep the default slot explicit.
+
+<eslint-code-block fix :rules="{'vue/single-v-slot-style': ['error', {namedSlotStyle: 'without-wrapper', defaultSlotStyle: 'with-wrapper'}]}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <my-component #foo>content</my-component>
+  <my-component>
+    <template #default="{ bar }">{{ bar }}</template>
+  </my-component>
+
+  <!-- ✗ BAD -->
+  <my-component>
+    <template #foo>content</template>
+  </my-component>
+  <my-component v-slot="{ bar }">{{ bar }}</my-component>
+</template>
+```
+
+</eslint-code-block>
+
+### `{ "treatCommentsAsInsignificant": true }`
+
+HTML comments are part of the rendered output, so by default a comment next to the slot makes the component ineligible. Set this option to `true` to ignore those comments and fold them into the slot content.
+
+<eslint-code-block fix :rules="{'vue/single-v-slot-style': ['error', {treatCommentsAsInsignificant: true}]}">
+
+```vue
+<template>
+  <!-- ✗ BAD -->
+  <my-component>
+    <!-- some comment -->
+    <template #foo>content</template>
+  </my-component>
+</template>
+```
+
+</eslint-code-block>
+
+With the default `false`, the same code is not reported.
+
+<eslint-code-block fix :rules="{'vue/single-v-slot-style': ['error']}">
+
+```vue
+<template>
+  <!-- ✓ GOOD -->
+  <my-component>
+    <!-- some comment -->
+    <template #foo>content</template>
+  </my-component>
+</template>
+```
+
+</eslint-code-block>
+
+## :couple: Related Rules
+
+- [vue/v-slot-style](./v-slot-style.md) — chooses between `#foo`, `v-slot:foo` and `v-slot` spellings. This rule chooses _where_ the directive goes, so the two are complementary. Its autofix emits the spellings that rule accepts with its default options.
+- [vue/no-lone-template](./no-lone-template.md) — reports `<template>` elements without any directive. It never reports a slot wrapper, so it does not overlap with this rule.
+
+### Conflict with `vue/valid-v-slot`
+
+The default `"without-wrapper"` style for **named** slots contradicts the [vue/valid-v-slot](./valid-v-slot.md) rule, which is part of the `essential` preset configs.
+
+[vue/valid-v-slot](./valid-v-slot.md) reports `Named slots must use '<template>' on a custom element.` for any named slot placed directly on a component, so with both rules enabled the following code is reported twice, with each rule asking for the opposite:
+
+```vue
+<template>
+  <my-component #foo>content</my-component>
+</template>
+```
+
+Vue 3 itself compiles `<my-component #foo>content</my-component>` and `<my-component><template #foo>content</template></my-component>` to exactly the same render function, so the unwrapped form works at runtime. See [vuejs/eslint-plugin-vue#1229](https://github.com/vuejs/eslint-plugin-vue/issues/1229), which tracks relaxing [vue/valid-v-slot](./valid-v-slot.md).
+
+Until that is resolved, choose one of the following:
+
+- keep [vue/valid-v-slot](./valid-v-slot.md) as-is and configure `{ "namedSlotStyle": "with-wrapper" }` or `{ "namedSlotStyle": "any" }`,
+- or turn off [vue/valid-v-slot](./valid-v-slot.md) if you want the unwrapped form for named slots.
+
+The **default** slot is not affected. All the forms this rule produces for it (`<my-component>`, `<my-component v-slot="{ bar }">` and `<template #default>`) are accepted by both [vue/valid-v-slot](./valid-v-slot.md) and [vue/v-slot-style](./v-slot-style.md) with their default settings.
+
+## :books: Further Reading
+
+- [Vue.js - Slots](https://vuejs.org/guide/components/slots.html)
+- [Vue.js - Named slots](https://vuejs.org/guide/components/slots.html#named-slots)
+- [Vue.js - Dynamic slot names](https://vuejs.org/guide/components/slots.html#dynamic-slot-names)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/single-v-slot-style.ts)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/single-v-slot-style.test.ts)

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -217,6 +217,7 @@ import restrictedComponentNames from './rules/restricted-component-names.ts'
 import returnInComputedProperty from './rules/return-in-computed-property.js'
 import returnInEmitsValidator from './rules/return-in-emits-validator.js'
 import scriptIndent from './rules/script-indent.ts'
+import singleVSlotStyle from './rules/single-v-slot-style.ts'
 import singlelineHtmlElementContentNewline from './rules/singleline-html-element-content-newline.ts'
 import slotNameCasing from './rules/slot-name-casing.ts'
 import sortKeys from './rules/sort-keys.js'
@@ -476,6 +477,7 @@ export default {
     'return-in-computed-property': returnInComputedProperty,
     'return-in-emits-validator': returnInEmitsValidator,
     'script-indent': scriptIndent,
+    'single-v-slot-style': singleVSlotStyle,
     'singleline-html-element-content-newline':
       singlelineHtmlElementContentNewline,
     'slot-name-casing': slotNameCasing,

--- a/lib/rules/single-v-slot-style.ts
+++ b/lib/rules/single-v-slot-style.ts
@@ -1,0 +1,468 @@
+/**
+ * @author Valentin Yushkevich
+ * See LICENSE file in root directory for full license.
+ */
+import utils from '../utils/index.js'
+
+type SlotStyle = 'any' | 'with-wrapper' | 'without-wrapper'
+
+interface Options {
+  /** The style for named slots. */
+  namedSlotStyle: SlotStyle
+  /** The style for the default slot. Inherits from `namedSlotStyle` when not set. */
+  defaultSlotStyle: SlotStyle
+  /** Whether HTML comments are ignored when looking for other children. */
+  treatCommentsAsInsignificant: boolean
+}
+
+function normalizeOptions(options: unknown): Options {
+  const normalized: Options = {
+    namedSlotStyle: 'without-wrapper',
+    defaultSlotStyle: 'without-wrapper',
+    treatCommentsAsInsignificant: false
+  }
+
+  if (typeof options === 'string') {
+    normalized.namedSlotStyle = options as SlotStyle
+    normalized.defaultSlotStyle = options as SlotStyle
+  } else if (options != null) {
+    const opts = options as Partial<Options>
+    if (opts.namedSlotStyle != null) {
+      normalized.namedSlotStyle = opts.namedSlotStyle
+      // `defaultSlotStyle` inherits from `namedSlotStyle` when it is not set.
+      normalized.defaultSlotStyle = opts.namedSlotStyle
+    }
+    if (opts.defaultSlotStyle != null) {
+      normalized.defaultSlotStyle = opts.defaultSlotStyle
+    }
+    if (opts.treatCommentsAsInsignificant != null) {
+      normalized.treatCommentsAsInsignificant =
+        opts.treatCommentsAsInsignificant === true
+    }
+  }
+
+  return normalized
+}
+
+/**
+ * Get the statically known slot name of a given `v-slot` directive.
+ * Returns `null` when the name cannot be determined statically
+ * (e.g. a dynamic argument such as `#[name]`).
+ */
+function getSlotName(vSlot: VDirective): string | null {
+  const { argument } = vSlot.key
+  if (argument == null) {
+    return 'default'
+  }
+  return argument.type === 'VIdentifier' ? argument.name : null
+}
+
+/**
+ * Check whether a given child node contributes to the rendered output.
+ * Whitespace-only text nodes do not.
+ */
+function isSignificantChild(node: VElement['children'][number]): boolean {
+  return node.type !== 'VText' || node.value.trim() !== ''
+}
+
+/**
+ * Get the HTML comments that are direct children of a given element.
+ * `vue-eslint-parser` does not put comments into `children`, so they have to be
+ * matched by range instead.
+ */
+function getOwnComments<T extends { range: Range }>(
+  element: VElement,
+  comments: readonly T[]
+): T[] {
+  const { endTag } = element
+  if (endTag == null) {
+    return []
+  }
+  const start = element.startTag.range[1]
+  const end = endTag.range[0]
+  return comments.filter(
+    (comment) =>
+      comment.range[0] >= start &&
+      comment.range[1] <= end &&
+      // Exclude comments that belong to a nested element.
+      element.children.every(
+        (child) =>
+          child.type !== 'VElement' ||
+          child.range[0] > comment.range[0] ||
+          comment.range[1] > child.range[1]
+      )
+  )
+}
+
+/**
+ * Get the range to insert an attribute after, within a start tag.
+ * Uses the last existing attribute, or the tag name when there is none,
+ * so that multiline start tags stay readable.
+ */
+function getAttributeInsertRange(element: VElement): Range {
+  const last = element.startTag.attributes.at(-1)
+  if (last) {
+    return last.range
+  }
+  const nameEnd = element.startTag.range[0] + 1 + element.rawName.length
+  return [element.startTag.range[0], nameEnd]
+}
+
+/**
+ * Get the indentation of the line that a given offset is on.
+ * Returns `null` if the offset is not preceded by whitespace only.
+ */
+function getLineIndent(text: string, offset: number): string | null {
+  const lineStart = text.lastIndexOf('\n', offset - 1) + 1
+  const indent = text.slice(lineStart, offset)
+  return /^[\t ]*$/u.test(indent) ? indent : null
+}
+
+/**
+ * Infer the indentation step between an outer and an inner offset.
+ * Returns `null` when it cannot be determined.
+ */
+function getIndentStep(
+  text: string,
+  outerOffset: number,
+  innerOffset: number
+): string | null {
+  const outer = getLineIndent(text, outerOffset)
+  const inner = getLineIndent(text, innerOffset)
+  if (outer == null || inner == null) {
+    return null
+  }
+  if (inner.length <= outer.length || !inner.startsWith(outer)) {
+    return null
+  }
+  return inner.slice(outer.length)
+}
+
+/**
+ * Add one indentation step to every line but the first.
+ */
+function indentLines(text: string, step: string): string {
+  return text
+    .split('\n')
+    .map((line, index) =>
+      index === 0 || line.length === 0 ? line : step + line
+    )
+    .join('\n')
+}
+
+/**
+ * Remove the line break and indentation that surround a block of content.
+ * The whitespace around the removed `<template>` already provides them.
+ */
+function stripSurroundingLineBreaks(text: string): string {
+  return text.replace(/^\n[\t ]*/u, '').replace(/\n[\t ]*$/u, '')
+}
+
+/**
+ * Remove up to one indentation step from every line but the first.
+ */
+function dedentLines(text: string, step: string): string {
+  return text
+    .split('\n')
+    .map((line, index) => {
+      if (index === 0) {
+        return line
+      }
+      let removed = 0
+      while (
+        removed < step.length &&
+        (line[removed] === ' ' || line[removed] === '\t')
+      ) {
+        removed++
+      }
+      return line.slice(removed)
+    })
+    .join('\n')
+}
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'enforce a consistent style for components with a single `v-slot`',
+      categories: undefined,
+      url: 'https://eslint.vuejs.org/rules/single-v-slot-style.html'
+    },
+    fixable: 'code',
+    schema: [
+      {
+        oneOf: [
+          { enum: ['any', 'with-wrapper', 'without-wrapper'] },
+          {
+            type: 'object',
+            properties: {
+              namedSlotStyle: {
+                enum: ['any', 'with-wrapper', 'without-wrapper']
+              },
+              defaultSlotStyle: {
+                enum: ['any', 'with-wrapper', 'without-wrapper']
+              },
+              treatCommentsAsInsignificant: { type: 'boolean' }
+            },
+            additionalProperties: false
+          }
+        ]
+      }
+    ],
+    messages: {
+      redundantWrapper:
+        "Redundant '<template>' wrapper for the only slot '{{name}}'.",
+      missingWrapper:
+        "Expected the only slot '{{name}}' to use a '<template>' wrapper."
+    }
+  },
+  create(context: RuleContext) {
+    const sourceCode = context.sourceCode
+    const options = normalizeOptions(context.options[0])
+
+    function getStyle(name: string): SlotStyle {
+      return name === 'default'
+        ? options.defaultSlotStyle
+        : options.namedSlotStyle
+    }
+
+    /**
+     * Build the directive text to place directly on the component.
+     * Returns `null` when no directive is needed at all.
+     */
+    function getDirectiveTextOnComponent(
+      vSlot: VDirective,
+      isDefaultSlot: boolean
+    ): string | null {
+      if (!isDefaultSlot) {
+        // Named slots keep the author's spelling (`#foo` / `v-slot:foo`).
+        return sourceCode.text.slice(vSlot.range[0], vSlot.range[1])
+      }
+      if (vSlot.value == null) {
+        // `<MyComponent>` already means the default slot, and both
+        // `<MyComponent v-slot>` and `<MyComponent #default>` are reported by
+        // `vue/valid-v-slot`, so drop the directive entirely.
+        return null
+      }
+      // `vue/valid-v-slot` requires a value here and `vue/v-slot-style`
+      // defaults to `v-slot` for the default slot on a component.
+      const value = sourceCode.text.slice(vSlot.key.range[1], vSlot.range[1])
+      return `v-slot${value}`
+    }
+
+    /**
+     * Build the directive text to place on the `<template>` wrapper.
+     */
+    function getDirectiveTextOnTemplate(
+      vSlot: VDirective,
+      isDefaultSlot: boolean
+    ): string {
+      if (!isDefaultSlot) {
+        return sourceCode.text.slice(vSlot.range[0], vSlot.range[1])
+      }
+      // `vue/v-slot-style` defaults to the `#default` shorthand on a wrapper.
+      const value = sourceCode.text.slice(vSlot.key.range[1], vSlot.range[1])
+      return `#default${value}`
+    }
+
+    /**
+     * Fix a redundant `<template>` wrapper by moving the `v-slot` directive
+     * onto the component and unwrapping the children.
+     */
+    function* fixUnwrap(
+      fixer: RuleFixer,
+      component: VElement,
+      template: VElement,
+      vSlot: VDirective,
+      isDefaultSlot: boolean
+    ): IterableIterator<Fix> {
+      const directiveText = getDirectiveTextOnComponent(vSlot, isDefaultSlot)
+      if (directiveText != null) {
+        yield fixer.insertTextAfterRange(
+          getAttributeInsertRange(component),
+          ` ${directiveText}`
+        )
+      }
+
+      const templateEndTag = template.endTag
+      const inner = templateEndTag
+        ? sourceCode.text.slice(
+            template.startTag.range[1],
+            templateEndTag.range[0]
+          )
+        : ''
+      const step = getIndentStep(
+        sourceCode.text,
+        component.range[0],
+        template.range[0]
+      )
+      const content = stripSurroundingLineBreaks(
+        step == null ? inner : dedentLines(inner, step)
+      )
+
+      // Only the `<template>` element itself is replaced, so sibling comments
+      // and the surrounding whitespace are kept as they are.
+      let start = template.range[0]
+      if (content === '') {
+        // Drop the now-empty line as well.
+        const lineStart = sourceCode.text.lastIndexOf('\n', start - 1)
+        if (
+          lineStart !== -1 &&
+          /^[\t ]*$/u.test(sourceCode.text.slice(lineStart + 1, start))
+        ) {
+          start = lineStart
+        }
+      }
+      yield fixer.replaceTextRange([start, template.range[1]], content)
+    }
+
+    /**
+     * Fix a missing `<template>` wrapper by moving the `v-slot` directive off
+     * the component and wrapping the children.
+     */
+    function* fixWrap(
+      fixer: RuleFixer,
+      component: VElement,
+      vSlot: VDirective,
+      isDefaultSlot: boolean
+    ): IterableIterator<Fix> {
+      const componentEndTag = component.endTag
+      /* c8 ignore next 3 -- guarded by the caller */
+      if (componentEndTag == null) {
+        return
+      }
+
+      // Remove the directive, together with the whitespace in front of it.
+      const { attributes } = component.startTag
+      const index = attributes.indexOf(vSlot)
+      const previous = index > 0 ? attributes[index - 1] : null
+      const removeFrom = previous
+        ? previous.range[1]
+        : component.startTag.range[0] + 1 + component.rawName.length
+      yield fixer.removeRange([removeFrom, vSlot.range[1]])
+
+      const contentStart = component.startTag.range[1]
+      const contentEnd = componentEndTag.range[0]
+      const content = sourceCode.text.slice(contentStart, contentEnd)
+      const directiveText = getDirectiveTextOnTemplate(vSlot, isDefaultSlot)
+
+      if (content.includes('\n')) {
+        const componentIndent = getLineIndent(
+          sourceCode.text,
+          component.range[0]
+        )
+        const step = getIndentStep(
+          sourceCode.text,
+          component.range[0],
+          contentStart + content.length - content.trimStart().length
+        )
+        if (componentIndent != null && step != null) {
+          const inner = indentLines(content, step)
+          yield fixer.replaceTextRange(
+            [contentStart, contentEnd],
+            `\n${componentIndent}${step}<template ${directiveText}>${inner}</template>\n${componentIndent}`
+          )
+          return
+        }
+      }
+
+      yield fixer.replaceTextRange(
+        [contentStart, contentEnd],
+        `<template ${directiveText}>${content}</template>`
+      )
+    }
+
+    return utils.defineTemplateBodyVisitor(context, {
+      VElement(node: VElement) {
+        if (!utils.isCustomComponent(node)) {
+          return
+        }
+
+        const vSlotOnComponent = utils.getDirective(node, 'slot')
+        const slotTemplateChildren = node.children.filter(
+          (child): child is VElement =>
+            child.type === 'VElement' &&
+            child.name === 'template' &&
+            utils.hasDirective(child, 'slot')
+        )
+
+        if (vSlotOnComponent) {
+          // `<MyComponent #foo>...</MyComponent>`
+          if (slotTemplateChildren.length > 0) {
+            // Mixed form, already reported by `vue/valid-v-slot`.
+            return
+          }
+          if (vSlotOnComponent.key.modifiers.length > 0) {
+            return
+          }
+          const name = getSlotName(vSlotOnComponent)
+          if (name == null || getStyle(name) !== 'with-wrapper') {
+            return
+          }
+          const isDefaultSlot = name === 'default'
+          // A self-closing component cannot be restructured safely.
+          const canFix = node.endTag != null
+          context.report({
+            node: vSlotOnComponent,
+            messageId: 'missingWrapper',
+            data: { name },
+            fix: canFix
+              ? (fixer) => [
+                  ...fixWrap(fixer, node, vSlotOnComponent, isDefaultSlot)
+                ]
+              : null
+          })
+          return
+        }
+
+        // `<MyComponent><template #foo>...</template></MyComponent>`
+        if (slotTemplateChildren.length !== 1) {
+          return
+        }
+        const significantChildren = node.children.filter(isSignificantChild)
+        if (significantChildren.length !== 1) {
+          return
+        }
+        const template = slotTemplateChildren[0]
+        /* c8 ignore next 3 -- the only significant child is the slot template */
+        if (significantChildren[0] !== template) {
+          return
+        }
+        if (!options.treatCommentsAsInsignificant) {
+          const templateBody = sourceCode.ast.templateBody
+          const comments = templateBody ? templateBody.comments : []
+          if (getOwnComments(node, comments).length > 0) {
+            return
+          }
+        }
+        // Any other attribute (`v-if`, `v-for`, `key`, ...) changes the meaning
+        // of the wrapper, so it cannot be removed.
+        if (template.startTag.attributes.length !== 1) {
+          return
+        }
+        const vSlot = utils.getDirective(template, 'slot')
+        /* c8 ignore next 3 -- guaranteed by the filter above */
+        if (vSlot == null) {
+          return
+        }
+        if (vSlot.key.modifiers.length > 0) {
+          return
+        }
+        const name = getSlotName(vSlot)
+        if (name == null || getStyle(name) !== 'without-wrapper') {
+          return
+        }
+        const isDefaultSlot = name === 'default'
+        context.report({
+          node: template.startTag,
+          messageId: 'redundantWrapper',
+          data: { name },
+          fix: (fixer) => [
+            ...fixUnwrap(fixer, node, template, vSlot, isDefaultSlot)
+          ]
+        })
+      }
+    })
+  }
+}

--- a/tests/lib/rules/single-v-slot-style.test.ts
+++ b/tests/lib/rules/single-v-slot-style.test.ts
@@ -1,0 +1,695 @@
+/**
+ * @author Valentin Yushkevich
+ * See LICENSE file in root directory for full license.
+ */
+import { RuleTester } from '../../eslint-compat'
+import rule from '../../../lib/rules/single-v-slot-style'
+import vueEslintParser from 'vue-eslint-parser'
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: vueEslintParser,
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  }
+})
+
+tester.run('single-v-slot-style', rule, {
+  valid: [
+    // no slots at all
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent /></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent>content</MyComponent></template>'
+    },
+    // already in the default `without-wrapper` style
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent #foo>content</MyComponent></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent v-slot="{ bar }">{{ bar }}</MyComponent></template>'
+    },
+    // more than one slot
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <template #foo>foo</template>
+            <template #bar>bar</template>
+          </MyComponent>
+        </template>
+      `
+    },
+    // the slot is not the only significant child
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <template #foo>foo</template>
+            <span>other</span>
+          </MyComponent>
+        </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <template #foo>foo</template>
+            other text
+          </MyComponent>
+        </template>
+      `
+    },
+    // comments are significant by default
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <!-- keep me -->
+            <template #foo>foo</template>
+          </MyComponent>
+        </template>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <!-- keep me -->
+            <template #foo>foo</template>
+          </MyComponent>
+        </template>
+      `,
+      options: [{ treatCommentsAsInsignificant: false }]
+    },
+    // the wrapper carries other attributes, so it cannot be removed
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo v-if="x">foo</template></MyComponent></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo v-for="x in xs" :key="x">foo</template></MyComponent></template>'
+    },
+    // `<template>` elements that are not slots
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template v-if="x">foo</template></MyComponent></template>'
+    },
+    // not a custom component
+    {
+      filename: 'test.vue',
+      code: '<template><div><template #foo>foo</template></div></template>'
+    },
+    // dynamic slot names are not statically known
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #[dyn]>foo</template></MyComponent></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent #[dyn]>foo</MyComponent></template>',
+      options: ['with-wrapper']
+    },
+    // modifiers are out of scope
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template v-slot:foo.mod>foo</template></MyComponent></template>'
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent #foo.mod>foo</MyComponent></template>',
+      options: ['with-wrapper']
+    },
+    // mixed form, reported by `vue/valid-v-slot` instead
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent v-slot="{ a }"><template #foo>foo</template></MyComponent></template>',
+      options: ['with-wrapper']
+    },
+
+    // `any`
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo>foo</template></MyComponent></template>',
+      options: ['any']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent #foo>foo</MyComponent></template>',
+      options: ['any']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #default>foo</template></MyComponent></template>',
+      options: [{ namedSlotStyle: 'any' }]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo>foo</template></MyComponent></template>',
+      options: [{ namedSlotStyle: 'any', defaultSlotStyle: 'without-wrapper' }]
+    },
+
+    // `with-wrapper`
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo>foo</template></MyComponent></template>',
+      options: ['with-wrapper']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #default="{ bar }">{{ bar }}</template></MyComponent></template>',
+      options: ['with-wrapper']
+    },
+    // a component without an explicit `v-slot` is never required to add a wrapper
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent>content</MyComponent></template>',
+      options: ['with-wrapper']
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent #foo>foo</MyComponent></template>',
+      options: [{ namedSlotStyle: 'without-wrapper' }]
+    },
+    // `defaultSlotStyle` inherits from `namedSlotStyle`
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #default>foo</template></MyComponent></template>',
+      options: [{ namedSlotStyle: 'with-wrapper' }]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo>foo</template></MyComponent></template>',
+      options: [{ namedSlotStyle: 'with-wrapper', defaultSlotStyle: 'any' }]
+    }
+  ],
+  invalid: [
+    // ---------------------------------------------------------------
+    // `without-wrapper` (default) - named slots
+    // ---------------------------------------------------------------
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo>content</template></MyComponent></template>',
+      output: '<template><MyComponent #foo>content</MyComponent></template>',
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 39
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo="{ bar }">{{ bar }}</template></MyComponent></template>',
+      output:
+        '<template><MyComponent #foo="{ bar }">{{ bar }}</MyComponent></template>',
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 49
+        }
+      ]
+    },
+    {
+      // the long form spelling is preserved
+      filename: 'test.vue',
+      code: '<template><MyComponent><template v-slot:foo>content</template></MyComponent></template>',
+      output:
+        '<template><MyComponent v-slot:foo>content</MyComponent></template>',
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 45
+        }
+      ]
+    },
+    {
+      // other attributes on the component are kept
+      filename: 'test.vue',
+      code: '<template><MyComponent v-if="x" class="a"><template #foo>content</template></MyComponent></template>',
+      output:
+        '<template><MyComponent v-if="x" class="a" #foo>content</MyComponent></template>',
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 1,
+          column: 43,
+          endLine: 1,
+          endColumn: 58
+        }
+      ]
+    },
+
+    // ---------------------------------------------------------------
+    // `without-wrapper` (default) - default slot
+    // ---------------------------------------------------------------
+    {
+      // no slot props: the directive is dropped entirely
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #default>content</template></MyComponent></template>',
+      output: '<template><MyComponent>content</MyComponent></template>',
+      errors: [
+        {
+          message:
+            "Redundant '<template>' wrapper for the only slot 'default'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 43
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent><template v-slot>content</template></MyComponent></template>',
+      output: '<template><MyComponent>content</MyComponent></template>',
+      errors: [
+        {
+          message:
+            "Redundant '<template>' wrapper for the only slot 'default'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 41
+        }
+      ]
+    },
+    {
+      // with slot props the directive has to stay
+      filename: 'test.vue',
+      code: '<template><MyComponent><template v-slot="{ bar }">{{ bar }}</template></MyComponent></template>',
+      output:
+        '<template><MyComponent v-slot="{ bar }">{{ bar }}</MyComponent></template>',
+      errors: [
+        {
+          message:
+            "Redundant '<template>' wrapper for the only slot 'default'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 51
+        }
+      ]
+    },
+    {
+      // `#default` is normalized to `v-slot`, which is what `vue/valid-v-slot`
+      // and `vue/v-slot-style` expect on a component
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #default="{ bar }">{{ bar }}</template></MyComponent></template>',
+      output:
+        '<template><MyComponent v-slot="{ bar }">{{ bar }}</MyComponent></template>',
+      errors: [
+        {
+          message:
+            "Redundant '<template>' wrapper for the only slot 'default'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 53
+        }
+      ]
+    },
+
+    // ---------------------------------------------------------------
+    // `without-wrapper` - indentation handling
+    // ---------------------------------------------------------------
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <template #foo>
+              <span>content</span>
+            </template>
+          </MyComponent>
+        </template>
+      `,
+      output: `
+        <template>
+          <MyComponent #foo>
+            <span>content</span>
+          </MyComponent>
+        </template>
+      `,
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <template #foo="{ bar }">
+              <span>{{ bar }}</span>
+              <span>{{ bar }}</span>
+            </template>
+          </MyComponent>
+        </template>
+      `,
+      output: `
+        <template>
+          <MyComponent #foo="{ bar }">
+            <span>{{ bar }}</span>
+            <span>{{ bar }}</span>
+          </MyComponent>
+        </template>
+      `,
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      // multiline start tag on the wrapper
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <template
+              #foo="{ bar }"
+            >
+              <span>{{ bar }}</span>
+            </template>
+          </MyComponent>
+        </template>
+      `,
+      output: `
+        <template>
+          <MyComponent #foo="{ bar }">
+            <span>{{ bar }}</span>
+          </MyComponent>
+        </template>
+      `,
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 4,
+          column: 13,
+          endLine: 6,
+          endColumn: 14
+        }
+      ]
+    },
+    {
+      // self-closing wrapper
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <template #foo />
+          </MyComponent>
+        </template>
+      `,
+      output: `
+        <template>
+          <MyComponent #foo>
+          </MyComponent>
+        </template>
+      `,
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 30
+        }
+      ]
+    },
+
+    // ---------------------------------------------------------------
+    // `treatCommentsAsInsignificant`
+    // ---------------------------------------------------------------
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent>
+            <!-- keep me -->
+            <template #foo>content</template>
+          </MyComponent>
+        </template>
+      `,
+      output: `
+        <template>
+          <MyComponent #foo>
+            <!-- keep me -->
+            content
+          </MyComponent>
+        </template>
+      `,
+      options: [{ treatCommentsAsInsignificant: true }],
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      // a comment nested inside the slot content never blocks the report
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo><span><!-- inner --></span></template></MyComponent></template>',
+      output:
+        '<template><MyComponent #foo><span><!-- inner --></span></MyComponent></template>',
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 39
+        }
+      ]
+    },
+
+    // ---------------------------------------------------------------
+    // `with-wrapper`
+    // ---------------------------------------------------------------
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent #foo>content</MyComponent></template>',
+      output:
+        '<template><MyComponent><template #foo>content</template></MyComponent></template>',
+      options: ['with-wrapper'],
+      errors: [
+        {
+          message:
+            "Expected the only slot 'foo' to use a '<template>' wrapper.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent #foo="{ bar }">{{ bar }}</MyComponent></template>',
+      output:
+        '<template><MyComponent><template #foo="{ bar }">{{ bar }}</template></MyComponent></template>',
+      options: [{ namedSlotStyle: 'with-wrapper' }],
+      errors: [
+        {
+          message:
+            "Expected the only slot 'foo' to use a '<template>' wrapper.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      // `v-slot` is normalized to the `#default` shorthand on the wrapper
+      filename: 'test.vue',
+      code: '<template><MyComponent v-slot="{ bar }">{{ bar }}</MyComponent></template>',
+      output:
+        '<template><MyComponent><template #default="{ bar }">{{ bar }}</template></MyComponent></template>',
+      options: ['with-wrapper'],
+      errors: [
+        {
+          message:
+            "Expected the only slot 'default' to use a '<template>' wrapper.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
+    },
+    {
+      // other attributes on the component are kept
+      filename: 'test.vue',
+      code: '<template><MyComponent class="a" #foo v-if="x">content</MyComponent></template>',
+      output:
+        '<template><MyComponent class="a" v-if="x"><template #foo>content</template></MyComponent></template>',
+      options: ['with-wrapper'],
+      errors: [
+        {
+          message:
+            "Expected the only slot 'foo' to use a '<template>' wrapper.",
+          line: 1,
+          column: 34,
+          endLine: 1,
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <MyComponent #foo="{ bar }">
+            <span>{{ bar }}</span>
+          </MyComponent>
+        </template>
+      `,
+      output: `
+        <template>
+          <MyComponent>
+            <template #foo="{ bar }">
+              <span>{{ bar }}</span>
+            </template>
+          </MyComponent>
+        </template>
+      `,
+      options: ['with-wrapper'],
+      errors: [
+        {
+          message:
+            "Expected the only slot 'foo' to use a '<template>' wrapper.",
+          line: 3,
+          column: 24,
+          endLine: 3,
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      // a self-closing component cannot be restructured safely
+      filename: 'test.vue',
+      code: '<template><MyComponent #foo /></template>',
+      output: null,
+      options: ['with-wrapper'],
+      errors: [
+        {
+          message:
+            "Expected the only slot 'foo' to use a '<template>' wrapper.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 28
+        }
+      ]
+    },
+
+    // ---------------------------------------------------------------
+    // option combinations
+    // ---------------------------------------------------------------
+    {
+      // `defaultSlotStyle` overrides the inherited `namedSlotStyle`
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #default>content</template></MyComponent></template>',
+      output: '<template><MyComponent>content</MyComponent></template>',
+      options: [{ namedSlotStyle: 'any', defaultSlotStyle: 'without-wrapper' }],
+      errors: [
+        {
+          message:
+            "Redundant '<template>' wrapper for the only slot 'default'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 43
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '<template><MyComponent v-slot="{ bar }">{{ bar }}</MyComponent></template>',
+      output:
+        '<template><MyComponent><template #default="{ bar }">{{ bar }}</template></MyComponent></template>',
+      options: [{ namedSlotStyle: 'any', defaultSlotStyle: 'with-wrapper' }],
+      errors: [
+        {
+          message:
+            "Expected the only slot 'default' to use a '<template>' wrapper.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 40
+        }
+      ]
+    },
+    {
+      // `defaultSlotStyle` inherits `namedSlotStyle` when it is not set
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #default="{ bar }">{{ bar }}</template></MyComponent></template>',
+      output:
+        '<template><MyComponent v-slot="{ bar }">{{ bar }}</MyComponent></template>',
+      options: [{ namedSlotStyle: 'without-wrapper' }],
+      errors: [
+        {
+          message:
+            "Redundant '<template>' wrapper for the only slot 'default'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 53
+        }
+      ]
+    },
+    {
+      // string shorthand
+      filename: 'test.vue',
+      code: '<template><MyComponent><template #foo>content</template></MyComponent></template>',
+      output: '<template><MyComponent #foo>content</MyComponent></template>',
+      options: ['without-wrapper'],
+      errors: [
+        {
+          message: "Redundant '<template>' wrapper for the only slot 'foo'.",
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 39
+        }
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
resolves #2975

Implemented to @FloEdelmann's spec: `namedSlotStyle` (default `without-wrapper`), `defaultSlotStyle` inheriting from it, and `treatCommentsAsInsignificant`.

Picking up @ota-meshi's point about #1229 — I think this needs a decision before it can land. `vue/valid-v-slot` is in the essential presets and reports `Named slots must use '<template>' on a custom element.`, so with the `without-wrapper` default the two rules ask for opposite things out of the box. For what it's worth, `@vue/compiler-dom` emits byte-identical render code for `<MyComp #foo>hello</MyComp>` and for the `<template #foo>` form, so #1229 looks like a genuine false positive rather than a Vue limitation.

So: keep `without-wrapper` and resolve #1229 first, or default named slots to `with-wrapper` and leave `without-wrapper` opt-in? I left it as specified for now and documented the conflict on the rule's page.

Default slots are unaffected — I checked every fixer output against `valid-v-slot` and `v-slot-style`, and only named-slot unwrapping conflicts.
