### PR TITLE
Add `simple-expressions-in-templates` rule

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -162,6 +162,7 @@ Rules in this category are enabled for all presets provided by eslint-plugin-vue
 | [vue/require-default-prop] | require default value for props |  | :three::two::hammer: |
 | [vue/require-explicit-emits] | require `emits` option with name triggered by `$emit()` | :bulb: | :three::hammer: |
 | [vue/require-prop-types] | require type definitions in props |  | :three::two::hammer: |
+| [vue/simple-expressions-in-templates] | disallow complex template expressions |  | :three::two::warning: |
 | [vue/singleline-html-element-content-newline] | require a line break before and after the contents of a singleline element | :wrench: | :three::two::lipstick: |
 | [vue/v-bind-style] | enforce `v-bind` directive style | :wrench: | :three::two::hammer: |
 | [vue/v-on-event-hyphenation] | enforce v-on event naming style on custom components in template | :wrench: | :three::hammer: |
@@ -595,6 +596,7 @@ The following rules extend the rules provided by ESLint itself and apply them to
 [vue/return-in-computed-property]: ./return-in-computed-property.md
 [vue/return-in-emits-validator]: ./return-in-emits-validator.md
 [vue/script-indent]: ./script-indent.md
+[vue/simple-expressions-in-templates]: ./simple-expressions-in-templates.md
 [vue/singleline-html-element-content-newline]: ./singleline-html-element-content-newline.md
 [vue/slot-name-casing]: ./slot-name-casing.md
 [vue/sort-keys]: ./sort-keys.md

--- a/docs/rules/simple-expressions-in-templates.md
+++ b/docs/rules/simple-expressions-in-templates.md
@@ -13,14 +13,20 @@ description: disallow complex template expressions
 
 ## :book: Rule Details
 
