### PR TITLE
feat(block-lang): add allowNoBlock option to require a block

### DIFF
--- a/.changeset/block-lang-allow-no-block.md
+++ b/.changeset/block-lang-allow-no-block.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-vue": minor
+---
+
+Added `allowNoBlock` option to `vue/block-lang` to report components that omit a required block entirely

--- a/docs/rules/block-lang.md
+++ b/docs/rules/block-lang.md
@@ -53,6 +53,7 @@ You can use the object as a value and use the following properties:
 
 - `lang` ... Specifies the available value for the `lang` attribute of the block. If multiple languages are available, specify them as an array. If you do not specify it, will disallow any language.
 - `allowNoLang` ... If `true`, allows the `lang` attribute not to be specified (allows the use of the default language of block).
+- `allowNoBlock` ... If `false`, requires the block to be present in the component. Default is `true`, which only checks the blocks that are actually written.
 
 ::: warning Note
 If the default language is specified for `lang` option of `<template>`, `<style>` and `<script>`, it will be enforced to not specify `lang` attribute.\
@@ -81,6 +82,35 @@ Same as `{ script: { allowNoLang: true } }`.
 <!-- ✗ BAD -->
 <script lang="js">
 </script>
+```
+
+</eslint-code-block>
+
+### `{ script: { lang: 'ts', allowNoBlock: false } }`
+
+By default the rule only checks the blocks that a component actually has, so a component that omits the block entirely is not reported. Set `allowNoBlock` to `false` to also require the block to be present.
+
+<eslint-code-block :rules="{'vue/block-lang': ['error', { script: { lang: 'ts', allowNoBlock: false } }]}">
+
+```vue
+<!-- ✓ GOOD -->
+<template>
+  <div />
+</template>
+
+<script setup lang="ts">
+</script>
+```
+
+</eslint-code-block>
+
+<eslint-code-block :rules="{'vue/block-lang': ['error', { script: { lang: 'ts', allowNoBlock: false } }]}">
+
+```vue
+<!-- ✗ BAD -->
+<template>
+  <div />
+</template>
 ```
 
 </eslint-code-block>

--- a/lib/rules/block-lang.js
+++ b/lib/rules/block-lang.js
@@ -9,6 +9,7 @@ const utils = require('../utils')
  * @typedef {object} BlockOptions
  * @property {Set<string>} lang
  * @property {boolean} allowNoLang
+ * @property {boolean} allowNoBlock
  */
 /**
  * @typedef { { [element: string]: BlockOptions | undefined } } Options
@@ -17,6 +18,7 @@ const utils = require('../utils')
  * @typedef {object} UserBlockOptions
  * @property {string[] | string} [lang]
  * @property {boolean} [allowNoLang]
+ * @property {boolean} [allowNoBlock]
  */
 /**
  * @typedef { { [element: string]: UserBlockOptions | undefined } } UserOptions
@@ -79,15 +81,18 @@ function normalizeOption(blockName, option) {
     lang.delete(def)
     hasDefault = true
   }
+  const isNoBlockAllowed = option.allowNoBlock !== false
   if (lang.size === 0) {
     return {
       lang,
-      allowNoLang: true
+      allowNoLang: true,
+      allowNoBlock: isNoBlockAllowed
     }
   }
   return {
     lang,
-    allowNoLang: hasDefault || Boolean(option.allowNoLang)
+    allowNoLang: hasDefault || Boolean(option.allowNoLang),
+    allowNoBlock: isNoBlockAllowed
   }
 }
 /**
@@ -141,7 +146,8 @@ module.exports = {
                       }
                     ]
                   },
-                  allowNoLang: { type: 'boolean' }
+                  allowNoLang: { type: 'boolean' },
+                  allowNoBlock: { type: 'boolean' }
                 },
                 additionalProperties: false
               }
@@ -156,6 +162,7 @@ module.exports = {
       expected:
         "Only {{allows}} can be used for the 'lang' attribute of '<{{tag}}>'.",
       missing: "The 'lang' attribute of '<{{tag}}>' is missing.",
+      missingBlock: "The '<{{tag}}>' block is missing.",
       unexpected: "Do not specify the 'lang' attribute of '<{{tag}}>'.",
       useOrNot:
         "Only {{allows}} can be used for the 'lang' attribute of '<{{tag}}>'. Or, not specifying the 'lang' attribute is allowed.",
@@ -221,8 +228,42 @@ module.exports = {
       }
     }
 
-    return utils.defineDocumentVisitor(context, {
-      'VDocumentFragment > VElement': verify
-    })
+    /**
+     * Reports the blocks that are required to exist but are not in the document.
+     * @returns {void}
+     */
+    function verifyMissingBlocks() {
+      const documentFragment =
+        context.sourceCode.parserServices.getDocumentFragment?.()
+      if (!documentFragment) {
+        return
+      }
+      const existingBlocks = new Set(
+        documentFragment.children
+          .filter(utils.isVElement)
+          .map((element) => element.name)
+      )
+      for (const [tag, option] of Object.entries(options)) {
+        if (!option || option.allowNoBlock || existingBlocks.has(tag)) {
+          continue
+        }
+        context.report({
+          loc: { line: 1, column: 0 },
+          messageId: 'missingBlock',
+          data: {
+            tag
+          }
+        })
+      }
+    }
+
+    return utils.compositingVisitors(
+      utils.defineDocumentVisitor(context, {
+        'VDocumentFragment > VElement': verify
+      }),
+      {
+        Program: verifyMissingBlocks
+      }
+    )
   }
 }

--- a/tests/lib/rules/block-lang.test.ts
+++ b/tests/lib/rules/block-lang.test.ts
@@ -32,7 +32,63 @@ tester.run('block-lang', rule, {
       <template></template>
       <script></script>
       <style></style>
-    `
+    `,
+    // `allowNoBlock` defaults to `true`, so a missing block is not reported.
+    {
+      code: '<template><div /></template>',
+      options: [{ script: { lang: 'ts' } }]
+    },
+    {
+      code: '<template><div /></template>',
+      options: [{ script: { lang: 'ts', allowNoBlock: true } }]
+    },
+    '<template><div /></template>',
+    {
+      code: `<template></template>
+      <script lang="ts"></script>`,
+      options: [{ script: { lang: 'ts', allowNoBlock: false } }]
+    },
+    {
+      code: `<template></template>
+      <script setup lang="ts"></script>`,
+      options: [{ script: { lang: 'ts', allowNoBlock: false } }]
+    },
+    // A block with no `lang` satisfies `allowNoBlock` on its own.
+    {
+      code: `<template></template>
+      <script></script>`,
+      options: [{ script: { allowNoBlock: false } }]
+    },
+    {
+      code: `<template></template>
+      <script></script>`,
+      options: [{ script: { lang: 'js', allowNoBlock: false } }]
+    },
+    // Several blocks of the same name.
+    {
+      code: `<i18n lang="json"></i18n>
+      <i18n lang="json"></i18n>
+      <template></template>`,
+      options: [{ i18n: { lang: 'json', allowNoBlock: false } }]
+    },
+    {
+      code: `<template></template>
+      <script lang="ts"></script>
+      <style lang="scss"></style>`,
+      options: [
+        {
+          template: { allowNoBlock: false },
+          script: { lang: 'ts', allowNoBlock: false },
+          style: { lang: 'scss', allowNoBlock: false }
+        }
+      ]
+    },
+    // Not an SFC, so there are no blocks to require.
+    {
+      filename: 'test.js',
+      code: 'var a = 1',
+      options: [{ script: { lang: 'ts', allowNoBlock: false } }]
+    }
   ],
   invalid: [
     {
@@ -204,6 +260,150 @@ tester.run('block-lang', rule, {
           column: 14,
           endLine: 3,
           endColumn: 27
+        }
+      ]
+    },
+    // https://github.com/vuejs/eslint-plugin-vue/issues/2720
+    {
+      code: '<template><div /></template>',
+      options: [{ script: { lang: 'ts', allowNoBlock: false } }],
+      errors: [
+        {
+          message: "The '<script>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
+        }
+      ]
+    },
+    {
+      filename: 'test.vue',
+      code: '',
+      options: [{ script: { lang: 'ts', allowNoBlock: false } }],
+      errors: [
+        {
+          message: "The '<script>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
+        }
+      ]
+    },
+    // Requiring a block without restricting its `lang`.
+    {
+      code: '<template><div /></template>',
+      options: [{ script: { allowNoBlock: false } }],
+      errors: [
+        {
+          message: "The '<script>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
+        }
+      ]
+    },
+    {
+      code: `<script lang="ts"></script>`,
+      options: [{ template: { allowNoBlock: false } }],
+      errors: [
+        {
+          message: "The '<template>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
+        }
+      ]
+    },
+    // A custom block can be required too.
+    {
+      code: `<template></template>
+      <script lang="ts"></script>`,
+      options: [{ i18n: { lang: 'json', allowNoBlock: false } }],
+      errors: [
+        {
+          message: "The '<i18n>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
+        }
+      ]
+    },
+    // Several missing blocks are reported separately.
+    {
+      code: '<template><div /></template>',
+      options: [
+        {
+          script: { lang: 'ts', allowNoBlock: false },
+          style: { lang: 'scss', allowNoBlock: false }
+        }
+      ],
+      errors: [
+        {
+          message: "The '<script>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
+        },
+        {
+          message: "The '<style>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
+        }
+      ]
+    },
+    // A present block is still checked for its `lang`, not reported as missing.
+    {
+      code: `<template></template>
+      <script></script>`,
+      options: [{ script: { lang: 'ts', allowNoBlock: false } }],
+      errors: [
+        {
+          message: "The 'lang' attribute of '<script>' is missing.",
+          line: 2,
+          column: 7,
+          endLine: 2,
+          endColumn: 15
+        }
+      ]
+    },
+    {
+      code: `<template></template>
+      <script setup></script>`,
+      options: [{ script: { lang: 'ts', allowNoBlock: false } }],
+      errors: [
+        {
+          message: "The 'lang' attribute of '<script>' is missing.",
+          line: 2,
+          column: 7,
+          endLine: 2,
+          endColumn: 21
+        }
+      ]
+    },
+    // A missing block and a wrong `lang` on another block.
+    {
+      code: `<template lang="pug"></template>`,
+      options: [
+        {
+          template: { lang: 'pug', allowNoBlock: false },
+          script: { lang: 'ts', allowNoBlock: false }
+        }
+      ],
+      errors: [
+        {
+          message: "The '<script>' block is missing.",
+          line: 1,
+          column: 1,
+          endLine: undefined,
+          endColumn: undefined
         }
       ]
     }


### PR DESCRIPTION
`vue/block-lang` only visits blocks that exist in the document (`'VDocumentFragment > VElement'`), so a component that omits `<script>` entirely is never checked. With `{ script: { lang: 'ts' } }` the rule is meant to keep TypeScript in every SFC, but dropping the `<script>` block silently passes.

Reporting this by default is not an option: the rule falls back to `{ script, template, style }` when configured without options, so it would start flagging every component without a `<style>` block. This adds an opt-in per-block `allowNoBlock` (default `true`) that mirrors the existing `allowNoLang`. When set to `false`, the block is required to be present; `<script setup>` counts as a `<script>` block, and a block that exists but has the wrong `lang` keeps reporting the existing messages.

Closes #2720

The option shape is the part I am least sure about: `allowNoBlock` per block mirrors `allowNoLang`, but a top-level `requireBlocks: ['script']` would read better if you expect this to grow. Say the word and I will switch it before review.

## Config

```json
{
  "vue/block-lang": ["error",
    {
      "script": {
        "lang": "ts",
        "allowNoBlock": false
      }
    }
  ]
}
```

## Before / after

```vue
<template>
  <div />
</template>
```

Before: no error.
After: `1:1  error  The '<script>' block is missing.  vue/block-lang`

Unchanged without the option — `{ script: { lang: 'ts' } }` on the same file still reports nothing.
