### PR TITLE
fix(no-dupe-keys): detect locals aliasing a different prop

### DIFF
--- a/.changeset/no-dupe-keys-prop-alias.md
+++ b/.changeset/no-dupe-keys-prop-alias.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": patch
+---
+
+Fixed `vue/no-dupe-keys` not reporting `<script setup>` variables that shadow a prop while aliasing a different one, such as `const foo = toRef(props, 'bar')`

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -59,6 +59,92 @@ function isInsideInitializer(node, references) {
 }
 
 /**
+ * Gets the name of the prop that the given expression reads from the props object.
+ * @param {Expression} node
+ * @param {ESNode[]} propReferences References to the props object
+ * @returns {string|null} The prop name, or `null` if it cannot be resolved
+ */
+function getAliasedPropName(node, propReferences) {
+  const expression = utils.skipChainExpression(utils.skipTSAsExpression(node))
+
+  // `props.foo` or `props['foo']`
+  if (expression.type === 'MemberExpression') {
+    return propReferences.includes(utils.skipTSAsExpression(expression.object))
+      ? utils.getStaticPropertyName(expression)
+      : null
+  }
+
+  // `toRef(props, 'foo')`
+  if (
+    expression.type === 'CallExpression' &&
+    expression.callee.type === 'Identifier' &&
+    expression.callee.name === 'toRef' &&
+    propReferences.includes(expression.arguments[0])
+  ) {
+    const key = expression.arguments[1]
+    return key?.type === 'Literal' && typeof key.value === 'string'
+      ? key.value
+      : null
+  }
+
+  return null
+}
+
+/**
+ * Checks whether the given expression evaluates to the props object itself,
+ * e.g. `props`, `defineProps()` or `toRefs(props)`.
+ * @param {Expression} node
+ * @param {ESNode[]} propReferences References to the props object
+ */
+function isPropsObject(node, propReferences) {
+  if (propReferences.includes(node)) {
+    return true
+  }
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'toRefs' &&
+    propReferences.includes(node.arguments[0])
+  )
+}
+
+/**
+ * Checks whether the given variable declarator binds `propName` to a *different* prop,
+ * e.g. `const foo = toRef(props, 'bar')`. Such a declaration shadows the `propName` prop
+ * in the template, so it is a duplicate key even though it reads from the props object.
+ * Declarations whose source prop cannot be resolved are not reported.
+ * @param {VariableDeclarator} node
+ * @param {string} propName
+ * @param {ESNode[]} propReferences References to the props object
+ */
+function aliasesOtherProp(node, propName, propReferences) {
+  const init = node.init
+  if (!init) {
+    return false
+  }
+
+  if (node.id.type === 'Identifier' && node.id.name === propName) {
+    const aliased = getAliasedPropName(init, propReferences)
+    return aliased !== null && aliased !== propName
+  }
+
+  if (node.id.type === 'ObjectPattern' && isPropsObject(init, propReferences)) {
+    for (const property of node.id.properties) {
+      if (property.type !== 'Property') continue
+      const value =
+        property.value.type === 'AssignmentPattern'
+          ? property.value.left
+          : property.value
+      if (value.type !== 'Identifier' || value.name !== propName) continue
+      const key = utils.getStaticPropertyName(property)
+      return key !== null && key !== propName
+    }
+  }
+
+  return false
+}
+
+/**
  * Collects all renamed props from a pattern
  * @param {Pattern | null} pattern - The destructuring pattern
  * @returns {Set<string>} - Set of prop names that have been renamed
@@ -146,21 +232,27 @@ module.exports = {
           const renamedProps = collectRenamedProps(propsNode)
 
           for (const prop of props) {
-            if (!prop.propName) continue
+            const propName = prop.propName
+            if (!propName) continue
 
-            if (renamedProps.has(prop.propName)) {
+            if (renamedProps.has(propName)) {
               continue
             }
 
             const variable = findVariable(
               utils.getScope(context, node),
-              prop.propName
+              propName
             )
             if (!variable || variable.defs.length === 0) continue
 
             if (
               variable.defs.some((def) => {
                 if (def.type !== 'Variable') return false
+                // Reading the props object does not make the declaration an alias
+                // of this prop, e.g. `const foo = toRef(props, 'bar')`.
+                if (aliasesOtherProp(def.node, propName, propReferences)) {
+                  return false
+                }
                 return isInsideInitializer(def.node, propReferences)
               })
             ) {
@@ -171,7 +263,7 @@ module.exports = {
               node: variable.defs[0].node,
               messageId: 'duplicateKey',
               data: {
-                name: prop.propName
+                name: propName
               }
             })
           }

--- a/tests/lib/rules/no-dupe-keys.test.ts
+++ b/tests/lib/rules/no-dupe-keys.test.ts
@@ -467,6 +467,62 @@ ruleTester.run('no-dupe-keys', rule, {
       filename: 'test.vue',
       code: `
       <script setup>
+      const props = defineProps(['foo'])
+      const foo = props['foo']
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import {toRefs} from 'vue'
+      const props = defineProps(['foo', 'bar'])
+      const { foo: renamedFoo, bar: renamedBar } = toRefs(props)
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import {toRef} from './my-utils'
+      const props = defineProps(['foo'])
+      const foo = toRef(props, 'foo')
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser }
+    },
+    {
+      // the aliased prop cannot be resolved, so the declaration is left alone
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import {toRef} from 'vue'
+      const props = defineProps(['foo', 'bar'])
+      const key = 'bar'
+      const foo = toRef(props, key)
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import {computed} from 'vue'
+      const props = defineProps(['foo'])
+      const foo = computed(() => props.foo || 'default')
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser }
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
       const {foo,bar} = defineProps(['foo', 'bar'])
       </script>
       `,
@@ -1283,6 +1339,114 @@ ruleTester.run('no-dupe-keys', rule, {
         }
       ],
       ...getTypeScriptFixtureTestOptions()
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import {toRef} from 'vue'
+      const props = defineProps(['foo', 'bar'])
+      const foo = toRef(props, 'bar')
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser },
+      errors: [
+        {
+          message:
+            "Duplicate key 'foo'. May cause name collision in script or template tag.",
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 38
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps(['foo', 'bar'])
+      const foo = props.bar
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser },
+      errors: [
+        {
+          message:
+            "Duplicate key 'foo'. May cause name collision in script or template tag.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 28
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      import {toRefs} from 'vue'
+      const props = defineProps(['foo', 'bar'])
+      const { bar: foo } = toRefs(props)
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser },
+      errors: [
+        {
+          message:
+            "Duplicate key 'foo'. May cause name collision in script or template tag.",
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 41
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup>
+      const props = defineProps(['foo', 'bar'])
+      const { bar: foo } = props
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser },
+      errors: [
+        {
+          message:
+            "Duplicate key 'foo'. May cause name collision in script or template tag.",
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 33
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <script>
+      import { toRef } from 'vue'
+      export default {
+        props: ['foo'],
+        setup(props) {
+          const foo = toRef(props, 'foo')
+          return { foo }
+        }
+      }
+      </script>
+      `,
+      languageOptions: { parser: vueEslintParser },
+      errors: [
+        {
+          message:
+            "Duplicate key 'foo'. May cause name collision in script or template tag.",
+          line: 8,
+          column: 20,
+          endLine: 8,
+          endColumn: 23
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
`onDefinePropsEnter` skips a local declaration that shadows a prop whenever the initializer mentions the props object anywhere (`isInsideInitializer`, added in #2189 so `const foo = toRef(props, 'foo')` stays valid). The check only asks whether props is touched, not which prop is read, so it also hides real collisions:

```vue
<script setup>
const props = defineProps(['foo', 'bar'])
const foo = toRef(props, 'bar')
</script>
```

The template's `foo` resolves to `props.bar` and prop `foo` becomes unreachable — exactly what the rule exists to catch.

The exemption is now skipped when the declaration provably aliases a *different* prop: `props.bar`, `props['bar']`, `toRef(props, 'bar')`, `const { bar: foo } = props` and `const { bar: foo } = toRefs(props)`. Same-name aliases keep passing, and declarations whose source prop can't be resolved (`toRef(props, key)`, `computed(() => props.bar + 1)`) are still left alone, so no new false positives.

The exact snippet from the issue (`const foo = toRef(props, 'foo')`) stays valid: it is a valid test from #2189, the setup binding wins in the template and unwraps to the same value the prop holds. Only the different-prop variants are reported. The Options API `setup()` path is untouched.

Refs #3070

The literal snippet from the report stays valid, so this does not close the issue by itself. Making that one error means reverting #2189 and reporting `const { foo } = toRefs(props)` and `const foo = props.foo` along with it — happy to redo it that way if that is what you want.