-This rule disallows complex template expressions, which are expressions containing more than one function call. As per the [Vue Style Guide](https://vuejs.org/style-guide/rules-strongly-recommended.html#simple-expressions-in-templates):
+This rule disallows complex template expressions. As per the [Vue Style Guide](https://vuejs.org/style-guide/rules-strongly-recommended.html#simple-expressions-in-templates):
 
 > Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.
+
+The complexity of an expression is calculated by counting all function calls.
 
 <eslint-code-block :rules="{'vue/simple-expressions-in-templates': ['error']}">
 
 ```vue
 <template>
+  <!-- eslint "vue/simple-expressions-in-templates": ["error", 1] -->
+
+  {{ normalizedFullName }}
+
   {{
     fullName
       .split(' ')
@@ -36,4 +42,10 @@ This rule disallows complex template expressions, which are expressions containi
 
 ## :wrench: Options
 
-Nothing.
+```json
+{
+  "vue/simple-expressions-in-templates": ["error", 1]
+}
+```
+
+This rule has one option, which is the maximum allowed complexity for a "mustache" template expression.

--- a/docs/rules/simple-expressions-in-templates.md
+++ b/docs/rules/simple-expressions-in-templates.md
@@ -1,0 +1,39 @@
+---
+pageClass: rule-details
+sidebarDepth: 0
+title: vue/simple-expressions-in-templates
+description: disallow complex template expressions
+---
+
+# vue/simple-expressions-in-templates
+
+> disallow complex template expressions
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> _**This rule has not been released yet.**_ </badge>
+
+## :book: Rule Details
+
+This rule disallows complex template expressions, which are expressions containing more than one function call. As per the [Vue Style Guide](https://vuejs.org/style-guide/rules-strongly-recommended.html#simple-expressions-in-templates):
+
+> Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.
+
+<eslint-code-block :rules="{'vue/simple-expressions-in-templates': ['error']}">
+
+```vue
+<template>
+  {{
+    fullName
+      .split(' ')
+      .map((word) => {
+        return word[0].toUpperCase() + word.slice(1)
+      })
+      .join(' ')
+  }}
+</template>
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+Nothing.

--- a/docs/rules/simple-expressions-in-templates.md
+++ b/docs/rules/simple-expressions-in-templates.md
@@ -9,7 +9,15 @@ description: disallow complex template expressions
 
 > disallow complex template expressions
 
-- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> _**This rule has not been released yet.**_ </badge>
+- :gear: This rule is included in the following preset configs:
+  - `*.configs["flat/strongly-recommended"]`
+  - `*.configs["flat/vue2-strongly-recommended"]`
+  - `*.configs["flat/recommended"]`
+  - `*.configs["flat/vue2-recommended"]`
+  - `"plugin:vue/strongly-recommended"`
+  - `"plugin:vue/vue2-strongly-recommended"`
+  - `"plugin:vue/recommended"`
+  - `"plugin:vue/vue2-recommended"`
 
 ## :book: Rule Details
 
@@ -49,3 +57,8 @@ The complexity of an expression is calculated by counting all function calls.
 ```
 
 This rule has one option, which is the maximum allowed complexity for a "mustache" template expression.
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/rules/simple-expressions-in-templates.ts)
+- [Test source](https://github.com/vuejs/eslint-plugin-vue/blob/master/tests/lib/rules/simple-expressions-in-templates.test.ts)

--- a/lib/configs/flat/vue2-strongly-recommended-error.ts
+++ b/lib/configs/flat/vue2-strongly-recommended-error.ts
@@ -29,6 +29,7 @@ export default [
       'vue/prop-name-casing': 'error',
       'vue/require-default-prop': 'error',
       'vue/require-prop-types': 'error',
+      'vue/simple-expressions-in-templates': 'error',
       'vue/singleline-html-element-content-newline': 'error',
       'vue/v-bind-style': 'error',
       'vue/v-on-style': 'error',

--- a/lib/configs/flat/vue2-strongly-recommended.ts
+++ b/lib/configs/flat/vue2-strongly-recommended.ts
@@ -29,6 +29,7 @@ export default [
       'vue/prop-name-casing': 'warn',
       'vue/require-default-prop': 'warn',
       'vue/require-prop-types': 'warn',
+      'vue/simple-expressions-in-templates': 'warn',
       'vue/singleline-html-element-content-newline': 'warn',
       'vue/v-bind-style': 'warn',
       'vue/v-on-style': 'warn',

--- a/lib/configs/flat/vue3-strongly-recommended-error.ts
+++ b/lib/configs/flat/vue3-strongly-recommended-error.ts
@@ -30,6 +30,7 @@ export default [
       'vue/require-default-prop': 'error',
       'vue/require-explicit-emits': 'error',
       'vue/require-prop-types': 'error',
+      'vue/simple-expressions-in-templates': 'error',
       'vue/singleline-html-element-content-newline': 'error',
       'vue/v-bind-style': 'error',
       'vue/v-on-event-hyphenation': [

--- a/lib/configs/flat/vue3-strongly-recommended.ts
+++ b/lib/configs/flat/vue3-strongly-recommended.ts
@@ -30,6 +30,7 @@ export default [
       'vue/require-default-prop': 'warn',
       'vue/require-explicit-emits': 'warn',
       'vue/require-prop-types': 'warn',
+      'vue/simple-expressions-in-templates': 'warn',
       'vue/singleline-html-element-content-newline': 'warn',
       'vue/v-bind-style': 'warn',
       'vue/v-on-event-hyphenation': [

--- a/lib/configs/vue2-strongly-recommended-error.ts
+++ b/lib/configs/vue2-strongly-recommended-error.ts
@@ -25,6 +25,7 @@ export default {
     'vue/prop-name-casing': 'error',
     'vue/require-default-prop': 'error',
     'vue/require-prop-types': 'error',
+    'vue/simple-expressions-in-templates': 'error',
     'vue/singleline-html-element-content-newline': 'error',
     'vue/v-bind-style': 'error',
     'vue/v-on-style': 'error',

--- a/lib/configs/vue2-strongly-recommended.ts
+++ b/lib/configs/vue2-strongly-recommended.ts
@@ -25,6 +25,7 @@ export default {
     'vue/prop-name-casing': 'warn',
     'vue/require-default-prop': 'warn',
     'vue/require-prop-types': 'warn',
+    'vue/simple-expressions-in-templates': 'warn',
     'vue/singleline-html-element-content-newline': 'warn',
     'vue/v-bind-style': 'warn',
     'vue/v-on-style': 'warn',

--- a/lib/configs/vue3-strongly-recommended-error.ts
+++ b/lib/configs/vue3-strongly-recommended-error.ts
@@ -26,6 +26,7 @@ export default {
     'vue/require-default-prop': 'error',
     'vue/require-explicit-emits': 'error',
     'vue/require-prop-types': 'error',
+    'vue/simple-expressions-in-templates': 'error',
     'vue/singleline-html-element-content-newline': 'error',
     'vue/v-bind-style': 'error',
     'vue/v-on-event-hyphenation': [

--- a/lib/configs/vue3-strongly-recommended.ts
+++ b/lib/configs/vue3-strongly-recommended.ts
@@ -26,6 +26,7 @@ export default {
     'vue/require-default-prop': 'warn',
     'vue/require-explicit-emits': 'warn',
     'vue/require-prop-types': 'warn',
+    'vue/simple-expressions-in-templates': 'warn',
     'vue/singleline-html-element-content-newline': 'warn',
     'vue/v-bind-style': 'warn',
     'vue/v-on-event-hyphenation': [

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -217,6 +217,7 @@ import restrictedComponentNames from './rules/restricted-component-names.ts'
 import returnInComputedProperty from './rules/return-in-computed-property.js'
 import returnInEmitsValidator from './rules/return-in-emits-validator.js'
 import scriptIndent from './rules/script-indent.ts'
+import simpleExpressionsInTemplates from './rules/simple-expressions-in-templates.ts'
 import singlelineHtmlElementContentNewline from './rules/singleline-html-element-content-newline.ts'
 import slotNameCasing from './rules/slot-name-casing.ts'
 import sortKeys from './rules/sort-keys.js'
@@ -476,6 +477,7 @@ export default {
     'return-in-computed-property': returnInComputedProperty,
     'return-in-emits-validator': returnInEmitsValidator,
     'script-indent': scriptIndent,
+    'simple-expressions-in-templates': simpleExpressionsInTemplates,
     'singleline-html-element-content-newline':
       singlelineHtmlElementContentNewline,
     'slot-name-casing': slotNameCasing,

--- a/lib/rules/simple-expressions-in-templates.ts
+++ b/lib/rules/simple-expressions-in-templates.ts
@@ -1,0 +1,37 @@
+/**
+ * @author Piet Maier
+ */
+
+'use strict'
+
+import utils from '../utils/index.js'
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow complex template expressions',
+      categories: ['vue3-strongly-recommended', 'vue2-strongly-recommended'],
+      url: 'https://eslint.vuejs.org/rules/simple-expressions-in-templates.html'
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      simpleExpressions:
+        'Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.'
+    }
+  },
+  create(context: RuleContext) {
+    return utils.defineTemplateBodyVisitor(context, {
+      // This pattern matches "mustache" interpolation expressions but not directive expressions.
+      'VElement > VExpressionContainer'(node: VExpressionContainer) {
+        if (node.expression?.type === 'CallExpression') {
+          context.report({
+            node,
+            messageId: 'simpleExpressions'
+          })
+        }
+      }
+    })
+  }
+}

--- a/lib/rules/simple-expressions-in-templates.ts
+++ b/lib/rules/simple-expressions-in-templates.ts
@@ -25,13 +25,38 @@ export default {
     return utils.defineTemplateBodyVisitor(context, {
       // This pattern matches "mustache" interpolation expressions but not directive expressions.
       'VElement > VExpressionContainer'(node: VExpressionContainer) {
-        if (node.expression?.type === 'CallExpression') {
+        const { expression } = node
+
+        if (!expression) return
+
+        if (expressionComplexity(context.sourceCode, expression) > 1) {
           context.report({
-            node,
+            node: expression,
             messageId: 'simpleExpressions'
           })
         }
       }
     })
   }
+}
+
+function expressionComplexity(sourceCode: SourceCode, node: ASTNode) {
+  let number = node.type === 'CallExpression' ? 1 : 0
+
+  const list =
+    (sourceCode.visitorKeys[node.type] as (keyof typeof node)[]) ?? []
+
+  for (const key of list) {
+    const value = node[key] as ASTNode | ASTNode[]
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        number += expressionComplexity(sourceCode, item)
+      }
+    } else if (value) {
+      number += expressionComplexity(sourceCode, value)
+    }
+  }
+
+  return number
 }

--- a/lib/rules/simple-expressions-in-templates.ts
+++ b/lib/rules/simple-expressions-in-templates.ts
@@ -15,7 +15,18 @@ export default {
       url: 'https://eslint.vuejs.org/rules/simple-expressions-in-templates.html'
     },
     fixable: null,
-    schema: [],
+    schema: {
+      type: 'array',
+      minItems: 0,
+      maxItems: 1,
+      items: [
+        {
+          type: 'number',
+          minimum: 0
+        }
+      ]
+    },
+    defaultOptions: [1],
     messages: {
       simpleExpressions:
         'Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.'
@@ -29,7 +40,9 @@ export default {
 
         if (!expression) return
 
-        if (expressionComplexity(context.sourceCode, expression)) {
+        const [complexity] = context.options as [number]
+
+        if (expressionComplexity(context.sourceCode, expression, complexity)) {
           context.report({
             node: expression,
             messageId: 'simpleExpressions'
@@ -46,7 +59,7 @@ export default {
 function expressionComplexity(
   sourceCode: SourceCode,
   node: ASTNode,
-  complexity = 1
+  complexity: number
 ) {
   if (complexity < 0) return true
 

--- a/lib/rules/simple-expressions-in-templates.ts
+++ b/lib/rules/simple-expressions-in-templates.ts
@@ -29,7 +29,7 @@ export default {
 
         if (!expression) return
 
-        if (expressionComplexity(context.sourceCode, expression) > 1) {
+        if (expressionComplexity(context.sourceCode, expression)) {
           context.report({
             node: expression,
             messageId: 'simpleExpressions'
@@ -40,23 +40,40 @@ export default {
   }
 }
 
-function expressionComplexity(sourceCode: SourceCode, node: ASTNode) {
-  let number = node.type === 'CallExpression' ? 1 : 0
+/**
+ * This function calculates the complexity of an expression and returns `true` if the complexity exceeds the given limit.
+ */
+function expressionComplexity(
+  sourceCode: SourceCode,
+  node: ASTNode,
+  complexity = 1
+) {
+  if (complexity < 0) return true
 
-  const list =
-    (sourceCode.visitorKeys[node.type] as (keyof typeof node)[]) ?? []
+  let number = 0
 
-  for (const key of list) {
-    const value = node[key] as ASTNode | ASTNode[]
+  function traverse(node: ASTNode) {
+    // Early Return: Return `true` if `complexity` has been exceeded.
+    if (node.type === 'CallExpression' && ++number > complexity) return true
 
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        number += expressionComplexity(sourceCode, item)
-      }
-    } else if (value) {
-      number += expressionComplexity(sourceCode, value)
+    // If the node type is unknown, its children are ignored.
+    const list =
+      (sourceCode.visitorKeys[node.type] as (keyof typeof node)[]) ?? []
+
+    // Recursive Step: Recursively traverse all children of the current node.
+    for (const key of list) {
+      const value = node[key] as ASTNode | ASTNode[]
+
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (traverse(item)) return true
+        }
+      } else if (value && traverse(value)) return true
     }
+
+    // Base Case: Return `false` if there are no more children to traverse.
+    return false
   }
 
-  return number
+  return traverse(node)
 }

--- a/tests/lib/rules/simple-expressions-in-templates.test.ts
+++ b/tests/lib/rules/simple-expressions-in-templates.test.ts
@@ -52,12 +52,11 @@ tester.run('simple-expressions-in-templates', rule, {
       `,
       errors: [
         {
-          message:
-            'Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.',
-          line: 3,
-          column: 9,
-          endLine: 10,
-          endColumn: 11
+          message: rule.meta.messages.simpleExpressions,
+          line: 4,
+          column: 11,
+          endLine: 9,
+          endColumn: 23
         }
       ],
       name: 'Invalid Style Guide Example'

--- a/tests/lib/rules/simple-expressions-in-templates.test.ts
+++ b/tests/lib/rules/simple-expressions-in-templates.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @author Piet Maier
+ */
+
+'use strict'
+
+import vueESLintParser from 'vue-eslint-parser'
+import rule from '../../../lib/rules/simple-expressions-in-templates'
+import { RuleTester } from '../../eslint-compat'
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: vueESLintParser,
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  }
+})
+
+tester.run('simple-expressions-in-templates', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <template></template>
+      `,
+      name: 'Empty Template'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ normalizedFullName }}
+      </template>
+      `,
+      name: 'Valid Style Guide Example'
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{
+          fullName
+            .split(' ')
+            .map((word) => {
+              return word[0].toUpperCase() + word.slice(1)
+            })
+            .join(' ')
+        }}
+      </template>
+      `,
+      errors: [
+        {
+          message:
+            'Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.',
+          line: 3,
+          column: 9,
+          endLine: 10,
+          endColumn: 11
+        }
+      ],
+      name: 'Invalid Style Guide Example'
+    }
+  ]
+})

--- a/tests/lib/rules/simple-expressions-in-templates.test.ts
+++ b/tests/lib/rules/simple-expressions-in-templates.test.ts
@@ -76,6 +76,33 @@ tester.run('simple-expressions-in-templates', rule, {
       </template>
       `,
       name: 'CallExpression with ArrowFunctionExpression as Argument'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ normalizedFullName }}
