### PR TITLE
fix(require-typed-ref): don't report calls in explicitly typed positions

### DIFF
--- a/.changeset/require-typed-ref-typed-positions.md
+++ b/.changeset/require-typed-ref-typed-positions.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/require-typed-ref` false positives when an explicit type annotation already applies to the `ref()` call

--- a/docs/rules/require-typed-ref.md
+++ b/docs/rules/require-typed-ref.md
@@ -32,10 +32,16 @@ const count = shallowRef()
 const count = ref<number>()
 const count = ref(0)
 const count: Ref<number | undefined> = ref()
+const count = ref() as Ref<number | undefined>
+
+function useCount(count: Ref<number | undefined>) {}
+useCount(ref())
 </script>
 ```
 
 </eslint-code-block>
+
+The rule does not report a call when an explicit type annotation already applies to it: a typed variable declaration or assignment, an `as`/`satisfies` expression, or an argument of a function that is declared in the same file with a typed parameter. Since the rule has no type information, annotations that are only known to the type checker — a parameter of an imported function, for example — cannot be detected.
 
 ## :wrench: Options
 

--- a/lib/rules/require-typed-ref.ts
+++ b/lib/rules/require-typed-ref.ts
@@ -2,14 +2,127 @@
  * @author Ivan Demchuk <https://github.com/Demivan>
  * See LICENSE file in root directory for full license.
  */
+import { findVariable } from '@eslint-community/eslint-utils'
 import { iterateDefineRefs } from '../utils/ref-object-references.ts'
 import utils from '../utils/index.js'
