### PR TITLE
fix(no-undef-properties): support `...toRefs(reactive({}))` in setup() return

### DIFF
--- a/.changeset/no-undef-properties-to-refs.md
+++ b/.changeset/no-undef-properties-to-refs.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-vue': patch
+---
+
+Fix `vue/no-undef-properties` false positives for properties returned via `...toRefs(reactive({ ... }))` from `setup()`

--- a/lib/rules/no-undef-properties.ts
+++ b/lib/rules/no-undef-properties.ts
@@ -8,6 +8,7 @@ import reserved from '../utils/vue-reserved.json' with { type: 'json' }
 import { toRegExpGroupMatcher } from '../utils/regexp.ts'
 import { getStyleVariablesContext } from '../utils/style-variables/index.ts'
 import { definePropertyReferenceExtractor } from '../utils/property-references.ts'
+import { ReferenceTracker } from '@eslint-community/eslint-utils'
 
 interface PropertyData {
   hasNestProperty?: boolean
@@ -100,6 +101,137 @@ export default {
      * Property names identified as defined via a Vuex or Pinia helpers
      */
     const propertiesDefinedByStoreHelpers = new Set<string>()
+
+    let reactiveApiNodes: {
+      reactive: Set<ESNode>
+      toRefs: Set<ESNode>
+    } | null = null
+
+    function getReactiveApiNodes() {
+      if (reactiveApiNodes) {
+        return reactiveApiNodes
+      }
+      const tracker = new ReferenceTracker(
+        context.sourceCode.scopeManager.scopes[0]
+      )
+      const reactive = new Set<ESNode>()
+      const toRefs = new Set<ESNode>()
+      const references = utils.iterateReferencesTraceMap(tracker, {
+        reactive: { [ReferenceTracker.CALL]: true },
+        toRefs: { [ReferenceTracker.CALL]: true }
+      })
+      for (const { node, path } of references) {
+        if (path.at(-1) === 'reactive') {
+          reactive.add(node)
+        } else {
+          toRefs.add(node)
+        }
+      }
+      return (reactiveApiNodes = { reactive, toRefs })
+    }
+
+    /**
+     * Resolve `toRefs(reactive({...}))`, or `toRefs(x)` where `x` is a `const`
+     * initialized with `reactive({...})`, to the object literal passed to `reactive`.
+     */
+    function getReactiveObjectFromToRefs(
+      node: Expression
+    ): ObjectExpression | null {
+      if (
+        node.type !== 'CallExpression' ||
+        !getReactiveApiNodes().toRefs.has(node)
+      ) {
+        return null
+      }
+      let arg = node.arguments[0]
+      if (arg && arg.type === 'Identifier') {
+        const variable = utils.findVariableByIdentifier(context, arg)
+        if (!variable || variable.defs.length !== 1) {
+          return null
+        }
+        const def = variable.defs[0]
+        if (
+          def.type !== 'Variable' ||
+          def.parent.kind !== 'const' ||
+          !def.node.init
+        ) {
+          return null
+        }
+        arg = def.node.init
+      }
+      if (
+        !arg ||
+        arg.type !== 'CallExpression' ||
+        !getReactiveApiNodes().reactive.has(arg)
+      ) {
+        return null
+      }
+      const reactiveArg = arg.arguments[0]
+      return reactiveArg && reactiveArg.type === 'ObjectExpression'
+        ? reactiveArg
+        : null
+    }
+
+    function* iterateSetupReturnObjects(
+      node: ObjectExpression
+    ): IterableIterator<ObjectExpression> {
+      const setup = utils.findProperty(node, GROUP_SETUP)
+      if (
+        !setup ||
+        (setup.value.type !== 'FunctionExpression' &&
+          setup.value.type !== 'ArrowFunctionExpression')
+      ) {
+        return
+      }
+      const body = setup.value.body
+      if (body.type === 'ObjectExpression') {
+        yield body
+        return
+      }
+      if (body.type !== 'BlockStatement') {
+        return
+      }
+      for (const statement of body.body) {
+        if (
+          statement.type === 'ReturnStatement' &&
+          statement.argument &&
+          statement.argument.type === 'ObjectExpression'
+        ) {
+          yield statement.argument
+        }
+      }
+    }
+
+    function* iterateSpreadToRefsNames(
+      node: ObjectExpression
+    ): IterableIterator<string> {
+      for (const property of node.properties) {
+        const reactiveObject =
+          property.type === 'SpreadElement'
+            ? getReactiveObjectFromToRefs(property.argument)
+            : null
+        if (!reactiveObject) {
+          continue
+        }
+        for (const p of reactiveObject.properties) {
+          const name = p.type === 'Property' && utils.getStaticPropertyName(p)
+          if (name) {
+            yield name
+          }
+        }
+      }
+    }
+
+    /**
+     * Iterate names defined by `...toRefs(reactive({...}))` spreads in the `setup()` return object.
+     */
+    function* iterateSetupToRefsNames(
+      node: ObjectExpression
+    ): IterableIterator<string> {
+      for (const returned of iterateSetupReturnObjects(node)) {
+        yield* iterateSpreadToRefsNames(returned)
+      }
+    }
 
     function isScriptSetupProgram(node: ASTNode) {
       return node === programNode
@@ -378,6 +510,12 @@ export default {
                 return getPropertyDataFromObjectProperty(propertyMap.get(name))
               }
             })
+          }
+
+          for (const name of iterateSetupToRefsNames(node)) {
+            if (!ctx.defineProperties.has(name)) {
+              ctx.defineProperties.set(name, {})
+            }
           }
 
           const watchersAndExposes = utils.iterateProperties(

--- a/tests/lib/rules/no-undef-properties.test.ts
+++ b/tests/lib/rules/no-undef-properties.test.ts
@@ -807,7 +807,49 @@ tester.run('no-undef-properties', rule, {
     </script>
     <template>
       <div id="app">Woof: {{ woof }}</div>
-    </template>`
+    </template>`,
+    {
+      // toRefs(reactive({...})) spread in setup() return
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>{{ a }} {{ b }}</div>
+      </template>
+      <script>
+      import { reactive, toRefs } from 'vue'
+
+      export default {
+        setup() {
+          const data = reactive({
+            a: 1,
+            b: 1,
+          });
+          return {
+            ...toRefs(data),
+          };
+        },
+      };
+      </script>
+      `
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>{{ a }} {{ b }} {{ c }}</div>
+      </template>
+      <script>
+      import { reactive, toRefs } from 'vue'
+
+      export default {
+        setup: () => ({
+          ...toRefs(reactive({ a: 1 })),
+          ...toRefs(reactive({ b: 1, c: 1 })),
+        }),
+      };
+      </script>
+      `
+    }
   ],
 
   invalid: [
@@ -1938,6 +1980,39 @@ tester.run('no-undef-properties', rule, {
           column: 28,
           endLine: 11,
           endColumn: 29
+        }
+      ]
+    },
+    {
+      // toRefs(reactive({...})) spread in setup() return
+      filename: 'test.vue',
+      code: `
+      <template>
+        <div>{{ a }} {{ b }} {{ c }}</div>
+      </template>
+      <script>
+      import { reactive, toRefs } from 'vue'
+
+      export default {
+        setup() {
+          const data = reactive({
+            a: 1,
+            b: 1,
+          });
+          return {
+            ...toRefs(data),
+          };
+        },
+      };
+      </script>
+      `,
+      errors: [
+        {
+          message: "'c' is not defined.",
+          line: 3,
+          column: 33,
+          endLine: 3,
+          endColumn: 34
         }
       ]
     }


### PR DESCRIPTION
Fixes #1915

## What

`vue/no-undef-properties` reported every template reference as undefined when a component exposes state via `...toRefs(data)` from `setup()`, where `data` is a `const` bound to `reactive({ ... })` (the exact example from the issue). The rule only collected explicit `Property` entries from the `setup()` return object and ignored spreads.

## Fix

In `onVueObjectEnter`, walk the `setup()` return object(s) for `SpreadElement`s whose argument is a `toRefs(...)` call (tracked via `ReferenceTracker`, same approach as `property-references.ts`) and resolve its argument to a `reactive({ ... })` object literal — either inline (`toRefs(reactive({...}))`) or through a single-definition `const` initialized with `reactive({...})`. The keys of that literal are then registered as defined setup properties. Anything not statically resolvable (non-`const`, reassigned, non-literal `reactive` arg, unknown call) is left untouched, so existing reporting is unchanged.

## Tests

- valid: `const data = reactive({a, b}); return { ...toRefs(data) }` (issue repro) and inline `setup: () => ({ ...toRefs(reactive({ a })), ...toRefs(reactive({ b, c })) })`
- invalid: same shape but the template references `c` which is not in the reactive object → still reported

## Validation

- `npx vitest run tests/lib/rules/no-undef-properties.test.ts` → 81 passed (78 before + 3 new)
- RED→GREEN: with the rule change stashed, the 3 new cases fail (`'a' is not defined.`, `'b' is not defined.`, and the invalid case reports extra `a`/`b`); with it restored, all pass
- `npm run build && npx vitest run tests/lib` → 288 files, 11624 tests passed
- `npx eslint lib/rules/no-undef-properties.ts tests/lib/rules/no-undef-properties.test.ts` → clean; `prettier --check` clean
- `npx tsc` → 27 pre-existing errors (all `../..`/`../../../dist` module resolution in tests before `npm run build`), none in the touched files; identical count on a clean checkout

Changeset added (`patch`). Happy to adjust.