+      </template>
+      `,
+      options: [0],
+      name: 'Valid Style Guide Example with Complexity 0'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{
+          fullName
+            .split(' ')
+            .map((word) => {
+              return word[0].toUpperCase() + word.slice(1)
+            })
+            .join(' ')
+        }}
+      </template>
+      `,
+      options: [5],
+      name: 'Invalid Style Guide Example with Complexity 5'
     }
   ],
   invalid: [
@@ -139,6 +166,51 @@ tester.run('simple-expressions-in-templates', rule, {
         }
       ],
       name: 'CallExpression with CallExpression as Argument'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{
+          fullName
+            .split(' ')
+            .map((word) => {
+              return word[0].toUpperCase() + word.slice(1)
+            })
+            .join(' ')
+        }}
+      </template>
+      `,
+      options: [4],
+      errors: [
+        {
+          message: rule.meta.messages.simpleExpressions,
+          line: 4,
+          column: 11,
+          endLine: 9,
+          endColumn: 23
+        }
+      ],
+      name: 'Invalid Style Guide Example with Complexity 4'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ test() }}
+      </template>
+      `,
+      options: [0],
+      errors: [
+        {
+          message: rule.meta.messages.simpleExpressions,
+          line: 3,
+          column: 12,
+          endLine: 3,
+          endColumn: 18
+        }
+      ],
+      name: 'CallExpression with Complexity 0'
     }
   ]
 })