+
+type FunctionNode =
+  FunctionDeclaration | FunctionExpression | ArrowFunctionExpression
+
+/** `ref() as Ref<T>`, `ref() satisfies Ref<T>` and `<Ref<T>>ref()` */
+const TYPE_ASSERTIONS = new Set([
+  'TSAsExpression',
+  'TSSatisfiesExpression',
+  'TSTypeAssertion'
+])
 
 function isNullOrUndefined(node: Expression | SpreadElement) {
   return (
     (node.type === 'Literal' && node.value === null) ||
     (node.type === 'Identifier' && node.name === 'undefined')
   )
+}
+
+function hasTypeAnnotation(node: Pattern): boolean {
+  return node.type === 'AssignmentPattern'
+    ? hasTypeAnnotation(node.left)
+    : 'typeAnnotation' in node && node.typeAnnotation != null
+}
+
+/**
+ * Resolves the single definition of the given identifier reference.
+ */
+function findDefinition(context: RuleContext, node: Identifier) {
+  const variable = findVariable(utils.getScope(context, node), node)
+  return variable?.defs.length === 1 ? variable.defs[0] : null
+}
+
+/**
+ * Checks whether the given identifier refers to a variable or a parameter
+ * that was declared with an explicit type annotation.
+ */
+function isTypedVariable(context: RuleContext, node: Identifier): boolean {
+  const def = findDefinition(context, node)
+  return (
+    (def?.type === 'Variable' || def?.type === 'Parameter') &&
+    hasTypeAnnotation(def.name as Pattern)
+  )
+}
+
+/**
+ * Resolves the identifier to the function it refers to, if that function is
+ * declared in the same file.
+ */
+function findFunction(
+  context: RuleContext,
+  node: Identifier
+): FunctionNode | null {
+  const def = findDefinition(context, node)
+  if (def?.type === 'FunctionName') {
+    return def.node
+  }
+  const init = def?.type === 'Variable' ? def.node.init : null
+  return init != null &&
+    (init.type === 'ArrowFunctionExpression' ||
+      init.type === 'FunctionExpression')
+    ? init
+    : null
+}
+
+/**
+ * Checks whether the parameter receiving the argument at the given index has
+ * an explicit type annotation.
+ */
+function hasTypedParameter(fn: FunctionNode, index: number): boolean {
+  const param = fn.params[index] ?? fn.params.at(-1)
+  if (param == null) {
+    return false
+  }
+  if (fn.params[index] == null && param.type !== 'RestElement') {
+    return false
+  }
+  return hasTypeAnnotation(param)
+}
+
+/**
+ * Checks whether an explicit type annotation already applies to the given
+ * expression, which makes the type of the created ref known.
+ */
+function isInTypedPosition(context: RuleContext, node: Expression): boolean {
+  const parent = node.parent
+  if (TYPE_ASSERTIONS.has(parent.type)) {
+    return true
+  }
+  switch (parent.type) {
+    // `const value: Ref<T> = ref()`
+    case 'VariableDeclarator': {
+      return parent.init === node && hasTypeAnnotation(parent.id)
+    }
+    // `function useValue(value: Ref<T> = ref()) {}`
+    case 'AssignmentPattern': {
+      return parent.right === node && hasTypeAnnotation(parent.left)
+    }
+    // `value = ref()` where `value` is typed
+    case 'AssignmentExpression': {
+      return (
+        parent.operator === '=' &&
+        parent.left.type === 'Identifier' &&
+        isTypedVariable(context, parent.left)
+      )
+    }
+    // `useValue(ref())` where the parameter of `useValue` is typed
+    case 'CallExpression': {
+      const index = parent.arguments.indexOf(node)
+      if (index === -1 || parent.callee.type !== 'Identifier') {
+        return false
+      }
+      const fn = findFunction(context, parent.callee)
+      return fn != null && hasTypedParameter(fn, index)
+    }
+    default: {
+      return false
+    }
+  }
 }
 
 export default {
@@ -85,17 +198,12 @@ export default {
             'typeArguments' in ref.node
               ? ref.node.typeArguments
               : ref.node.typeParameters
-          if (typeArguments == null) {
-            if (
-              ref.node.parent.type === 'VariableDeclarator' &&
-              ref.node.parent.id.type === 'Identifier'
-            ) {
-              if (ref.node.parent.id.typeAnnotation == null) {
-                report(ref.name, ref.node)
-              }
-            } else {
-              report(ref.name, ref.node)
-            }
+          if (typeArguments != null) {
+            continue
+          }
+
+          if (!isInTypedPosition(context, ref.node)) {
+            report(ref.name, ref.node)
           }
         }
       }

--- a/tests/lib/rules/require-typed-ref.test.ts
+++ b/tests/lib/rules/require-typed-ref.test.ts
@@ -106,6 +106,95 @@ tester.run('require-typed-ref', rule, {
         import { ref } from 'vue'
         const count = ref()
       `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        const count: Ref<number | null> = ref(null)
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        const count = ref(null) as Ref<number | null>
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        const count = ref() satisfies Ref<number | undefined>
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { shallowRef } from 'vue'
+        const count = <Ref<number | undefined>>shallowRef()
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        let count: Ref<number | undefined>
+        count = ref()
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        function useCount(count: Ref<number | undefined>) {
+          count = ref()
+        }
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        function useCount(count: Ref<number | null>) {}
+        useCount(ref(null))
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        const useCount = (count: Ref<number | undefined>) => {}
+        useCount(ref())
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        function useCount(...counts: Ref<number | undefined>[]) {}
+        useCount(ref(), ref())
+      `
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        function useCount(count: Ref<number | undefined> = ref()) {}
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <script setup lang="ts">
+          import { ref, type Ref } from 'vue'
+          const count: Ref<number | null> = ref(null)
+        </script>
+      `,
+      languageOptions: {
+        parser: vueEslintParser,
+        parserOptions: { parser: tsEslintParser }
+      }
     }
   ],
   invalid: [
@@ -272,6 +361,92 @@ tester.run('require-typed-ref', rule, {
           column: 27,
           endLine: 5,
           endColumn: 32
+        }
+      ]
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        let count
+        count = ref()
+      `,
+      errors: [
+        {
+          messageId: 'noType',
+          line: 4,
+          column: 17,
+          endLine: 4,
+          endColumn: 22
+        }
+      ]
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        function useCount(count) {}
+        useCount(ref())
+      `,
+      errors: [
+        {
+          messageId: 'noType',
+          line: 4,
+          column: 18,
+          endLine: 4,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      // the type of an imported function is not available to this rule
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        import { useCount } from './use-count'
+        useCount(ref())
+      `,
+      errors: [
+        {
+          messageId: 'noType',
+          line: 4,
+          column: 18,
+          endLine: 4,
+          endColumn: 23
+        }
+      ]
+    },
+    {
+      // the type of a member call is not available to this rule
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        composable.useCount(ref())
+      `,
+      errors: [
+        {
+          messageId: 'noType',
+          line: 3,
+          column: 29,
+          endLine: 3,
+          endColumn: 34
+        }
+      ]
+    },
+    {
+      filename: 'test.ts',
+      code: `
+        import { ref } from 'vue'
+        function useCount(count: Ref<number | undefined>) {}
+        useCount(ref(), ref())
+      `,
+      errors: [
+        {
+          messageId: 'noType',
+          line: 4,
+          column: 25,
+          endLine: 4,
+          endColumn: 30
         }
       ]
     }


### PR DESCRIPTION
`vue/require-typed-ref` skipped a `ref()`/`shallowRef()` call only when its
parent was a `VariableDeclarator` whose `id` carried a type annotation. Every
other parent fell through to an unconditional report, so a call whose type was
already pinned down by an annotation elsewhere was still flagged.

The check now covers the positions where an explicit annotation is visible in
the AST:

- `as` / `satisfies` / `<T>` assertions
- assignment to a variable or parameter declared with a type annotation
- default value of a typed parameter
- argument of a function declared in the same file whose parameter at that
  index is typed

```ts
// reported before, valid now
const count = ref() as Ref<number | undefined>

let count: Ref<number | undefined>
count = ref()

function useCount(count: Ref<number | null>) {}
useCount(ref(null))
```

Calls still get reported when the type is only known to the type checker: an
imported or member-expression callee, and contextual types such as
`return { count: ref() }` under an annotated return type.

Closes #3024