--- a/tests/lib/rules/simple-expressions-in-templates.test.ts
+++ b/tests/lib/rules/simple-expressions-in-templates.test.ts
@@ -28,11 +28,54 @@ tester.run('simple-expressions-in-templates', rule, {
     {
       filename: 'test.vue',
       code: `
+      <template>{{ }}</template>
+      `,
+      name: 'Empty Mustache Interpolation'
+    },
+    {
+      filename: 'test.vue',
+      code: `
       <template>
         {{ normalizedFullName }}
       </template>
       `,
       name: 'Valid Style Guide Example'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ test() }}
+      </template>
+      `,
+      name: 'CallExpression with Identifier as Callee'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ test.test() }}
+      </template>
+      `,
+      name: 'CallExpression with MemberExpression as Callee'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ test(' ') }}
+      </template>
+      `,
+      name: 'CallExpression with Literal as Argument'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ test(() => {}) }}
+      </template>
+      `,
+      name: 'CallExpression with ArrowFunctionExpression as Argument'
     }
   ],
   invalid: [

--- a/tests/lib/rules/simple-expressions-in-templates.test.ts
+++ b/tests/lib/rules/simple-expressions-in-templates.test.ts
@@ -103,6 +103,42 @@ tester.run('simple-expressions-in-templates', rule, {
         }
       ],
       name: 'Invalid Style Guide Example'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ test()() }}
+      </template>
+      `,
+      errors: [
+        {
+          message: rule.meta.messages.simpleExpressions,
+          line: 3,
+          column: 12,
+          endLine: 3,
+          endColumn: 20
+        }
+      ],
+      name: 'CallExpression with CallExpression as Callee'
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        {{ test(test()) }}
+      </template>
+      `,
+      errors: [
+        {
+          message: rule.meta.messages.simpleExpressions,
+          line: 3,
+          column: 12,
+          endLine: 3,
+          endColumn: 24
+        }
+      ],
+      name: 'CallExpression with CallExpression as Argument'
     }
   ]
 })


### PR DESCRIPTION
This PR adds the `simple-expressions-in-templates` rule. The rule corresponds to a [strongly recommended rule in the Vue Style Guide](https://vuejs.org/style-guide/rules-strongly-recommended.html#simple-expressions-in-templates). The PR also closes #253.

The Style Guide rule disallows complex expressions in "mustache" templates, but does not specify what constitutes a complex expression. Similar rules exist in other projects, including the [ESLint built-in "complexity" rule](https://eslint.org/docs/latest/rules/complexity), which uses cyclomatic complexity. However, that approach is not suitable for component templates, which consist of single expressions. This implementation instead calculates complexity by counting the number of function calls within an expression. With a default maximum of 1, the rule allows complex logic to be extracted into methods that can be called inside the template, thereby correctly allowing the good and disallowing the bad example from the Style Guide. The upper limit can also be configured if necessary.

Of course, not every expression that would be considered complex falls under this definition. Nevertheless, I believe this to be a suitable approach, in terms of both implementation and runtime complexity. It also has the advantage of enabling users to configure the allowed complexity according to their needs, in contrast to for example the `no-unreadable-*` rules of the `eslint-plugin-unicorn` package. The rule could also be extended to include `new` expressions or take complex callback functions passed to function calls into account. I welcome feedback and would be happy to advance the implementation if you have any suggestions.